### PR TITLE
Release for v0.1.1

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - tagpr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mc-server-dashboard-api"
-version = "0.1.0"
+version = "0.1.1"
 description = "Minecraft server management dashboard API"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.13"
 
 [options]
-exclude-newer = "2026-05-09T06:03:44.878874569Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -589,7 +589,7 @@ wheels = [
 
 [[package]]
 name = "mc-server-dashboard-api"
-version = "0.1.0"
+version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This pull request is for the next release as v0.1.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
## What's Changed
* ci: introduce tagpr for automated release management (#201) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/202
* fix(tagpr): use postVersionCommand for `uv lock` so lockfile gets bumped by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/204
* docs: document test hierarchy policy (Resolves #167) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/205
* test: split pre-commit / pre-push / CI test scope (Resolves #171) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/208


**Full Changelog**: https://github.com/mmiura-2351/mc-server-dashboard-api/compare/v0.1.0...tagpr-from-v0.1.0