### PR TITLE
Fix systemd network restrictions blocking version API calls

### DIFF
--- a/app/services/version_manager.py
+++ b/app/services/version_manager.py
@@ -34,11 +34,11 @@ class MinecraftVersionManager:
         self._cache_duration = timedelta(hours=6)  # Cache for 6 hours
         self.minimum_version = version.Version("1.8.0")
 
-        # Simple timeout configuration
-        self._request_timeout = 30  # Individual request timeout in seconds
-        self._total_timeout = 60  # Total operation timeout in seconds
+        # Timeout configuration - reduced from workaround values
+        self._request_timeout = 15  # Individual request timeout in seconds
+        self._total_timeout = 30  # Total operation timeout in seconds
         self._client_timeout = aiohttp.ClientTimeout(
-            total=self._request_timeout, connect=10, sock_read=10
+            total=self._request_timeout, connect=5, sock_read=5
         )
 
     async def get_supported_versions(self, server_type: ServerType) -> List[VersionInfo]:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -320,6 +320,10 @@ IPAddressAllow=::1/128
 IPAddressAllow=10.0.0.0/8
 IPAddressAllow=172.16.0.0/12
 IPAddressAllow=192.168.0.0/16
+# Allow external API access for Minecraft version management
+IPAddressAllow=piston-meta.mojang.com
+IPAddressAllow=api.papermc.io
+IPAddressAllow=maven.minecraftforge.net
 
 # Resource limits
 LimitNOFILE=65536


### PR DESCRIPTION
## Summary
- Resolves systemd network restrictions preventing external API access for version management
- Adds specific IPAddressAllow rules for required Minecraft version APIs
- Simplifies timeout configurations that were added as workarounds

## Problem Solved
The `/api/v1/servers/versions/supported` endpoint was experiencing timeouts in production due to systemd service configuration that blocked all outbound connections (`IPAddressDeny=any`). This prevented the application from fetching version information from:
- `https://piston-meta.mojang.com` (Vanilla versions)
- `https://api.papermc.io` (Paper versions)  
- `https://maven.minecraftforge.net` (Forge versions)

## Changes Made
- **SystemD Configuration** (`scripts/deploy.sh`):
  - Added `IPAddressAllow` rules for the three required external APIs
  - Maintains security by only allowing specific domain access
  
- **Version Manager** (`app/services/version_manager.py`):
  - Reduced request timeout from 30s to 15s
  - Reduced total timeout from 60s to 30s
  - Simplified connect/socket timeouts from 10s to 5s
  - Updated comments to reflect these are no longer workaround values

## Test Plan
- [x] All existing unit tests pass (31/31 for version manager)
- [x] Lint and format checks pass
- [x] Pre-commit hooks execute successfully
- [x] Full test suite runs successfully
- [ ] Deploy to staging and verify version endpoint functionality
- [ ] Confirm external API calls succeed in production environment

## Security Considerations
- Maintains network security by only allowing specific required domains
- Does not compromise the existing security hardening in systemd service
- Follows principle of least privilege by allowing only necessary external access

Resolves #95

🤖 Generated with [Claude Code](https://claude.ai/code)