### PR TITLE
fix: Remove IPAddressAllow domain restrictions from systemd service

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -320,10 +320,7 @@ IPAddressAllow=::1/128
 IPAddressAllow=10.0.0.0/8
 IPAddressAllow=172.16.0.0/12
 IPAddressAllow=192.168.0.0/16
-# Allow external API access for Minecraft version management
-IPAddressAllow=piston-meta.mojang.com
-IPAddressAllow=api.papermc.io
-IPAddressAllow=maven.minecraftforge.net
+# External API access for Minecraft version management (domains removed - systemd doesn't support domain names in IPAddressAllow)
 
 # Resource limits
 LimitNOFILE=65536

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -313,14 +313,7 @@ PrivateDevices=true
 
 # Network restrictions
 RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
-IPAddressDeny=any
-IPAddressAllow=localhost
-IPAddressAllow=127.0.0.0/8
-IPAddressAllow=::1/128
-IPAddressAllow=10.0.0.0/8
-IPAddressAllow=172.16.0.0/12
-IPAddressAllow=192.168.0.0/16
-# External API access for Minecraft version management (domains removed - systemd doesn't support domain names in IPAddressAllow)
+# IPAddress restrictions removed - IPAddressDeny=any blocks external API access needed for Minecraft version management
 
 # Resource limits
 LimitNOFILE=65536


### PR DESCRIPTION
## Summary
- Remove all IPAddress restrictions from systemd service configuration
- Resolve external API access issues that prevent Minecraft version management
- Allow necessary network access while maintaining other security hardening features

## Problem
The systemd service configuration included `IPAddressDeny=any` which completely blocked external network access. This prevented the application from accessing external APIs required for Minecraft version management:
- `piston-meta.mojang.com` (Minecraft version metadata)
- `api.papermc.io` (Paper server versions)
- `maven.minecraftforge.net` (Forge versions)

Additionally, domain names in `IPAddressAllow` are not supported by systemd and caused configuration errors.

## Changes Made
- Removed `IPAddressDeny=any` directive
- Removed all `IPAddressAllow` entries (localhost, private networks, domain names)
- Added explanatory comment about why IPAddress restrictions were removed
- Maintained `RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX` for basic network protocol restrictions
- Kept all other security hardening features intact

## Technical Details
- `IPAddressDeny=any` blocks all network access by default, requiring explicit allow rules
- Since the application needs access to various external APIs with changing IP addresses, maintaining an allow list is impractical
- The application doesn't require excessive network security restrictions for its use case
- Other systemd security features remain active (ProtectSystem, PrivateTmp, etc.)

## Test Plan
- [x] Verify systemd service configuration generates without IPAddress restrictions
- [x] Confirm removal of unsupported domain name entries
- [ ] Test external API access for version management (requires production deployment)
- [ ] Verify service starts successfully without network configuration errors

Resolves #97

🤖 Generated with [Claude Code](https://claude.ai/code)