### PR TITLE
test: annotate Java-dependent integration tests + fix two pollution blockers (Resolves #209)

### DIFF
--- a/tests/integration/test_server_export_import.py
+++ b/tests/integration/test_server_export_import.py
@@ -4,6 +4,7 @@ import zipfile
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
@@ -85,6 +86,7 @@ class TestServerExportImport:
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert "Server directory not found" in response.json()["detail"]
 
+    @pytest.mark.requires_java
     def test_import_server_success(self, client: TestClient, admin_headers, db):
         """Test successful server import"""
         # Create test ZIP file
@@ -341,6 +343,7 @@ class TestServerExportImport:
             if server_dir.exists():
                 shutil.rmtree(server_dir)
 
+    @pytest.mark.requires_java
     def test_import_server_port_conflict_only_with_running_servers(
         self, client: TestClient, admin_headers, admin_user, db
     ):

--- a/tests/integration/test_server_port_conflicts.py
+++ b/tests/integration/test_server_port_conflicts.py
@@ -1,9 +1,14 @@
 from unittest.mock import patch
 
+import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
 from app.servers.models import Server, ServerStatus, ServerType
+
+# Every test in this file calls `POST /api/v1/servers`, which triggers
+# real Java discovery inside MinecraftServerManager — skip without a JRE.
+pytestmark = pytest.mark.requires_java
 
 
 class TestServerPortConflicts:

--- a/tests/unit/core/test_database.py
+++ b/tests/unit/core/test_database.py
@@ -46,18 +46,18 @@ class TestDatabaseModule:
 
     @patch("app.core.database.db_monitor")
     def test_db_monitor_import_success(self, mock_db_monitor):
-        """Test successful db_monitor import and setup (lines 14-16)"""
-        mock_db_monitor.setup_sqlalchemy_monitoring = Mock()
+        """Test db_monitor is accessible on the database module (lines 14-16)."""
+        # `importlib.reload(app.core.database)` was previously used here to try
+        # to re-trigger the top-level import block, but it has no real assertion
+        # value (the @patch is set on the pre-reload module reference) and the
+        # reload replaces `SessionLocal` / `engine` / `Base` with new instances,
+        # breaking identity checks (`is`) in any service already constructed
+        # against the pre-reload references — notably the integration tests
+        # `TestDatabaseIntegrationServiceEnhanced.test_*_initialization_*`.
+        # We keep the @patch as a smoke check that the symbol can be patched.
+        from app.core.database import db_monitor as imported
 
-        # Reload the module to trigger the import block
-        import importlib
-
-        import app.core.database
-
-        importlib.reload(app.core.database)
-
-        # The mock should be called during module import
-        # Note: This test is tricky because the import happens at module level
+        assert imported is mock_db_monitor
 
     def test_db_monitor_import_error_handling(self):
         """Test ImportError handling for db_monitor (lines 17-19)"""

--- a/tests/unit/versions/test_router.py
+++ b/tests/unit/versions/test_router.py
@@ -246,8 +246,10 @@ class TestVersionRouter:
                 # Verify scheduler was called correctly
                 mock_scheduler.trigger_immediate_update.assert_called_once_with(force_refresh=True)
         finally:
-            # Clean up dependency override
-            app.dependency_overrides.clear()
+            # Pop only what this test added — `clear()` would also drop the
+            # `get_db` override set by tests/conftest.py, breaking every
+            # integration test that runs afterwards (401 on auth fixtures).
+            app.dependency_overrides.pop(get_current_user, None)
 
     def test_trigger_version_update_forbidden_non_admin(self, client):
         """Test manual version update trigger by non-admin user"""
@@ -269,8 +271,10 @@ class TestVersionRouter:
             data = response.json()
             assert "administrator" in data["detail"].lower()
         finally:
-            # Clean up dependency override
-            app.dependency_overrides.clear()
+            # Pop only what this test added — `clear()` would also drop the
+            # `get_db` override set by tests/conftest.py, breaking every
+            # integration test that runs afterwards (401 on auth fixtures).
+            app.dependency_overrides.pop(get_current_user, None)
 
     def test_get_scheduler_status_admin(self, client):
         """Test getting scheduler status as admin"""
@@ -311,8 +315,10 @@ class TestVersionRouter:
                 assert data["update_interval_hours"] == 24
                 assert "retry_config" in data
         finally:
-            # Clean up dependency override
-            app.dependency_overrides.clear()
+            # Pop only what this test added — `clear()` would also drop the
+            # `get_db` override set by tests/conftest.py, breaking every
+            # integration test that runs afterwards (401 on auth fixtures).
+            app.dependency_overrides.pop(get_current_user, None)
 
     def test_get_scheduler_status_forbidden_non_admin(self, client):
         """Test getting scheduler status as non-admin user"""
@@ -334,8 +340,10 @@ class TestVersionRouter:
             data = response.json()
             assert "administrator" in data["detail"].lower()
         finally:
-            # Clean up dependency override
-            app.dependency_overrides.clear()
+            # Pop only what this test added — `clear()` would also drop the
+            # `get_db` override set by tests/conftest.py, breaking every
+            # integration test that runs afterwards (401 on auth fixtures).
+            app.dependency_overrides.pop(get_current_user, None)
 
     # ===================
     # Error handling tests
@@ -393,8 +401,10 @@ class TestVersionRouter:
                 data = response.json()
                 assert "Failed to trigger version update" in data["detail"]
         finally:
-            # Clean up dependency override
-            app.dependency_overrides.clear()
+            # Pop only what this test added — `clear()` would also drop the
+            # `get_db` override set by tests/conftest.py, breaking every
+            # integration test that runs afterwards (401 on auth fixtures).
+            app.dependency_overrides.pop(get_current_user, None)
 
     # ===================
     # Parameter validation tests
@@ -433,8 +443,10 @@ class TestVersionRouter:
             # Should return 422 for invalid enum value
             assert response.status_code == 422
         finally:
-            # Clean up dependency override
-            app.dependency_overrides.clear()
+            # Pop only what this test added — `clear()` would also drop the
+            # `get_db` override set by tests/conftest.py, breaking every
+            # integration test that runs afterwards (401 on auth fixtures).
+            app.dependency_overrides.pop(get_current_user, None)
 
 
 # ===================


### PR DESCRIPTION
## Summary

Mark the 5 server-creation API tests that require a JRE on `PATH` with `@pytest.mark.requires_java`, so the auto-skip helper added by #171 actually engages and **pre-push smoke runs cleanly without `--no-verify`** in Java-less environments. While running the smoke set to verify, two pre-existing test-pollution bugs were also fixed (each was independently producing ~50 cascading failures and would have blocked #209's completion condition on its own).

## Test marker changes

| File | Scope | Reason |
|---|---|---|
| `tests/integration/test_server_port_conflicts.py` | file-level `pytestmark = pytest.mark.requires_java` (3 tests) | All tests `POST /api/v1/servers`, which runs real Java discovery |
| `tests/integration/test_server_export_import.py` | 2 individual tests | Only `test_import_server_success` and `test_import_server_port_conflict_only_with_running_servers` actually create a server; the other 13 tests exercise validation/failure paths that short-circuit before Java is needed |

## Pollution blockers fixed in the same PR

#209's completion criterion is "`uv run pytest tests/unit tests/integration -m \"not slow\"` runs cleanly without Java on PATH." After adding the markers above, that command still failed with ~100 unrelated tests because of two pre-existing bugs. Both are mechanical fixes:

**1. `tests/unit/versions/test_router.py` — 6× `app.dependency_overrides.clear()`**

Six `finally` blocks called `clear()` to undo a `get_current_user` override they added. `clear()` also drops the `get_db` override that `tests/conftest.py` installs at module-import time, so every integration test that ran afterwards hit the real `./app.db` instead of the worker-scoped SQLite — producing 401s from the auth fixtures (the same admin user the test created didn't exist in the real DB).

Replaced with `app.dependency_overrides.pop(get_current_user, None)` so each test removes only what it added.

**2. `tests/unit/core/test_database.py::test_db_monitor_import_success` — `importlib.reload`**

The test reloaded `app.core.database` to chase line coverage. The reload replaces `SessionLocal` / `engine` / `Base` with new instances, breaking `is`-identity checks in services already constructed against the pre-reload references (`database_integration_service.SessionLocal is SessionLocal` failed in `TestDatabaseIntegrationServiceEnhanced.test_*_initialization_*`).

The reload also wasn't actually exercising the patched code path — `@patch` is applied to the pre-reload module reference, so re-running the import block runs the unpatched `db_monitor`. Replaced with a direct `assert db_monitor is mock_db_monitor` smoke check.

## Verification

```
$ java -version
bash: java: command not found

$ uv run pytest tests/unit tests/integration -m "not slow" --tb=short -q
1347 passed, 6 skipped, 99 deselected in 280.63s
```

The 6 skipped tests: 5 are the new `requires_java` annotations (auto-skipped by the helper from #171), 1 was pre-existing.

The new pre-push hook also fires automatically on this branch and passes:

```
pytest (unit + integration smoke, excludes slow).........................Passed
```

This is the first commit on the repo where `git push` works in a Java-less env without `--no-verify`.

## Out of scope (explicitly)

- Other parallel race conditions exposed by switching to `[pytest]` in `pytest.ini` — still tracked by **#210**. This PR keeps the existing `[tool:pytest]` quirk; sequential execution is the only reason the test_router pollution above wasn't surfacing all along.
- `actions/setup-java@v4` in the CI workflows — still tracked by **#211**. Now even more important: once #209 ships, an absent JRE on CI would silently skip the 5 marked tests.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] `pytest tests/unit tests/integration -m "not slow"` clean in Java-less env (1347 passed, 6 skipped)
- [x] Pre-push hook fires automatically and passes
- [x] `pytest tests/integration/test_server_port_conflicts.py --collect-only` → 3 tests deselected when no Java (skip), all 3 collected when Java present
- [ ] CI on push (`ci.yaml`) green — Java is on the runner so the 5 tests still execute

Resolves #209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
