### PR TITLE
chore: Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "21:00"  # UTC (JST 6:00 AM)
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "coverage*"
+          - "pre-commit*"
+          - "mypy*"
+          - "ruff*"
+          - "pytest*"


### PR DESCRIPTION
## Summary
- Add Dependabot configuration to automate dependency updates
- Configure weekly update schedule (every Monday at JST 6:00 AM)
- Group development dependencies into single PR for easier management

## Changes
- Created `.github/dependabot.yml` with pip ecosystem configuration
- Set up weekly update schedule
- Configured dependency grouping for dev dependencies (coverage, pre-commit, mypy, ruff, pytest)
- Added appropriate labels for dependency PRs

## Test plan
- [x] Verify YAML syntax is valid
- [ ] After merge, monitor first Dependabot run on Monday
- [ ] Confirm grouped dev dependencies create single PR
- [ ] Verify PR labels are applied correctly

## Note
This is a clean PR without unrelated changes. The previous PR #101 was closed due to CI issues from unrelated changes.

🤖 Generated with [Claude Code](https://claude.ai/code)