### PR TITLE
fix: replace blocking subprocess calls with async alternatives

### DIFF
--- a/app/services/minecraft_server.py
+++ b/app/services/minecraft_server.py
@@ -51,21 +51,26 @@ class MinecraftServerManager:
     async def _check_java_availability(self) -> bool:
         """Check if Java is available in the system"""
         try:
-            result = subprocess.run(
-                ["java", "-version"], capture_output=True, text=True, timeout=10
+            process = await asyncio.create_subprocess_exec(
+                "java", "-version",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
             )
-            if result.returncode == 0:
+            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=10)
+            
+            if process.returncode == 0:
+                stderr_text = stderr.decode('utf-8') if stderr else ''
                 logger.debug(
-                    f"Java version detected: {result.stderr.split()[2] if result.stderr else 'unknown'}"
+                    f"Java version detected: {stderr_text.split()[2] if stderr_text else 'unknown'}"
                 )
                 return True
             else:
                 logger.error("Java is not available or not working properly")
                 return False
         except (
-            subprocess.TimeoutExpired,
+            asyncio.TimeoutError,
             FileNotFoundError,
-            subprocess.SubprocessError,
+            OSError,
         ) as e:
             logger.error(f"Java availability check failed: {e}")
             return False


### PR DESCRIPTION
## Summary
- Replaced blocking `subprocess.run` with `asyncio.create_subprocess_exec`
- Used `asyncio.wait_for` for proper timeout handling
- Prevented blocking the event loop during Java version checks
- Improved error handling for async subprocess operations

## Changes
- Modified `_check_java_availability()` method in `minecraft_server.py`
- Replaced `subprocess.run` with `asyncio.create_subprocess_exec`
- Added proper async/await pattern with timeout
- Updated exception handling for async operations

## Testing
- Java version check now runs asynchronously
- Timeout handling preserved with `asyncio.wait_for`
- Error handling covers `asyncio.TimeoutError`, `FileNotFoundError`, and `OSError`

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)