### PR TITLE
feat: Configure Dependabot to group all dependencies into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       day: "monday"
       time: "21:00"  # UTC (JST 6:00 AM)
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "python"
@@ -16,11 +16,6 @@ updates:
       prefix: "chore"
       include: "scope"
     groups:
-      dev-dependencies:
-        dependency-type: "development"
+      all-dependencies:
         patterns:
-          - "coverage*"
-          - "pre-commit*"
-          - "mypy*"
-          - "ruff*"
-          - "pytest*"
+          - "*"


### PR DESCRIPTION
## Summary
Configures Dependabot to group all dependency updates into a single weekly PR instead of creating separate PRs for each package.

## Changes
- **Grouping**: Changed from `dev-dependencies` (specific packages) to `all-dependencies` (wildcard pattern `*`)
- **PR Limit**: Reduced `open-pull-requests-limit` from 5 to 1
- **Scope**: Now includes all package types (production + development) in one PR

## Benefits
✅ **Simplified Management**: Single weekly PR instead of multiple PRs  
✅ **Easier Review**: All dependency changes reviewed together  
✅ **Reduced CI Load**: One test run instead of multiple  
✅ **Cleaner History**: Less PR noise in repository  
✅ **Faster Merges**: Single approval process  

## Configuration Details

### Before
```yaml
open-pull-requests-limit: 5
groups:
  dev-dependencies:
    dependency-type: "development"
    patterns:
      - "coverage*"
      - "pre-commit*"
      - "mypy*"  
      - "ruff*"
      - "pytest*"
```

### After  
```yaml
open-pull-requests-limit: 1
groups:
  all-dependencies:
    patterns:
      - "*"
```

## Expected Behavior
- **Next Monday (JST 6:00 AM)**: Dependabot will create one PR with all available dependency updates
- **Future updates**: Always grouped into single weekly PR
- **Emergency security updates**: Still processed immediately but grouped if possible

## Test Plan
- [x] YAML syntax validation passes
- [ ] Monitor next Dependabot run to confirm single PR creation
- [ ] Verify all package types are included in the grouped PR

🤖 Generated with [Claude Code](https://claude.ai/code)