### PR TITLE
ci: pin Temurin 21 in CI / nightly workflows (Resolves #211)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,12 @@ jobs:
           enable-cache: true
           python-version: "3.13.3"
 
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
       - name: Set up just
         uses: extractions/setup-just@v2
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -25,6 +25,12 @@ jobs:
           enable-cache: true
           python-version: "3.13.3"
 
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
       - name: Set up just
         uses: extractions/setup-just@v2
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -101,6 +101,8 @@ markers =
 > **Status:** The `markers` directive is currently silently dropped because the file uses the `[tool:pytest]` section header (the `setup.cfg` form). Selection (`-m slow` / `-m "not slow"`) still works fine — it does not require registration — but pytest emits "unknown mark" warnings that are suppressed by `--disable-warnings` in `addopts`. Migrating the config to `pyproject.toml` under `[tool.pytest.ini_options]` is the proper fix and will re-enable `--strict-markers`; this is deferred because the migration also activates the `-n auto --dist loadscope` directives that are currently no-ops, and doing so exposes pre-existing race conditions in the integration auth fixtures.
 >
 > `tests/conftest.py` provides an automatic skip for `requires_java` when no JRE is on `PATH` (added in #171).
+>
+> **CI Java version:** `.github/workflows/ci.yaml` and `.github/workflows/nightly.yaml` explicitly install Temurin 21 via `actions/setup-java@v4`. This pins the JRE used for `requires_java` tests so the runner image's bundled Java cannot silently change and so `requires_java` tests are never silently skipped on CI (see #211).
 
 ---
 


### PR DESCRIPTION
## Summary
- Add explicit `actions/setup-java@v4` (Temurin 21) to `ci.yaml` test job and `nightly.yaml` full-suite job
- Document the pinned CI Java version in `docs/TESTING.md` alongside the existing `requires_java` notes

## Why
Currently both workflows rely on whatever JRE happens to ship with the `ubuntu-latest` runner image. Combined with #209's `requires_java` auto-skip helper, a runner-image change that removed the bundled JRE would silently skip the very tests intended as drift-catchers — exactly the failure mode #211 calls out.

Java 21 (LTS, latest) is chosen because it covers the highest Minecraft target in `app/services/java_compatibility.py` (1.21+). Lower-version coverage is out of scope per #211.

## Test plan
- [ ] CI run on this PR shows a `Set up Java` step with `Java version: 21.x` in the logs
- [ ] `nightly.yaml` is manually dispatched at least once to confirm the new step runs
- [ ] `requires_java`-marked tests are no longer auto-skipped in CI logs

Resolves #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)