### PR TITLE
fix: Correct GroupAccessService.check_server_access() method call signatures (Issue #70)

### DIFF
--- a/app/services/group_service.py
+++ b/app/services/group_service.py
@@ -690,7 +690,7 @@ class GroupService:
                 status_code=status.HTTP_404_NOT_FOUND, detail="Server not found"
             )
 
-        self.access_service.check_server_access(user, server, self.db)
+        self.access_service.check_server_access(user, server)
 
         # Check group access
         group = self.get_group_by_id(user, group_id)
@@ -799,7 +799,7 @@ class GroupService:
                 status_code=status.HTTP_404_NOT_FOUND, detail="Server not found"
             )
 
-        self.access_service.check_server_access(user, server, self.db)
+        self.access_service.check_server_access(user, server)
 
         # Check group access
         group = self.get_group_by_id(user, group_id)
@@ -871,7 +871,7 @@ class GroupService:
                 status_code=status.HTTP_404_NOT_FOUND, detail="Server not found"
             )
 
-        self.access_service.check_server_access(user, server, self.db)
+        self.access_service.check_server_access(user, server)
 
         # Get attached groups with details
         result = (


### PR DESCRIPTION
## Summary
Fixed method call signatures in `group_service.py` that were incorrectly passing 3 arguments instead of 2 to `GroupAccessService.check_server_access()`.

## Problem
The `/api/v1/groups/servers/{id}` endpoint was failing with a TypeError:
```
Failed to get server groups: GroupAccessService.check_server_access() takes 2 positional arguments but 3 were given
```

## Root Cause
During the implementation of the comprehensive shared resource access model (commit 9b46b68), three method calls were incorrectly updated to include an extra `self.db` parameter.

## Changes Made
- **attach_group_to_server()** at line 693: Removed `self.db` parameter
- **detach_group_from_server()** at line 802: Removed `self.db` parameter  
- **get_server_groups()** at line 874: Removed `self.db` parameter

### Before:
```python
self.access_service.check_server_access(user, server, self.db)
```

### After:
```python
self.access_service.check_server_access(user, server)
```

## Test plan
- [x] All unit tests pass (30/30)
- [x] Code quality checks pass (ruff & black)
- [x] Method signature matches: `check_server_access(user: User, server: Server) -> None`

## Impact
- Fixes broken `/api/v1/groups/servers/{id}` endpoint
- Restores server-group attachment/detachment operations
- Enables fetching server groups for UI display

🤖 Generated with [Claude Code](https://claude.ai/code)