### PR TITLE
Release for v0.1.1

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - tagpr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mc-server-dashboard-api"
-version = "0.1.0"
+version = "0.1.1"
 description = "Minecraft server management dashboard API"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.13"
 
 [options]
-exclude-newer = "2026-05-19T19:07:43.151317283Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "mc-server-dashboard-api"
-version = "0.1.0"
+version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This pull request is for the next release as v0.1.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
## What's Changed
* ci: introduce tagpr for automated release management (#201) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/202
* fix(tagpr): use postVersionCommand for `uv lock` so lockfile gets bumped by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/204
* docs: document test hierarchy policy (Resolves #167) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/205
* test: split pre-commit / pre-push / CI test scope (Resolves #171) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/208
* test: annotate Java-dependent integration tests + fix two pollution blockers (Resolves #209) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/212
* ci: pin Temurin 21 in CI / nightly workflows (Resolves #211) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/214
* test: migrate pytest config to pyproject.toml and fix xdist race (Resolves #210) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/215
* test: tighten pytest filterwarnings to upstream-only (Resolves #216) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/218
* test: eliminate Runtime/Resource warning leaks and tighten filterwarnings (Resolves #217) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/219
* chore(typing): enable mypy in pre-commit with relaxed config (Resolves #86) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/220
* refactor(versions): introduce Port + Adapter layering (pilot for #154) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/229
* refactor(users,auth): introduce Port + Adapter layering (Resolves #222) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/230
* fix(users): reject duplicate email and inactive login attempts by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/236
* refactor(audit): introduce Port + Adapter layering (Resolves #223) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/238
* refactor(audit): isolate writer session; codify sync-port rule by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/246
* refactor(audit): type tracker via AuditTrackerProtocol by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/248
* test(audit): fault-injecting fixtures and exact statistics counts by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/249
* fix(audit): warn when command.ip_address differs from tracker by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/250
* fix(audit): dialect-aware severity filter for SQLite by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/251
* refactor(auth,users): remove legacy sync shims by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/252
* refactor(users): relocate Role enum to domain-pure module (Resolves part of #235) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/253
* refactor(files): introduce Repository + minimal ServerReadPort (#224) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/254
* refactor(templates): introduce Repository + TemplatesUnitOfWork (Resolves #225) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/256
* refactor(groups): introduce Repository + GroupsUnitOfWork (Resolves #226) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/261
* refactor(backups): introduce Repository + BackupsUnitOfWork (Resolves #227) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/264
* refactor(servers): introduce Repository + ServersUnitOfWork (PR 1/3, #228) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/265
* fix: TOCTOU on file_history version_number + port-conflict regression (PR 2a/?, #228) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/266
* refactor: migrate authorization_service to async + sibling-Port DI (PR 2b/?, #228) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/269
* refactor: merge server_service + apply_template / attach_group fixes (PR 2c/?, #228, Resolves #257 #259 #270) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/275
* refactor(servers): migrate database_integration + minecraft_server with thread audit (PR 2d/?, #228) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/279
* refactor: mechanical service moves + atomic backup rename (PR 2e/?, #228) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/283
* refactor: migrate visibility + websocket to repository pattern (PR 2f/?, #228) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/286
* refactor: sweep app/services/, close #154 (PR 3/?, Resolves #228 #154 #235) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/290
* docs: clarify _LegacyGroupFacade cross-boundary import in test_legacy_shim (Resolves #277) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/295
* refactor(audit): remove unused db parameter from AuditService.log_* (Resolves #247) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/296
* refactor: move file_edit_history migration helper to files adapters layer (Resolves #268) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/297
* test: restore exception-branch coverage for template internal helpers (Resolves #258) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/298
* test: add true TOCTOU regression test for file_history with separate-session writers (Resolves #267) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/299
* refactor: relocate legacy facade modules to adapters layer (ARCHITECTURE §4.2, Resolves #291) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/300
* refactor: lift FastAPI deps out of servers authorization + drop dead decorators (Resolves #273, Resolves #292) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/301
* refactor(templates): move Template ORM into app/templates/models.py (Resolves #255) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/303
* refactor(backups): move Backup ORM into app/backups/models.py (Resolves #263) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/304
* refactor: denormalize server_owner_id onto BackupEntity, restore can_delete_backup 2-arg (Resolves #274) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/305
* refactor: drop ORM refetch in control.py start/restart, migrate manager to ServerEntity (Resolves #272) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/306
* refactor: wrap update_server / delete_server in ServersUnitOfWork (Resolves #278) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/308
* refactor: replace Session-DI with ServerRepository Port in servers application layer (Resolves #285) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/309
* refactor: drop app/servers/service.py shim by migrating last imports (Resolves #276) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/310
* refactor: fail-loud when ServerRepository is missing in _validate_port_availability (Resolves #281) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/311
* fix: mount visibility_router + correct get_current_active_user import (Resolves #288) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/312
* refactor: expose broadcast_group_change to remove Demeter chain in GroupService (Resolves #262) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/313
* feat: invoke VisibilityMigrationService at lifespan startup (Resolves #289) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/315
* refactor: make _notify_status_change async-aware to restore bool result + ordering (Resolves #280) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/316
* feat: periodic cleanup of .pending/ and .failed/ in backups_directory (Resolves #284) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/317
* test: restore coverage for authorization + visibility services (Resolves #293) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/318
* test: migrate tests/test_security.py off legacy BackupService facade (Resolves #294) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/319
* refactor: rename mock_db_session, fix update_port fake, sweep stale comments (Resolves #307) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/320
* fix: restore granted=False permission_check_denied audit event (Resolves #302) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/321
* fix: re-order visibility routes so /migration/* matches before /{resource_type}/{resource_id} (Resolves #314) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/322
* test: consolidate conftest fixtures into helpers (Resolves #168) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/323
* chore: add minimal flake.nix for reproducible dev environment (Resolves #172) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/324
* test: reorganize tests by domain per ARCHITECTURE (Resolves #170) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/325
* fix: cancel and await log streaming tasks in WebSocket disconnect (Resolves #74) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/326
* test: add router + schema validator coverage for groups & templates (Resolves #78) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/327
* feat: add comprehensive health and readiness endpoints (Resolves #21) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/328
* feat: add structured logging with correlation IDs (Resolves #24, Phase 1) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/330
* feat: standardize pagination + error responses (backward-compat, Resolves #76) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/332
* feat: environment-specific configuration with per-env defaults and validators (Resolves #22) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/331
* feat: actionable error responses for server creation failures (Resolves #33) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/334
* feat: password strength validation + brute force protection (Phase 1, Resolves #73) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/333
* fix: token revocation on user deactivation via token_version claim (Resolves #237) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/336
* perf: test execution time optimization (Refs #79 Phase 1) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/335
* feat: optional port + auto-assign + port discovery endpoints (Resolves #31, Resolves #32) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/337
* fix: register /validate endpoint in unified servers router (Resolves #338) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/339
* feat: file operation error handling + audit logging (Resolves #35, Resolves #36, Closes #41) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/340
* docs: add daemon architecture migration guide (Resolves #61) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/342
* feat: add missing database indexes for hot query paths (Refs #75 Phase 1) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/343
* feat: Prometheus metrics export for health + business gauges (Resolves #329) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/344
* fix: enforce upload size limit + encoding validator + rename conflict 409 (Resolves #341) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/345
* chore: add direnv integration + Nix usage in README (Resolves #173, Resolves #174) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/346
* refactor: remove templates feature (Resolves #352) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/355
* feat: populate is_stable field correctly for pre-release versions (Resolves #354) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/356
* fix: version group upper bound + jar download_url validation (Resolves #353) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/358
* perf: cache parsed Settings properties with functools.cached_property (Resolves #367) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/373
* perf: replace COUNT loops with GROUP BY aggregation in server statistics (Resolves #362) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/375
* perf: replace NOT IN subquery with LEFT JOIN + IS NULL in visibility repository by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/374
* perf: replace model_validate with model_construct for trusted entity conversions by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/376
* perf: merge audit log count + fetch into single filtered query (Resolves #372) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/377
* perf: consolidate audit statistics count queries (Resolves #363) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/378
* perf: migrate groups pagination from in-memory slicing to SQL LIMIT/OFFSET (Resolves #365) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/379
* perf: add HTTP Cache-Control headers to read-only list endpoints (Resolves #364) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/381
* perf: explicitly configure SQLAlchemy connection pool settings (Resolves #369) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/380
* perf: remove unused memory_start + add TTL cache to MemoryTracker (Resolves #359) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/382
* perf: add semaphore concurrency control for backup/WebSocket/file I/O (Resolves #351) by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/383
* fix: avoid importlib.reload(app.core.config) in concurrency tests by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/385
* docs(architecture): document audit and real-time event emission patterns by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/387
* refactor(files): split file_management_service into focused modules by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/388
* refactor(servers): split minecraft_server.py into mixin modules by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/389
* chore(python): bump Python patch version to latest 3.13.x by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/391
* chore(deps): bump starlette floor to latest patch by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/392
* chore(deps): bump fastapi floor to 0.136 by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/393
* chore(deps): bump pydantic and pydantic-settings to latest 2.x by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/394
* chore(deps): bump SQLAlchemy to latest 2.0.x by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/399
* refactor(audit): migrate auth/users/files callsites to AuditWriter DI by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/401
* chore: remove stale REFACTOR_PLAN.md and populate_initial_versions.py by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/402
* fix(files): sanitize upload filename to block path traversal by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/403


**Full Changelog**: https://github.com/mmiura-2351/mc-server-dashboard-api/compare/v0.1.0...tagpr-from-v0.1.0