### PR TITLE
fix(tagpr): use postVersionCommand for `uv lock` so lockfile gets bumped

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -3,6 +3,6 @@
     versionFile = pyproject.toml
     vPrefix = true
     changelog = false
-    command = "uv lock"
+    postVersionCommand = "uv lock"
     majorLabels = tagpr:major
     minorLabels = tagpr:minor


### PR DESCRIPTION
## 概要

PR #202 でマージした tagpr 設定 (\`.tagpr\` の \`command = \"uv lock\"\`) は意図と逆のタイミングで実行されており、リリース PR #203 で \`uv.lock\` が \`0.1.1\` へ追従しない状態だった。tagpr の正しい設定オプションに切替える。

## 原因

tagpr の README より:

| オプション | 実行タイミング |
|---|---|
| \`tagpr.command\` | versionFile 更新の **前** |
| \`tagpr.postVersionCommand\` | versionFile 更新の **後** |

\`uv lock\` は \`pyproject.toml\` の新しいバージョンを読み込んでから走る必要があるため、後者の \`postVersionCommand\` を使うのが正しい。実際 PR #203 の tagpr 実行ログでは:

\`\`\`
sh [-c uv lock]
Resolved 83 packages in 0.80ms   ← 旧バージョンで cache hit、uv.lock 変更無し
git [add -f .tagpr]
git [diff --raw HEAD]
M pyproject.toml                  ← uv.lock が含まれない
\`\`\`

\`uv lock\` 自体は走ったが、当時 \`pyproject.toml\` はまだ \`0.1.0\` のままだったため uv は「変更なし」と判定。

## 修正

\`.tagpr\`:
\`\`\`diff
-    command = \"uv lock\"
+    postVersionCommand = \"uv lock\"
\`\`\`

## 検証

ローカルで \`pyproject.toml\` を \`0.1.0\` → \`0.1.1\` に編集後 \`uv lock\` を実行すると、\`uv.lock\` の line 592 (\`name = \"mc-server-dashboard-api\"\` ブロック) の \`version\` が \`0.1.0\` → \`0.1.1\` へ更新されることを確認済。

## 期待動作 (マージ後)

1. master push → tagpr 再実行
2. PR #203 (\`Release for v0.1.1\`) の差分に \`uv.lock\` の更新が追加される
3. \`pyproject.toml\` + \`uv.lock\` の 2 ファイルが \`0.1.1\` に同期した状態で PR が更新される

## 関連

派生元: #202 (Resolves #201)