### PR TITLE
test: tighten pytest filterwarnings to upstream-only (Resolves #216)

### DIFF
--- a/app/audit/router.py
+++ b/app/audit/router.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
 from app.audit.models import AuditLog
@@ -28,8 +28,7 @@ class AuditLogResponse(BaseModel):
     # Include user information if available
     user_email: Optional[str] = None
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class AuditLogListResponse(BaseModel):

--- a/app/backups/models.py
+++ b/app/backups/models.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from enum import Enum as PyEnum
 
 from sqlalchemy import (
@@ -15,6 +14,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship
 
 from app.core.database import Base
+from app.core.datetime_utils import utcnow
 
 
 class ScheduleAction(str, PyEnum):
@@ -59,10 +59,8 @@ class BackupSchedule(Base):
     next_backup_at = Column(DateTime, nullable=True, index=True)
 
     # Timestamps
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
-    updated_at = Column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
-    )
+    created_at = Column(DateTime, default=utcnow, nullable=False)
+    updated_at = Column(DateTime, default=utcnow, onupdate=utcnow, nullable=False)
 
     # Relations
     server = relationship("Server", back_populates="backup_schedule")
@@ -94,7 +92,7 @@ class BackupScheduleLog(Base):
     old_config = Column(JSON, nullable=True)
     new_config = Column(JSON, nullable=True)
     executed_by_user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at = Column(DateTime, default=utcnow, nullable=False)
 
     # Relations
     server = relationship("Server")

--- a/app/core/daemon_config.py
+++ b/app/core/daemon_config.py
@@ -9,7 +9,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class DaemonMode(str, Enum):
@@ -128,7 +128,8 @@ class DaemonConfig(BaseModel):
         default=3, ge=1, le=10, description="Maximum recovery attempts per process"
     )
 
-    @validator("pid_file_directory")
+    @field_validator("pid_file_directory")
+    @classmethod
     def validate_pid_directory(cls, v):
         """Validate PID file directory"""
         if v is not None:
@@ -147,7 +148,8 @@ class DaemonConfig(BaseModel):
 
         return v
 
-    @validator("monitoring_interval_seconds")
+    @field_validator("monitoring_interval_seconds")
+    @classmethod
     def validate_monitoring_interval(cls, v):
         """Validate monitoring interval"""
         if v <= 0:
@@ -156,7 +158,8 @@ class DaemonConfig(BaseModel):
             raise ValueError("Monitoring interval too long (max 300 seconds)")
         return v
 
-    @validator("resource_limits")
+    @field_validator("resource_limits")
+    @classmethod
     def validate_resource_limits(cls, v):
         """Validate resource limits"""
         if v.max_memory_mb <= 0:

--- a/app/core/datetime_utils.py
+++ b/app/core/datetime_utils.py
@@ -1,0 +1,18 @@
+"""Datetime helpers.
+
+`utcnow()` returns a naive datetime representing the current UTC wall time
+(the same semantics as the deprecated `datetime.datetime.utcnow()`). It exists
+so the codebase can avoid the deprecated call without changing storage or
+comparison semantics — DB columns are declared as `DateTime` (not
+`DateTime(timezone=True)`), so values written by this helper round-trip as
+naive datetimes just as `datetime.utcnow()` did.
+
+New code that does not interact with naive DB rows should prefer
+`datetime.now(timezone.utc)` (timezone-aware UTC) directly.
+"""
+
+from datetime import datetime, timezone
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)

--- a/app/core/visibility_schemas.py
+++ b/app/core/visibility_schemas.py
@@ -7,7 +7,7 @@ Defines request/response models for the Phase 2 visibility management system.
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from app.core.visibility import ResourceType, VisibilityType
 from app.users.models import Role
@@ -24,10 +24,11 @@ class VisibilityUpdateRequest(BaseModel):
         description="Role restriction for role_based visibility (required if visibility_type is role_based)",
     )
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {"visibility_type": "role_based", "role_restriction": "operator"}
         }
+    )
 
 
 class UserAccessGrantRequest(BaseModel):
@@ -35,8 +36,7 @@ class UserAccessGrantRequest(BaseModel):
 
     user_id: int = Field(description="ID of the user to grant access to")
 
-    class Config:
-        json_schema_extra = {"example": {"user_id": 123}}
+    model_config = ConfigDict(json_schema_extra={"example": {"user_id": 123}})
 
 
 class UserAccessGrantResponse(BaseModel):
@@ -46,8 +46,7 @@ class UserAccessGrantResponse(BaseModel):
     granted_by_user_id: Optional[int]
     granted_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class VisibilityInfoResponse(BaseModel):
@@ -61,9 +60,9 @@ class VisibilityInfoResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    class Config:
-        from_attributes = True
-        json_schema_extra = {
+    model_config = ConfigDict(
+        from_attributes=True,
+        json_schema_extra={
             "example": {
                 "resource_type": "server",
                 "resource_id": 1,
@@ -79,7 +78,8 @@ class VisibilityInfoResponse(BaseModel):
                 "created_at": "2024-01-01T10:00:00Z",
                 "updated_at": "2024-01-01T11:00:00Z",
             }
-        }
+        },
+    )
 
 
 class MigrationStatusResponse(BaseModel):
@@ -90,8 +90,8 @@ class MigrationStatusResponse(BaseModel):
     resource_stats: dict
     visibility_distribution: dict
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "migration_complete": True,
                 "issues": [],
@@ -105,6 +105,7 @@ class MigrationStatusResponse(BaseModel):
                 },
             }
         }
+    )
 
 
 class MigrationExecuteResponse(BaseModel):
@@ -114,14 +115,15 @@ class MigrationExecuteResponse(BaseModel):
     message: str
     migration_counts: dict
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "success": True,
                 "message": "Migration completed successfully",
                 "migration_counts": {"servers": 10, "groups": 5, "total": 15},
             }
         }
+    )
 
 
 # Export schemas

--- a/app/files/models.py
+++ b/app/files/models.py
@@ -2,12 +2,11 @@
 File edit history models for tracking file changes.
 """
 
-from datetime import datetime
-
 from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import relationship
 
 from app.core.database import Base
+from app.core.datetime_utils import utcnow
 
 
 class FileEditHistory(Base):
@@ -29,7 +28,7 @@ class FileEditHistory(Base):
     editor_user_id = Column(
         Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
     )
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at = Column(DateTime, default=utcnow, nullable=False)
     description = Column(Text, nullable=True)  # Optional description of the edit
 
     # Relationships

--- a/app/services/template_service.py
+++ b/app/services/template_service.py
@@ -314,7 +314,7 @@ class TemplateService:
             if template_path.exists():
                 # Extract template files to server directory
                 with tarfile.open(template_path, "r:gz") as tar:
-                    tar.extractall(path=server_dir)
+                    tar.extractall(path=server_dir, filter="data")
 
                 logger.info(f"Applied template {template_id} files to {server_dir}")
 

--- a/app/versions/management.py
+++ b/app/versions/management.py
@@ -6,12 +6,13 @@ manual update triggers and database maintenance operations.
 """
 
 import logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Optional
 
 from sqlalchemy.orm import Session
 
 from app.core.database import SessionLocal
+from app.core.datetime_utils import utcnow
 from app.servers.models import ServerType
 from app.versions.repository import VersionRepository
 from app.versions.schemas import VersionUpdateResult
@@ -287,7 +288,7 @@ class VersionManagementService:
 
             # Check for very old data (older than 30 days)
             try:
-                cutoff_date = datetime.utcnow() - timedelta(days=30)
+                cutoff_date = utcnow() - timedelta(days=30)
                 old_versions = repo.get_versions_older_than(cutoff_date)
                 if old_versions:
                     validation_results["warnings"].append(

--- a/app/versions/models.py
+++ b/app/versions/models.py
@@ -2,12 +2,12 @@
 Database models for Minecraft version management
 """
 
-from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import Boolean, Column, DateTime, Index, Integer, String, Text
 
 from app.core.database import Base
+from app.core.datetime_utils import utcnow
 
 
 class MinecraftVersion(Base):
@@ -43,10 +43,8 @@ class MinecraftVersion(Base):
     )  # Active/inactive flag
 
     # Timestamps
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
-    updated_at = Column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
-    )
+    created_at = Column(DateTime, default=utcnow, nullable=False)
+    updated_at = Column(DateTime, default=utcnow, onupdate=utcnow, nullable=False)
 
     # Indexes for performance
     __table_args__ = (
@@ -125,7 +123,7 @@ class VersionUpdateLog(Base):
     executed_by_user_id = Column(Integer, nullable=True)  # User ID for manual updates
 
     # Timestamps
-    started_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+    started_at = Column(DateTime, default=utcnow, nullable=False, index=True)
     completed_at = Column(DateTime, nullable=True)
 
     # Indexes for performance

--- a/app/versions/repository.py
+++ b/app/versions/repository.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 from sqlalchemy import and_, desc, func
 from sqlalchemy.orm import Session
 
+from app.core.datetime_utils import utcnow
 from app.servers.models import ServerType
 from app.versions.models import MinecraftVersion, VersionUpdateLog
 from app.versions.schemas import (
@@ -105,7 +106,7 @@ class VersionRepository:
             existing.is_stable = version_data.is_stable
             existing.build_number = version_data.build_number
             existing.is_active = True  # Reactivate if was inactive
-            existing.updated_at = datetime.utcnow()
+            existing.updated_at = utcnow()
 
             self.db.commit()
             self.db.refresh(existing)
@@ -131,7 +132,7 @@ class VersionRepository:
         for field, value in version_data.model_dump(exclude_unset=True).items():
             setattr(db_version, field, value)
 
-        db_version.updated_at = datetime.utcnow()
+        db_version.updated_at = utcnow()
 
         self.db.commit()
         self.db.refresh(db_version)
@@ -155,7 +156,7 @@ class VersionRepository:
         count = query.count()
 
         query.update(
-            {"is_active": False, "updated_at": datetime.utcnow()},
+            {"is_active": False, "updated_at": utcnow()},
             synchronize_session=False,
         )
 
@@ -167,7 +168,7 @@ class VersionRepository:
         Remove very old inactive versions to save space
         Returns number of versions deleted
         """
-        cutoff_date = datetime.utcnow() - timedelta(days=days_old)
+        cutoff_date = utcnow() - timedelta(days=days_old)
 
         query = self.db.query(MinecraftVersion).filter(
             and_(
@@ -245,7 +246,7 @@ class VersionRepository:
             return None
 
         db_log.status = status
-        db_log.completed_at = datetime.utcnow()
+        db_log.completed_at = utcnow()
         db_log.execution_time_ms = execution_time_ms
         db_log.error_message = error_message
 

--- a/app/versions/scheduler.py
+++ b/app/versions/scheduler.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from app.core.database import SessionLocal
+from app.core.datetime_utils import utcnow
 from app.versions.schemas import VersionUpdateResult
 from app.versions.service import VersionUpdateService
 
@@ -117,13 +118,13 @@ class VersionUpdateSchedulerService:
             # No previous update, update is due
             return True
 
-        time_since_last_update = datetime.utcnow() - self._last_successful_update
+        time_since_last_update = utcnow() - self._last_successful_update
         return time_since_last_update >= timedelta(hours=self._update_interval_hours)
 
     def _get_next_update_time(self) -> datetime:
         """Calculate the next scheduled update time"""
         if self._last_successful_update is None:
-            return datetime.utcnow()
+            return utcnow()
 
         return self._last_successful_update + timedelta(hours=self._update_interval_hours)
 
@@ -152,7 +153,7 @@ class VersionUpdateSchedulerService:
 
                     if result.success:
                         # Update successful
-                        self._last_successful_update = datetime.utcnow()
+                        self._last_successful_update = utcnow()
                         self._last_error = None
 
                         logger.info(
@@ -228,7 +229,7 @@ class VersionUpdateSchedulerService:
             )
 
             if result.success:
-                self._last_successful_update = datetime.utcnow()
+                self._last_successful_update = utcnow()
                 self._last_error = None
                 logger.info("Manual version update completed successfully")
             else:

--- a/app/versions/schemas.py
+++ b/app/versions/schemas.py
@@ -148,11 +148,13 @@ class VersionStatsResponse(BaseModel):
     by_server_type: Dict[str, Dict[str, int]] = Field(
         ...,
         description="Statistics breakdown by server type",
-        example={
-            "vanilla": {"total": 50, "active": 45},
-            "paper": {"total": 120, "active": 115},
-            "fabric": {"total": 80, "active": 75},
-            "forge": {"total": 200, "active": 180},
+        json_schema_extra={
+            "example": {
+                "vanilla": {"total": 50, "active": 45},
+                "paper": {"total": 120, "active": 115},
+                "fabric": {"total": 80, "active": 75},
+                "forge": {"total": 200, "active": 180},
+            }
         },
     )
 

--- a/app/versions/service.py
+++ b/app/versions/service.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Optional
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
+from app.core.datetime_utils import utcnow
 from app.servers.models import ServerType
 from app.services.version_manager import minecraft_version_manager
 from app.versions.models import MinecraftVersion
@@ -144,7 +145,7 @@ class VersionUpdateService:
             )
             self.db.commit()
 
-            self._last_update_time = datetime.utcnow()
+            self._last_update_time = utcnow()
 
             success_msg = (
                 f"Version update completed: +{total_added} -{total_removed} ~{total_updated} "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,10 +84,9 @@ markers = [
     "requires_java: test needs a working JRE on PATH. Automatically skipped when Java is not detected.",
 ]
 filterwarnings = [
-    "ignore::DeprecationWarning",
-    "ignore::PendingDeprecationWarning",
-    "ignore:.*'crypt' is deprecated.*:DeprecationWarning",
-    "ignore:.*Support for class-based.*:DeprecationWarning",
+    "error::DeprecationWarning",
+    "error::PendingDeprecationWarning",
+    "ignore:'crypt' is deprecated:DeprecationWarning",
 ]
 
 [tool.coverage.run]

--- a/tests/integration/test_database_version_integration.py
+++ b/tests/integration/test_database_version_integration.py
@@ -4,7 +4,6 @@ Integration tests for database-based version management in server creation.
 Tests that server creation now uses fast database queries instead of slow external API calls.
 """
 
-import asyncio
 from pathlib import Path
 from unittest.mock import patch
 
@@ -38,7 +37,7 @@ class TestDatabaseVersionIntegration:
             email="admin@test.com",
             is_active=True,
             is_approved=True,
-            role=Role.admin
+            role=Role.admin,
         )
         return user
 
@@ -51,7 +50,7 @@ class TestDatabaseVersionIntegration:
             server_type=ServerType.vanilla,
             max_memory=1024,
             max_players=20,
-            port=25565
+            port=25565,
         )
 
     @pytest.fixture
@@ -64,7 +63,7 @@ class TestDatabaseVersionIntegration:
             version="1.21.6",
             download_url="https://launcher.mojang.com/v1/objects/test.jar",
             is_stable=True,
-            is_active=True
+            is_active=True,
         )
 
         db.add(db_version)
@@ -73,16 +72,28 @@ class TestDatabaseVersionIntegration:
 
     @pytest.mark.asyncio
     async def test_server_creation_uses_database_validation(
-        self, server_service, sample_create_request, mock_admin_user, db, sample_db_version
+        self,
+        server_service,
+        sample_create_request,
+        mock_admin_user,
+        db,
+        sample_db_version,
     ):
         """Test that server creation uses database for version validation (FAST)"""
 
         # Mock filesystem operations to avoid actual file creation
-        with patch.object(server_service.filesystem_service, 'create_server_directory') as mock_create_dir, \
-             patch.object(server_service.jar_service, 'get_server_jar') as mock_get_jar, \
-             patch.object(server_service.filesystem_service, 'generate_server_files') as mock_gen_files, \
-             patch.object(server_service, '_validate_java_compatibility') as mock_java_compat:
-
+        with (
+            patch.object(
+                server_service.filesystem_service, "create_server_directory"
+            ) as mock_create_dir,
+            patch.object(server_service.jar_service, "get_server_jar") as mock_get_jar,
+            patch.object(
+                server_service.filesystem_service, "generate_server_files"
+            ) as mock_gen_files,
+            patch.object(
+                server_service, "_validate_java_compatibility"
+            ) as mock_java_compat,
+        ):
             # Setup mocks
             mock_create_dir.return_value = "/tmp/test-server"
             mock_get_jar.return_value = "/tmp/test-server/server.jar"
@@ -90,7 +101,9 @@ class TestDatabaseVersionIntegration:
             mock_java_compat.return_value = None
 
             # Create server - this should use database validation
-            result = await server_service.create_server(sample_create_request, mock_admin_user, db)
+            result = await server_service.create_server(
+                sample_create_request, mock_admin_user, db
+            )
 
             # Verify result
             assert result.name == "test-server"
@@ -112,9 +125,10 @@ class TestDatabaseVersionIntegration:
         """Test that JAR service uses database for version validation (FAST PATH)"""
 
         # Mock external dependencies
-        with patch.object(jar_service.cache_manager, 'get_or_download_jar') as mock_cache, \
-             patch.object(jar_service.cache_manager, 'copy_jar_to_server') as mock_copy:
-
+        with (
+            patch.object(jar_service.cache_manager, "get_or_download_jar") as mock_cache,
+            patch.object(jar_service.cache_manager, "copy_jar_to_server") as mock_copy,
+        ):
             mock_cache.return_value = "/cache/vanilla-1.21.6.jar"
             mock_copy.return_value = "/server/server.jar"
 
@@ -130,17 +144,17 @@ class TestDatabaseVersionIntegration:
             mock_cache.assert_called_once_with(
                 ServerType.vanilla,
                 "1.21.6",
-                "https://launcher.mojang.com/v1/objects/test.jar"
+                "https://launcher.mojang.com/v1/objects/test.jar",
             )
 
     @pytest.mark.asyncio
-    async def test_jar_service_error_on_unsupported_version(
-        self, jar_service, db
-    ):
+    async def test_jar_service_error_on_unsupported_version(self, jar_service, db):
         """Test that JAR service raises error when version not supported"""
 
         # Call with version not in database - should raise error instead of fallback
-        with pytest.raises(FileOperationException, match="Version 1.20.0 is not supported"):
+        with pytest.raises(
+            FileOperationException, match="Version 1.20.0 is not supported"
+        ):
             await jar_service.get_server_jar(
                 ServerType.vanilla, "1.20.0", "/tmp/test-server", db
             )
@@ -159,16 +173,23 @@ class TestDatabaseVersionIntegration:
             server_type=ServerType.vanilla,
             max_memory=1024,
             max_players=20,
-            port=25565
+            port=25565,
         )
 
         # Mock filesystem and validation to avoid unrelated errors
         # Also mock jar service to ensure version validation happens first
-        with patch.object(server_service.validation_service, 'validate_server_uniqueness') as mock_unique, \
-             patch.object(server_service, '_validate_java_compatibility') as mock_java, \
-             patch.object(server_service.filesystem_service, 'create_server_directory') as mock_dir, \
-             patch.object(server_service.jar_service, '_is_version_supported_db') as mock_jar_version_check:
-
+        with (
+            patch.object(
+                server_service.validation_service, "validate_server_uniqueness"
+            ) as mock_unique,
+            patch.object(server_service, "_validate_java_compatibility") as mock_java,
+            patch.object(
+                server_service.filesystem_service, "create_server_directory"
+            ) as mock_dir,
+            patch.object(
+                server_service.jar_service, "_is_version_supported_db"
+            ) as mock_jar_version_check,
+        ):
             mock_unique.return_value = None
             mock_java.return_value = None
             mock_dir.return_value = Path("/tmp/test-server")
@@ -183,16 +204,15 @@ class TestDatabaseVersionIntegration:
             assert "not supported" in str(exc_info.value.detail).lower()
 
     @pytest.mark.asyncio
-    async def test_database_only_performance(
-        self, jar_service, db, sample_db_version
-    ):
+    async def test_database_only_performance(self, jar_service, db, sample_db_version):
         """Test that database-only approach provides fast performance"""
         import time
 
         # Test database path timing
-        with patch.object(jar_service.cache_manager, 'get_or_download_jar') as mock_cache, \
-             patch.object(jar_service.cache_manager, 'copy_jar_to_server') as mock_copy:
-
+        with (
+            patch.object(jar_service.cache_manager, "get_or_download_jar") as mock_cache,
+            patch.object(jar_service.cache_manager, "copy_jar_to_server") as mock_copy,
+        ):
             mock_cache.return_value = "/cache/test.jar"
             mock_copy.return_value = "/server/server.jar"
 
@@ -205,13 +225,16 @@ class TestDatabaseVersionIntegration:
 
             # Database path should be very fast (< 50ms typically)
             assert db_time < 0.1  # 100ms threshold for CI environments
-            print(f"Database performance: {db_time*1000:.1f}ms")
+            print(f"Database performance: {db_time * 1000:.1f}ms")
 
         # Test that unsupported versions fail fast
         start_time = time.time()
         try:
             await jar_service.get_server_jar(
-                ServerType.vanilla, "1.19.0", "/tmp/test", db  # Version not in DB
+                ServerType.vanilla,
+                "1.19.0",
+                "/tmp/test",
+                db,  # Version not in DB
             )
         except FileOperationException:
             pass  # Expected error
@@ -219,4 +242,4 @@ class TestDatabaseVersionIntegration:
 
         # Error should also be fast
         assert error_time < 0.1  # 100ms threshold for CI environments
-        print(f"Error handling performance: {error_time*1000:.1f}ms")
+        print(f"Error handling performance: {error_time * 1000:.1f}ms")

--- a/tests/integration/test_server_export_import.py
+++ b/tests/integration/test_server_export_import.py
@@ -93,16 +93,16 @@ class TestServerExportImport:
         zip_buffer = io.BytesIO()
 
         # First, create a version in the database to ensure it's supported
+        from app.core.datetime_utils import utcnow
         from app.versions.models import MinecraftVersion
-        from datetime import datetime
 
         version = MinecraftVersion(
             server_type="vanilla",
             version="1.21.6",
             download_url="https://launcher.mojang.com/v1/objects/test.jar",
-            release_date=datetime.utcnow(),
+            release_date=utcnow(),
             is_stable=True,
-            is_active=True
+            is_active=True,
         )
         db.add(version)
         db.commit()
@@ -125,9 +125,14 @@ class TestServerExportImport:
         zip_buffer.seek(0)
 
         # Mock JAR download and caching to avoid actual network calls
-        with patch("app.services.jar_cache_manager.jar_cache_manager.get_or_download_jar") as mock_cache, \
-             patch("app.services.jar_cache_manager.jar_cache_manager.copy_jar_to_server") as mock_copy:
-
+        with (
+            patch(
+                "app.services.jar_cache_manager.jar_cache_manager.get_or_download_jar"
+            ) as mock_cache,
+            patch(
+                "app.services.jar_cache_manager.jar_cache_manager.copy_jar_to_server"
+            ) as mock_copy,
+        ):
             mock_cache.return_value = "/cache/test-vanilla-1.21.6.jar"
             mock_copy.return_value = "/server/server.jar"
 
@@ -349,16 +354,16 @@ class TestServerExportImport:
     ):
         """Test that import allows port conflicts with stopped servers"""
         # First, create a version in the database to ensure it's supported
+        from app.core.datetime_utils import utcnow
         from app.versions.models import MinecraftVersion
-        from datetime import datetime
 
         version = MinecraftVersion(
             server_type="vanilla",
             version="1.21.6",
             download_url="https://launcher.mojang.com/v1/objects/test.jar",
-            release_date=datetime.utcnow(),
+            release_date=utcnow(),
             is_stable=True,
-            is_active=True
+            is_active=True,
         )
         db.add(version)
         db.commit()
@@ -396,9 +401,14 @@ class TestServerExportImport:
         zip_buffer.seek(0)
 
         # Mock JAR download and caching to avoid actual network calls
-        with patch("app.services.jar_cache_manager.jar_cache_manager.get_or_download_jar") as mock_cache, \
-             patch("app.services.jar_cache_manager.jar_cache_manager.copy_jar_to_server") as mock_copy:
-
+        with (
+            patch(
+                "app.services.jar_cache_manager.jar_cache_manager.get_or_download_jar"
+            ) as mock_cache,
+            patch(
+                "app.services.jar_cache_manager.jar_cache_manager.copy_jar_to_server"
+            ) as mock_copy,
+        ):
             mock_cache.return_value = "/cache/test-vanilla-1.21.6.jar"
             mock_copy.return_value = "/server/server.jar"
 
@@ -415,7 +425,9 @@ class TestServerExportImport:
 
             assert response.status_code == status.HTTP_201_CREATED
             server_data = response.json()
-            assert server_data["port"] == 25565  # Should get the same port as stopped server
+            assert (
+                server_data["port"] == 25565
+            )  # Should get the same port as stopped server
 
         # Cleanup
         import shutil

--- a/tests/integration/test_server_port_conflicts.py
+++ b/tests/integration/test_server_port_conflicts.py
@@ -17,16 +17,16 @@ class TestServerPortConflicts:
     ):
         """Test that creating servers with duplicate ports is now allowed during creation"""
         # First, create a version in the database to ensure it's supported
+        from app.core.datetime_utils import utcnow
         from app.versions.models import MinecraftVersion
-        from datetime import datetime
 
         version = MinecraftVersion(
             server_type="vanilla",
             version="1.21.6",
             download_url="https://launcher.mojang.com/v1/objects/test.jar",
-            release_date=datetime.utcnow(),
+            release_date=utcnow(),
             is_stable=True,
-            is_active=True
+            is_active=True,
         )
         db.add(version)
         db.commit()
@@ -47,9 +47,14 @@ class TestServerPortConflicts:
         db.commit()
 
         # Mock JAR download and caching to avoid actual network calls
-        with patch("app.services.jar_cache_manager.jar_cache_manager.get_or_download_jar") as mock_cache, \
-             patch("app.services.jar_cache_manager.jar_cache_manager.copy_jar_to_server") as mock_copy:
-
+        with (
+            patch(
+                "app.services.jar_cache_manager.jar_cache_manager.get_or_download_jar"
+            ) as mock_cache,
+            patch(
+                "app.services.jar_cache_manager.jar_cache_manager.copy_jar_to_server"
+            ) as mock_copy,
+        ):
             mock_cache.return_value = "/cache/test-vanilla-1.21.6.jar"
             mock_copy.return_value = "/server/server.jar"
 
@@ -86,16 +91,16 @@ class TestServerPortConflicts:
     ):
         """Test that creating a server succeeds when port conflicts with stopped server"""
         # First, create a version in the database to ensure it's supported
+        from app.core.datetime_utils import utcnow
         from app.versions.models import MinecraftVersion
-        from datetime import datetime
 
         version = MinecraftVersion(
             server_type="vanilla",
             version="1.21.6",
             download_url="https://launcher.mojang.com/v1/objects/test.jar",
-            release_date=datetime.utcnow(),
+            release_date=utcnow(),
             is_stable=True,
-            is_active=True
+            is_active=True,
         )
         db.add(version)
         db.commit()
@@ -117,9 +122,14 @@ class TestServerPortConflicts:
         db.commit()
 
         # Mock JAR download and caching to avoid actual network calls
-        with patch("app.services.jar_cache_manager.jar_cache_manager.get_or_download_jar") as mock_cache, \
-             patch("app.services.jar_cache_manager.jar_cache_manager.copy_jar_to_server") as mock_copy:
-
+        with (
+            patch(
+                "app.services.jar_cache_manager.jar_cache_manager.get_or_download_jar"
+            ) as mock_cache,
+            patch(
+                "app.services.jar_cache_manager.jar_cache_manager.copy_jar_to_server"
+            ) as mock_copy,
+        ):
             mock_cache.return_value = "/cache/test-vanilla-1.21.6.jar"
             mock_copy.return_value = "/server/server.jar"
 
@@ -156,16 +166,16 @@ class TestServerPortConflicts:
     ):
         """Test that creating servers with duplicate ports is allowed regardless of existing server status"""
         # First, create a version in the database to ensure it's supported
+        from app.core.datetime_utils import utcnow
         from app.versions.models import MinecraftVersion
-        from datetime import datetime
 
         version = MinecraftVersion(
             server_type="vanilla",
             version="1.21.6",
             download_url="https://launcher.mojang.com/v1/objects/test.jar",
-            release_date=datetime.utcnow(),
+            release_date=utcnow(),
             is_stable=True,
-            is_active=True
+            is_active=True,
         )
         db.add(version)
         db.commit()
@@ -187,9 +197,14 @@ class TestServerPortConflicts:
         db.commit()
 
         # Mock JAR download and caching to avoid actual network calls
-        with patch("app.services.jar_cache_manager.jar_cache_manager.get_or_download_jar") as mock_cache, \
-             patch("app.services.jar_cache_manager.jar_cache_manager.copy_jar_to_server") as mock_copy:
-
+        with (
+            patch(
+                "app.services.jar_cache_manager.jar_cache_manager.get_or_download_jar"
+            ) as mock_cache,
+            patch(
+                "app.services.jar_cache_manager.jar_cache_manager.copy_jar_to_server"
+            ) as mock_copy,
+        ):
             mock_cache.return_value = "/cache/test-vanilla-1.21.6.jar"
             mock_copy.return_value = "/server/server.jar"
 

--- a/tests/unit/servers/test_service.py
+++ b/tests/unit/servers/test_service.py
@@ -224,9 +224,7 @@ class TestServerService:
             with pytest.raises(InvalidRequestException) as exc_info:
                 await server_service.create_server(mock_request, mock_user, mock_db)
 
-            assert "Version 1.20.1 is not supported for vanilla" in str(
-                exc_info.value
-            )
+            assert "Version 1.20.1 is not supported for vanilla" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_get_server_success(self, server_service, mock_db):

--- a/tests/unit/services/test_version_manager.py
+++ b/tests/unit/services/test_version_manager.py
@@ -126,7 +126,6 @@ class TestMinecraftVersionManager:
             assert all(v.server_type == ServerType.paper for v in versions)
             assert versions[0].build_number == 196
 
-
     @pytest.mark.asyncio
     async def test_get_supported_versions_with_cache(self):
         """Test getting supported versions with cache hit"""
@@ -461,7 +460,9 @@ class TestMinecraftVersionManagerMissingCoverage:
         # Should return real versions from Forge API, not fallback
         assert len(result) > 3  # More than the 3 fallback versions
         assert all(v.server_type == ServerType.forge for v in result)
-        assert all(v.download_url.startswith("https://maven.minecraftforge.net") for v in result)
+        assert all(
+            v.download_url.startswith("https://maven.minecraftforge.net") for v in result
+        )
 
     @pytest.mark.asyncio
     async def test_get_forge_versions_raises_error_on_failure(self, manager):

--- a/tests/unit/versions/test_management.py
+++ b/tests/unit/versions/test_management.py
@@ -2,11 +2,12 @@
 Unit tests for VersionManagementService
 """
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from app.core.datetime_utils import utcnow
 from app.versions.management import VersionManagementService
 from app.versions.schemas import VersionUpdateResult
 
@@ -34,7 +35,7 @@ class TestVersionManagementService:
             versions_updated=5,
             versions_removed=2,
             execution_time_ms=2500,
-            errors=[]
+            errors=[],
         )
 
     @pytest.fixture
@@ -47,7 +48,7 @@ class TestVersionManagementService:
             versions_updated=0,
             versions_removed=0,
             execution_time_ms=1000,
-            errors=["Failed to connect to Mojang API"]
+            errors=["Failed to connect to Mojang API"],
         )
 
     # ===================
@@ -55,18 +56,18 @@ class TestVersionManagementService:
     # ===================
 
     @pytest.mark.asyncio
-    async def test_trigger_manual_update_success(self, management_service, mock_update_result):
+    async def test_trigger_manual_update_success(
+        self, management_service, mock_update_result
+    ):
         """Test successful manual update trigger"""
-        with patch('app.versions.management.VersionUpdateService') as mock_service_class:
+        with patch("app.versions.management.VersionUpdateService") as mock_service_class:
             # Mock service
             mock_service = Mock()
             mock_service_class.return_value = mock_service
             mock_service.update_versions = AsyncMock(return_value=mock_update_result)
 
             result = await management_service.trigger_manual_update(
-                server_types=None,
-                force_refresh=True,
-                user_id=123
+                server_types=None, force_refresh=True, user_id=123
             )
 
             assert result.success
@@ -76,19 +77,21 @@ class TestVersionManagementService:
 
             # Verify service was called correctly
             mock_service.update_versions.assert_called_once_with(
-                server_types=None,
-                force_refresh=True,
-                user_id=123
+                server_types=None, force_refresh=True, user_id=123
             )
 
     @pytest.mark.asyncio
-    async def test_trigger_manual_update_failure(self, management_service, mock_failed_update_result):
+    async def test_trigger_manual_update_failure(
+        self, management_service, mock_failed_update_result
+    ):
         """Test failed manual update trigger"""
-        with patch('app.versions.management.VersionUpdateService') as mock_service_class:
+        with patch("app.versions.management.VersionUpdateService") as mock_service_class:
             # Mock service
             mock_service = Mock()
             mock_service_class.return_value = mock_service
-            mock_service.update_versions = AsyncMock(return_value=mock_failed_update_result)
+            mock_service.update_versions = AsyncMock(
+                return_value=mock_failed_update_result
+            )
 
             result = await management_service.trigger_manual_update()
 
@@ -97,11 +100,13 @@ class TestVersionManagementService:
             assert len(result.errors) == 1
 
     @pytest.mark.asyncio
-    async def test_trigger_manual_update_with_server_types(self, management_service, mock_update_result):
+    async def test_trigger_manual_update_with_server_types(
+        self, management_service, mock_update_result
+    ):
         """Test manual update with specific server types"""
         from app.servers.models import ServerType
 
-        with patch('app.versions.management.VersionUpdateService') as mock_service_class:
+        with patch("app.versions.management.VersionUpdateService") as mock_service_class:
             # Mock service
             mock_service = Mock()
             mock_service_class.return_value = mock_service
@@ -109,18 +114,14 @@ class TestVersionManagementService:
 
             server_types = [ServerType.vanilla, ServerType.paper]
             result = await management_service.trigger_manual_update(
-                server_types=server_types,
-                force_refresh=False,
-                user_id=456
+                server_types=server_types, force_refresh=False, user_id=456
             )
 
             assert result.success
 
             # Verify correct parameters were passed
             mock_service.update_versions.assert_called_once_with(
-                server_types=server_types,
-                force_refresh=False,
-                user_id=456
+                server_types=server_types, force_refresh=False, user_id=456
             )
 
     # ===================
@@ -129,56 +130,60 @@ class TestVersionManagementService:
 
     def test_get_version_statistics_success(self, management_service):
         """Test successful version statistics retrieval"""
-        with patch('app.versions.management.VersionRepository') as mock_repo_class:
+        with patch("app.versions.management.VersionRepository") as mock_repo_class:
             # Mock repository
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
 
             # Mock version data
             mock_versions = {
-                'vanilla': [Mock(version='1.21.6', last_updated=datetime.utcnow())],
-                'paper': [Mock(version='1.21.6-123', last_updated=datetime.utcnow())],
-                'fabric': [],
-                'forge': [Mock(version='1.21.6-forge-1.0.0', last_updated=datetime.utcnow())]
+                "vanilla": [Mock(version="1.21.6", last_updated=utcnow())],
+                "paper": [Mock(version="1.21.6-123", last_updated=utcnow())],
+                "fabric": [],
+                "forge": [Mock(version="1.21.6-forge-1.0.0", last_updated=utcnow())],
             }
 
             def mock_get_versions_by_server_type(server_type):
                 return mock_versions.get(server_type, [])
 
-            mock_repo.get_versions_by_server_type.side_effect = mock_get_versions_by_server_type
-            mock_repo.get_all_versions.return_value = [Mock(last_updated=datetime.utcnow())]
+            mock_repo.get_versions_by_server_type.side_effect = (
+                mock_get_versions_by_server_type
+            )
+            mock_repo.get_all_versions.return_value = [Mock(last_updated=utcnow())]
 
             stats = management_service.get_version_statistics()
 
-            assert stats['total_versions'] == 3
-            assert stats['by_server_type']['vanilla']['count'] == 1
-            assert stats['by_server_type']['paper']['count'] == 1
-            assert stats['by_server_type']['fabric']['count'] == 0
-            assert stats['by_server_type']['forge']['count'] == 1
-            assert stats['database_status'] == 'healthy'
-            assert stats['last_update'] is not None
+            assert stats["total_versions"] == 3
+            assert stats["by_server_type"]["vanilla"]["count"] == 1
+            assert stats["by_server_type"]["paper"]["count"] == 1
+            assert stats["by_server_type"]["fabric"]["count"] == 0
+            assert stats["by_server_type"]["forge"]["count"] == 1
+            assert stats["database_status"] == "healthy"
+            assert stats["last_update"] is not None
 
     def test_get_version_statistics_with_errors(self, management_service):
         """Test version statistics with some errors"""
-        with patch('app.versions.management.VersionRepository') as mock_repo_class:
+        with patch("app.versions.management.VersionRepository") as mock_repo_class:
             # Mock repository
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
 
             # Mock some server types to raise errors
             def mock_get_versions_with_error(server_type):
-                if server_type == 'fabric':
+                if server_type == "fabric":
                     raise Exception("Database connection error")
-                return [Mock(version='1.21.6', last_updated=datetime.utcnow())]
+                return [Mock(version="1.21.6", last_updated=utcnow())]
 
-            mock_repo.get_versions_by_server_type.side_effect = mock_get_versions_with_error
-            mock_repo.get_all_versions.return_value = [Mock(last_updated=datetime.utcnow())]
+            mock_repo.get_versions_by_server_type.side_effect = (
+                mock_get_versions_with_error
+            )
+            mock_repo.get_all_versions.return_value = [Mock(last_updated=utcnow())]
 
             stats = management_service.get_version_statistics()
 
-            assert stats['database_status'] == 'degraded'
-            assert 'error' in stats['by_server_type']['fabric']
-            assert stats['by_server_type']['vanilla']['count'] == 1
+            assert stats["database_status"] == "degraded"
+            assert "error" in stats["by_server_type"]["fabric"]
+            assert stats["by_server_type"]["vanilla"]["count"] == 1
 
     # ===================
     # Cleanup tests
@@ -186,18 +191,20 @@ class TestVersionManagementService:
 
     def test_cleanup_old_versions_success(self, management_service):
         """Test successful version cleanup"""
-        with patch('app.versions.management.VersionRepository') as mock_repo_class:
+        with patch("app.versions.management.VersionRepository") as mock_repo_class:
             # Mock repository
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
 
             # Mock version data - simulate having more versions than keep_latest
-            mock_versions = [Mock(id=i, version=f'1.21.{i}') for i in range(150)]
+            mock_versions = [Mock(id=i, version=f"1.21.{i}") for i in range(150)]
 
             def mock_get_versions_by_server_type(server_type):
                 return mock_versions
 
-            mock_repo.get_versions_by_server_type.side_effect = mock_get_versions_by_server_type
+            mock_repo.get_versions_by_server_type.side_effect = (
+                mock_get_versions_by_server_type
+            )
             mock_repo.delete_version.return_value = True
 
             # Mock session for committing
@@ -205,21 +212,21 @@ class TestVersionManagementService:
 
             result = management_service.cleanup_old_versions(keep_latest=100)
 
-            assert result['status'] == 'success'
-            assert result['total_removed'] == 200  # 50 removed per server type * 4 types
+            assert result["status"] == "success"
+            assert result["total_removed"] == 200  # 50 removed per server type * 4 types
 
             # Should have called delete_version for each version beyond keep_latest
             assert mock_repo.delete_version.call_count == 200
 
     def test_cleanup_old_versions_no_cleanup_needed(self, management_service):
         """Test cleanup when no cleanup is needed"""
-        with patch('app.versions.management.VersionRepository') as mock_repo_class:
+        with patch("app.versions.management.VersionRepository") as mock_repo_class:
             # Mock repository
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
 
             # Mock having fewer versions than keep_latest
-            mock_versions = [Mock(id=i, version=f'1.21.{i}') for i in range(50)]
+            mock_versions = [Mock(id=i, version=f"1.21.{i}") for i in range(50)]
             mock_repo.get_versions_by_server_type.return_value = mock_versions
 
             # Mock session for committing
@@ -227,26 +234,28 @@ class TestVersionManagementService:
 
             result = management_service.cleanup_old_versions(keep_latest=100)
 
-            assert result['status'] == 'success'
-            assert result['total_removed'] == 0
+            assert result["status"] == "success"
+            assert result["total_removed"] == 0
 
             # Should not have called delete_version
             mock_repo.delete_version.assert_not_called()
 
     def test_cleanup_old_versions_with_errors(self, management_service):
         """Test cleanup with some errors"""
-        with patch('app.versions.management.VersionRepository') as mock_repo_class:
+        with patch("app.versions.management.VersionRepository") as mock_repo_class:
             # Mock repository
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
 
             # Mock some server types to raise errors
             def mock_get_versions_with_error(server_type):
-                if server_type == 'forge':
+                if server_type == "forge":
                     raise Exception("Database error")
-                return [Mock(id=i, version=f'1.21.{i}') for i in range(150)]
+                return [Mock(id=i, version=f"1.21.{i}") for i in range(150)]
 
-            mock_repo.get_versions_by_server_type.side_effect = mock_get_versions_with_error
+            mock_repo.get_versions_by_server_type.side_effect = (
+                mock_get_versions_with_error
+            )
             mock_repo.delete_version.return_value = True
 
             # Mock session for committing
@@ -254,9 +263,9 @@ class TestVersionManagementService:
 
             result = management_service.cleanup_old_versions(keep_latest=100)
 
-            assert result['status'] == 'partial_failure'
-            assert 'error' in result['by_server_type']['forge']
-            assert result['total_removed'] == 150  # 50 removed for 3 working server types
+            assert result["status"] == "partial_failure"
+            assert "error" in result["by_server_type"]["forge"]
+            assert result["total_removed"] == 150  # 50 removed for 3 working server types
 
     # ===================
     # Database validation tests
@@ -264,7 +273,7 @@ class TestVersionManagementService:
 
     def test_validate_database_integrity_healthy(self, management_service):
         """Test database validation when everything is healthy"""
-        with patch('app.versions.management.VersionRepository') as mock_repo_class:
+        with patch("app.versions.management.VersionRepository") as mock_repo_class:
             # Mock repository
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
@@ -274,8 +283,8 @@ class TestVersionManagementService:
 
             # Mock versions exist for all server types
             mock_repo.get_versions_by_server_type.return_value = [
-                Mock(version='1.21.6'),
-                Mock(version='1.21.5')
+                Mock(version="1.21.6"),
+                Mock(version="1.21.5"),
             ]
 
             # Mock no old versions
@@ -283,45 +292,47 @@ class TestVersionManagementService:
 
             result = management_service.validate_database_integrity()
 
-            assert result['status'] == 'healthy'
-            assert len(result['issues']) == 0
-            assert len(result['warnings']) == 0
-            assert 'vanilla' in result['statistics']
-            assert 'paper' in result['statistics']
+            assert result["status"] == "healthy"
+            assert len(result["issues"]) == 0
+            assert len(result["warnings"]) == 0
+            assert "vanilla" in result["statistics"]
+            assert "paper" in result["statistics"]
 
     def test_validate_database_integrity_with_issues(self, management_service):
         """Test database validation with issues found"""
-        with patch('app.versions.management.VersionRepository') as mock_repo_class:
+        with patch("app.versions.management.VersionRepository") as mock_repo_class:
             # Mock repository
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
 
             # Mock duplicates found
             mock_repo.find_duplicate_versions.return_value = [
-                ('vanilla', '1.21.6', 2),
-                ('paper', '1.21.5', 3)
+                ("vanilla", "1.21.6", 2),
+                ("paper", "1.21.5", 3),
             ]
 
             # Mock some server types have no versions
             def mock_get_versions_by_server_type(server_type):
-                if server_type == 'fabric':
+                if server_type == "fabric":
                     return []
-                return [Mock(version='1.21.6')]
+                return [Mock(version="1.21.6")]
 
-            mock_repo.get_versions_by_server_type.side_effect = mock_get_versions_by_server_type
+            mock_repo.get_versions_by_server_type.side_effect = (
+                mock_get_versions_by_server_type
+            )
 
             # Mock old versions found
-            old_date = datetime.utcnow() - timedelta(days=35)
+            old_date = utcnow() - timedelta(days=35)
             mock_repo.get_versions_older_than.return_value = [
-                Mock(version='1.20.1', last_updated=old_date)
+                Mock(version="1.20.1", last_updated=old_date)
             ]
 
             result = management_service.validate_database_integrity()
 
-            assert result['status'] == 'issues_found'
-            assert len(result['issues']) == 1
-            assert 'duplicate' in result['issues'][0].lower()
-            assert len(result['warnings']) == 2  # No fabric versions + old versions
+            assert result["status"] == "issues_found"
+            assert len(result["issues"]) == 1
+            assert "duplicate" in result["issues"][0].lower()
+            assert len(result["warnings"]) == 2  # No fabric versions + old versions
 
     # ===================
     # Session management tests
@@ -344,7 +355,7 @@ class TestVersionManagementService:
         """Test that new session is created when none provided"""
         service = VersionManagementService()
 
-        with patch('app.versions.management.SessionLocal') as mock_session_local:
+        with patch("app.versions.management.SessionLocal") as mock_session_local:
             mock_session = Mock()
             mock_session_local.return_value = mock_session
 
@@ -362,6 +373,7 @@ class TestVersionManagementService:
 # Convenience function tests
 # ===================
 
+
 class TestConvenienceFunctions:
     """Test convenience functions"""
 
@@ -370,7 +382,9 @@ class TestConvenienceFunctions:
         """Test the convenience function for triggering updates"""
         from app.versions.management import trigger_version_update
 
-        with patch('app.versions.management.VersionManagementService') as mock_service_class:
+        with patch(
+            "app.versions.management.VersionManagementService"
+        ) as mock_service_class:
             # Mock management service
             mock_service = Mock()
             mock_service_class.return_value = mock_service
@@ -382,15 +396,14 @@ class TestConvenienceFunctions:
                 versions_updated=0,
                 versions_removed=0,
                 execution_time_ms=1000,
-                errors=[]
+                errors=[],
             )
 
             mock_service.trigger_manual_update = AsyncMock(return_value=mock_result)
 
             # Test function call
             result = await trigger_version_update(
-                server_types=['vanilla', 'paper'],
-                force_refresh=True
+                server_types=["vanilla", "paper"], force_refresh=True
             )
 
             assert result.success
@@ -399,15 +412,17 @@ class TestConvenienceFunctions:
             # Verify service was called correctly
             mock_service.trigger_manual_update.assert_called_once()
             call_args = mock_service.trigger_manual_update.call_args
-            assert call_args[1]['force_refresh'] is True
-            assert call_args[1]['user_id'] is None
+            assert call_args[1]["force_refresh"] is True
+            assert call_args[1]["user_id"] is None
 
     @pytest.mark.asyncio
     async def test_trigger_version_update_invalid_server_type(self):
         """Test convenience function with invalid server type"""
         from app.versions.management import trigger_version_update
 
-        with patch('app.versions.management.VersionManagementService') as mock_service_class:
+        with patch(
+            "app.versions.management.VersionManagementService"
+        ) as mock_service_class:
             # Mock management service
             mock_service = Mock()
             mock_service_class.return_value = mock_service
@@ -419,15 +434,14 @@ class TestConvenienceFunctions:
                 versions_updated=0,
                 versions_removed=0,
                 execution_time_ms=800,
-                errors=[]
+                errors=[],
             )
 
             mock_service.trigger_manual_update = AsyncMock(return_value=mock_result)
 
             # Test with invalid server type - should be filtered out
             result = await trigger_version_update(
-                server_types=['vanilla', 'invalid_type', 'paper'],
-                force_refresh=False
+                server_types=["vanilla", "invalid_type", "paper"], force_refresh=False
             )
 
             assert result.success

--- a/tests/unit/versions/test_models.py
+++ b/tests/unit/versions/test_models.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 import pytest
 from sqlalchemy.exc import IntegrityError
 
+from app.core.datetime_utils import utcnow
 from app.servers.models import ServerType
 from app.versions.models import MinecraftVersion, VersionUpdateLog
 
@@ -160,7 +161,7 @@ class TestVersionUpdateLog:
 
     def test_duration_seconds_from_timestamps(self, db):
         """Test duration_seconds property from timestamps"""
-        start_time = datetime.utcnow()
+        start_time = utcnow()
         end_time = start_time + timedelta(seconds=3.5)
 
         log = VersionUpdateLog(

--- a/tests/unit/versions/test_repository.py
+++ b/tests/unit/versions/test_repository.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
+from app.core.datetime_utils import utcnow
 from app.servers.models import ServerType
 from app.versions.models import MinecraftVersion, VersionUpdateLog
 from app.versions.repository import VersionRepository
@@ -224,7 +225,7 @@ class TestVersionRepository:
     async def test_cleanup_old_versions(self, repository, db):
         """Test cleaning up old inactive versions"""
         # Create an old inactive version
-        old_date = datetime.utcnow() - timedelta(days=35)
+        old_date = utcnow() - timedelta(days=35)
         old_version = MinecraftVersion(
             server_type=ServerType.vanilla.value,
             version="1.20.0",
@@ -331,13 +332,13 @@ class TestVersionRepository:
         old_log = VersionUpdateLog(
             update_type="scheduled",
             status="success",
-            started_at=datetime.utcnow() - timedelta(hours=2),
+            started_at=utcnow() - timedelta(hours=2),
         )
 
         latest_log = VersionUpdateLog(
             update_type="manual",
             status="success",
-            started_at=datetime.utcnow() - timedelta(minutes=30),
+            started_at=utcnow() - timedelta(minutes=30),
         )
 
         db.add_all([old_log, latest_log])
@@ -356,7 +357,7 @@ class TestVersionRepository:
             VersionUpdateLog(
                 update_type="manual",
                 status="success",
-                started_at=datetime.utcnow() - timedelta(hours=i),
+                started_at=utcnow() - timedelta(hours=i),
             )
             for i in range(3)
         ]
@@ -364,7 +365,7 @@ class TestVersionRepository:
         scheduled_log = VersionUpdateLog(
             update_type="scheduled",
             status="success",
-            started_at=datetime.utcnow() - timedelta(hours=1),
+            started_at=utcnow() - timedelta(hours=1),
         )
 
         db.add_all(manual_logs + [scheduled_log])
@@ -389,7 +390,7 @@ class TestVersionRepository:
             VersionUpdateLog(
                 update_type="scheduled",
                 status="success",
-                started_at=datetime.utcnow() - timedelta(hours=i),
+                started_at=utcnow() - timedelta(hours=i),
             )
             for i in range(5)
         ]

--- a/tests/unit/versions/test_router.py
+++ b/tests/unit/versions/test_router.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from app.core.datetime_utils import utcnow
 from app.main import app
 from app.users.models import Role
 from app.versions.schemas import VersionUpdateResult
@@ -37,9 +38,9 @@ class TestVersionRouter:
         vanilla_version.is_stable = True
         vanilla_version.build_number = None
         vanilla_version.is_active = True
-        vanilla_version.last_updated = datetime.utcnow()
-        vanilla_version.created_at = datetime.utcnow()
-        vanilla_version.updated_at = datetime.utcnow()
+        vanilla_version.last_updated = utcnow()
+        vanilla_version.created_at = utcnow()
+        vanilla_version.updated_at = utcnow()
         mock_versions.append(vanilla_version)
 
         # Mock paper version
@@ -52,9 +53,9 @@ class TestVersionRouter:
         paper_version.is_stable = True
         paper_version.build_number = 123
         paper_version.is_active = True
-        paper_version.last_updated = datetime.utcnow()
-        paper_version.created_at = datetime.utcnow()
-        paper_version.updated_at = datetime.utcnow()
+        paper_version.last_updated = utcnow()
+        paper_version.created_at = utcnow()
+        paper_version.updated_at = utcnow()
         mock_versions.append(paper_version)
 
         # Mock forge version
@@ -67,9 +68,9 @@ class TestVersionRouter:
         forge_version.is_stable = True
         forge_version.build_number = None
         forge_version.is_active = True
-        forge_version.last_updated = datetime.utcnow()
-        forge_version.created_at = datetime.utcnow()
-        forge_version.updated_at = datetime.utcnow()
+        forge_version.last_updated = utcnow()
+        forge_version.created_at = utcnow()
+        forge_version.updated_at = utcnow()
         mock_versions.append(forge_version)
 
         return mock_versions
@@ -85,7 +86,7 @@ class TestVersionRouter:
 
     def test_get_supported_versions_all(self, client, mock_db_versions):
         """Test getting all supported versions"""
-        with patch('app.versions.router.VersionRepository') as mock_repo_class:
+        with patch("app.versions.router.VersionRepository") as mock_repo_class:
             # Mock repository
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
@@ -108,7 +109,7 @@ class TestVersionRouter:
         """Test getting versions filtered by server type"""
         vanilla_versions = [v for v in mock_db_versions if v.server_type == "vanilla"]
 
-        with patch('app.versions.router.VersionRepository') as mock_repo_class:
+        with patch("app.versions.router.VersionRepository") as mock_repo_class:
             # Mock repository
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
@@ -132,7 +133,7 @@ class TestVersionRouter:
             "forge": {"total": 20, "active": 20},
         }
 
-        with patch('app.versions.router.VersionRepository') as mock_repo_class:
+        with patch("app.versions.router.VersionRepository") as mock_repo_class:
             # Mock repository
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
@@ -153,7 +154,7 @@ class TestVersionRouter:
         """Test getting versions for specific server type"""
         paper_versions = [v for v in mock_db_versions if v.server_type == "paper"]
 
-        with patch('app.versions.router.VersionRepository') as mock_repo_class:
+        with patch("app.versions.router.VersionRepository") as mock_repo_class:
             # Mock repository
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
@@ -173,11 +174,13 @@ class TestVersionRouter:
         """Test getting specific version details"""
         specific_version = mock_db_versions[0]  # vanilla 1.21.6
 
-        with patch('app.versions.router.VersionRepository') as mock_repo_class:
+        with patch("app.versions.router.VersionRepository") as mock_repo_class:
             # Mock repository
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
-            mock_repo.get_version_by_type_and_version = AsyncMock(return_value=specific_version)
+            mock_repo.get_version_by_type_and_version = AsyncMock(
+                return_value=specific_version
+            )
 
             response = client.get("/api/v1/versions/vanilla/1.21.6")
 
@@ -190,7 +193,7 @@ class TestVersionRouter:
 
     def test_get_specific_version_not_found(self, client):
         """Test getting specific version that doesn't exist"""
-        with patch('app.versions.router.VersionRepository') as mock_repo_class:
+        with patch("app.versions.router.VersionRepository") as mock_repo_class:
             # Mock repository
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
@@ -217,7 +220,7 @@ class TestVersionRouter:
             versions_updated=2,
             versions_removed=1,
             execution_time_ms=2500,
-            errors=[]
+            errors=[],
         )
 
         # Mock admin user
@@ -230,9 +233,11 @@ class TestVersionRouter:
         app.dependency_overrides[get_current_user] = mock_admin_user
 
         try:
-            with patch('app.versions.router.version_update_scheduler') as mock_scheduler:
+            with patch("app.versions.router.version_update_scheduler") as mock_scheduler:
                 # Mock scheduler
-                mock_scheduler.trigger_immediate_update = AsyncMock(return_value=mock_result)
+                mock_scheduler.trigger_immediate_update = AsyncMock(
+                    return_value=mock_result
+                )
 
                 response = client.post("/api/v1/versions/update?force_refresh=true")
 
@@ -244,7 +249,9 @@ class TestVersionRouter:
                 assert data["message"] == "Update completed successfully"
 
                 # Verify scheduler was called correctly
-                mock_scheduler.trigger_immediate_update.assert_called_once_with(force_refresh=True)
+                mock_scheduler.trigger_immediate_update.assert_called_once_with(
+                    force_refresh=True
+                )
         finally:
             # Pop only what this test added — `clear()` would also drop the
             # `get_db` override set by tests/conftest.py, breaking every
@@ -286,10 +293,7 @@ class TestVersionRouter:
             "last_successful_update": "2024-12-15T10:30:00",
             "next_update_time": "2024-12-16T10:30:00",
             "last_error": None,
-            "retry_config": {
-                "max_attempts": 3,
-                "base_delay_seconds": 300
-            }
+            "retry_config": {"max_attempts": 3, "base_delay_seconds": 300},
         }
 
         # Mock admin user
@@ -302,7 +306,7 @@ class TestVersionRouter:
         app.dependency_overrides[get_current_user] = mock_admin_user
 
         try:
-            with patch('app.versions.router.version_update_scheduler') as mock_scheduler:
+            with patch("app.versions.router.version_update_scheduler") as mock_scheduler:
                 # Mock scheduler
                 mock_scheduler.get_status.return_value = mock_status
 
@@ -351,11 +355,13 @@ class TestVersionRouter:
 
     def test_get_supported_versions_database_error(self, client):
         """Test handling database errors in supported versions endpoint"""
-        with patch('app.versions.router.VersionRepository') as mock_repo_class:
+        with patch("app.versions.router.VersionRepository") as mock_repo_class:
             # Mock repository to raise exception
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
-            mock_repo.get_all_active_versions = AsyncMock(side_effect=Exception("Database connection failed"))
+            mock_repo.get_all_active_versions = AsyncMock(
+                side_effect=Exception("Database connection failed")
+            )
 
             response = client.get("/api/v1/versions/supported")
 
@@ -365,11 +371,13 @@ class TestVersionRouter:
 
     def test_get_version_stats_database_error(self, client):
         """Test handling database errors in stats endpoint"""
-        with patch('app.versions.router.VersionRepository') as mock_repo_class:
+        with patch("app.versions.router.VersionRepository") as mock_repo_class:
             # Mock repository to raise exception
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
-            mock_repo.get_version_stats = AsyncMock(side_effect=Exception("Database query failed"))
+            mock_repo.get_version_stats = AsyncMock(
+                side_effect=Exception("Database query failed")
+            )
 
             response = client.get("/api/v1/versions/stats")
 
@@ -391,9 +399,11 @@ class TestVersionRouter:
         app.dependency_overrides[get_current_user] = mock_admin_user
 
         try:
-            with patch('app.versions.router.version_update_scheduler') as mock_scheduler:
+            with patch("app.versions.router.version_update_scheduler") as mock_scheduler:
                 # Mock scheduler to raise exception
-                mock_scheduler.trigger_immediate_update = AsyncMock(side_effect=Exception("Scheduler failed"))
+                mock_scheduler.trigger_immediate_update = AsyncMock(
+                    side_effect=Exception("Scheduler failed")
+                )
 
                 response = client.post("/api/v1/versions/update")
 
@@ -453,6 +463,7 @@ class TestVersionRouter:
 # Integration-style tests
 # ===================
 
+
 class TestVersionRouterIntegration:
     """Integration-style tests for version router"""
 
@@ -473,24 +484,26 @@ class TestVersionRouterIntegration:
         mock_version.is_stable = True
         mock_version.build_number = None
         mock_version.is_active = True
-        mock_version.last_updated = datetime.utcnow()
-        mock_version.created_at = datetime.utcnow()
-        mock_version.updated_at = datetime.utcnow()
+        mock_version.last_updated = utcnow()
+        mock_version.created_at = utcnow()
+        mock_version.updated_at = utcnow()
 
         mock_versions = [mock_version]
 
         mock_stats = {
             "_total": {"total": 1, "active": 1},
-            "vanilla": {"total": 1, "active": 1}
+            "vanilla": {"total": 1, "active": 1},
         }
 
-        with patch('app.versions.router.VersionRepository') as mock_repo_class:
+        with patch("app.versions.router.VersionRepository") as mock_repo_class:
             mock_repo = Mock()
             mock_repo_class.return_value = mock_repo
             mock_repo.get_all_active_versions = AsyncMock(return_value=mock_versions)
             mock_repo.get_version_stats = AsyncMock(return_value=mock_stats)
             mock_repo.get_versions_by_type = AsyncMock(return_value=mock_versions)
-            mock_repo.get_version_by_type_and_version = AsyncMock(return_value=mock_versions[0])
+            mock_repo.get_version_by_type_and_version = AsyncMock(
+                return_value=mock_versions[0]
+            )
 
             # Test 1: Get all supported versions
             response1 = client.get("/api/v1/versions/supported")

--- a/tests/unit/versions/test_scheduler.py
+++ b/tests/unit/versions/test_scheduler.py
@@ -3,11 +3,12 @@ Unit tests for VersionUpdateSchedulerService
 """
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from app.core.datetime_utils import utcnow
 from app.versions.scheduler import VersionUpdateSchedulerService
 from app.versions.schemas import VersionUpdateResult
 
@@ -30,7 +31,7 @@ class TestVersionUpdateSchedulerService:
             versions_updated=2,
             versions_removed=1,
             execution_time_ms=1500,
-            errors=[]
+            errors=[],
         )
 
     @pytest.fixture
@@ -43,7 +44,7 @@ class TestVersionUpdateSchedulerService:
             versions_updated=0,
             versions_removed=0,
             execution_time_ms=500,
-            errors=["External API error"]
+            errors=["External API error"],
         )
 
     # ===================
@@ -108,13 +109,19 @@ class TestVersionUpdateSchedulerService:
 
     def test_set_update_interval_invalid(self, scheduler):
         """Test setting invalid update intervals"""
-        with pytest.raises(ValueError, match="Update interval must be between 1 and 168 hours"):
+        with pytest.raises(
+            ValueError, match="Update interval must be between 1 and 168 hours"
+        ):
             scheduler.set_update_interval(0)
 
-        with pytest.raises(ValueError, match="Update interval must be between 1 and 168 hours"):
+        with pytest.raises(
+            ValueError, match="Update interval must be between 1 and 168 hours"
+        ):
             scheduler.set_update_interval(169)
 
-        with pytest.raises(ValueError, match="Update interval must be between 1 and 168 hours"):
+        with pytest.raises(
+            ValueError, match="Update interval must be between 1 and 168 hours"
+        ):
             scheduler.set_update_interval(-1)
 
     def test_set_retry_config_valid(self, scheduler):
@@ -125,16 +132,24 @@ class TestVersionUpdateSchedulerService:
 
     def test_set_retry_config_invalid(self, scheduler):
         """Test setting invalid retry configuration"""
-        with pytest.raises(ValueError, match="Max retry attempts must be between 1 and 10"):
+        with pytest.raises(
+            ValueError, match="Max retry attempts must be between 1 and 10"
+        ):
             scheduler.set_retry_config(0, 120)
 
-        with pytest.raises(ValueError, match="Max retry attempts must be between 1 and 10"):
+        with pytest.raises(
+            ValueError, match="Max retry attempts must be between 1 and 10"
+        ):
             scheduler.set_retry_config(11, 120)
 
-        with pytest.raises(ValueError, match="Base delay must be between 60 and 3600 seconds"):
+        with pytest.raises(
+            ValueError, match="Base delay must be between 60 and 3600 seconds"
+        ):
             scheduler.set_retry_config(3, 50)
 
-        with pytest.raises(ValueError, match="Base delay must be between 60 and 3600 seconds"):
+        with pytest.raises(
+            ValueError, match="Base delay must be between 60 and 3600 seconds"
+        ):
             scheduler.set_retry_config(3, 4000)
 
     # ===================
@@ -148,7 +163,7 @@ class TestVersionUpdateSchedulerService:
     def test_is_update_due_recent_update(self, scheduler):
         """Test update due logic with recent update"""
         # Set last update to 1 hour ago
-        scheduler._last_successful_update = datetime.utcnow() - timedelta(hours=1)
+        scheduler._last_successful_update = utcnow() - timedelta(hours=1)
         scheduler.set_update_interval(24)
 
         assert not scheduler._is_update_due()
@@ -156,7 +171,7 @@ class TestVersionUpdateSchedulerService:
     def test_is_update_due_old_update(self, scheduler):
         """Test update due logic with old update"""
         # Set last update to 25 hours ago
-        scheduler._last_successful_update = datetime.utcnow() - timedelta(hours=25)
+        scheduler._last_successful_update = utcnow() - timedelta(hours=25)
         scheduler.set_update_interval(24)
 
         assert scheduler._is_update_due()
@@ -165,10 +180,10 @@ class TestVersionUpdateSchedulerService:
         """Test next update time calculation"""
         # No previous update
         next_time = scheduler._get_next_update_time()
-        assert next_time <= datetime.utcnow()
+        assert next_time <= utcnow()
 
         # With previous update
-        last_update = datetime.utcnow() - timedelta(hours=12)
+        last_update = utcnow() - timedelta(hours=12)
         scheduler._last_successful_update = last_update
         scheduler.set_update_interval(24)
 
@@ -185,9 +200,10 @@ class TestVersionUpdateSchedulerService:
     @pytest.mark.asyncio
     async def test_trigger_immediate_update_success(self, scheduler, mock_update_result):
         """Test successful immediate update trigger"""
-        with patch('app.versions.scheduler.SessionLocal') as mock_session_local, \
-             patch('app.versions.scheduler.VersionUpdateService') as mock_service_class:
-
+        with (
+            patch("app.versions.scheduler.SessionLocal") as mock_session_local,
+            patch("app.versions.scheduler.VersionUpdateService") as mock_service_class,
+        ):
             # Mock database session
             mock_session = Mock()
             mock_session_local.return_value = mock_session
@@ -205,17 +221,18 @@ class TestVersionUpdateSchedulerService:
 
             # Verify service was called correctly
             mock_service.update_versions.assert_called_once_with(
-                server_types=None,
-                force_refresh=False,
-                user_id=None
+                server_types=None, force_refresh=False, user_id=None
             )
 
     @pytest.mark.asyncio
-    async def test_trigger_immediate_update_failure(self, scheduler, mock_failed_update_result):
+    async def test_trigger_immediate_update_failure(
+        self, scheduler, mock_failed_update_result
+    ):
         """Test failed immediate update trigger"""
-        with patch('app.versions.scheduler.SessionLocal') as mock_session_local, \
-             patch('app.versions.scheduler.VersionUpdateService') as mock_service_class:
-
+        with (
+            patch("app.versions.scheduler.SessionLocal") as mock_session_local,
+            patch("app.versions.scheduler.VersionUpdateService") as mock_service_class,
+        ):
             # Mock database session
             mock_session = Mock()
             mock_session_local.return_value = mock_session
@@ -223,7 +240,9 @@ class TestVersionUpdateSchedulerService:
             # Mock service
             mock_service = Mock()
             mock_service_class.return_value = mock_service
-            mock_service.update_versions = AsyncMock(return_value=mock_failed_update_result)
+            mock_service.update_versions = AsyncMock(
+                return_value=mock_failed_update_result
+            )
 
             result = await scheduler.trigger_immediate_update()
 
@@ -231,11 +250,14 @@ class TestVersionUpdateSchedulerService:
             assert scheduler.last_error == "Update failed"
 
     @pytest.mark.asyncio
-    async def test_trigger_immediate_update_with_force(self, scheduler, mock_update_result):
+    async def test_trigger_immediate_update_with_force(
+        self, scheduler, mock_update_result
+    ):
         """Test immediate update with force refresh"""
-        with patch('app.versions.scheduler.SessionLocal') as mock_session_local, \
-             patch('app.versions.scheduler.VersionUpdateService') as mock_service_class:
-
+        with (
+            patch("app.versions.scheduler.SessionLocal") as mock_session_local,
+            patch("app.versions.scheduler.VersionUpdateService") as mock_service_class,
+        ):
             # Mock database session
             mock_session = Mock()
             mock_session_local.return_value = mock_session
@@ -251,9 +273,7 @@ class TestVersionUpdateSchedulerService:
 
             # Verify force_refresh was passed
             mock_service.update_versions.assert_called_once_with(
-                server_types=None,
-                force_refresh=True,
-                user_id=None
+                server_types=None, force_refresh=True, user_id=None
             )
 
     # ===================
@@ -295,7 +315,7 @@ class TestVersionUpdateSchedulerService:
         assert scheduler.next_update_time is None
 
         # Test after setting some values
-        test_time = datetime.utcnow()
+        test_time = utcnow()
         scheduler._last_successful_update = test_time
         scheduler._last_error = "Test error"
 
@@ -309,9 +329,12 @@ class TestVersionUpdateSchedulerService:
     @pytest.mark.asyncio
     async def test_scheduler_loop_with_due_update(self, scheduler, mock_update_result):
         """Test scheduler loop when update is due"""
-        with patch.object(scheduler, '_is_update_due', return_value=True), \
-             patch.object(scheduler, '_execute_scheduled_update', new_callable=AsyncMock) as mock_execute:
-
+        with (
+            patch.object(scheduler, "_is_update_due", return_value=True),
+            patch.object(
+                scheduler, "_execute_scheduled_update", new_callable=AsyncMock
+            ) as mock_execute,
+        ):
             # Start scheduler
             await scheduler.start_scheduler()
 
@@ -328,9 +351,12 @@ class TestVersionUpdateSchedulerService:
     @pytest.mark.asyncio
     async def test_scheduler_loop_no_due_update(self, scheduler):
         """Test scheduler loop when no update is due"""
-        with patch.object(scheduler, '_is_update_due', return_value=False), \
-             patch.object(scheduler, '_execute_scheduled_update', new_callable=AsyncMock) as mock_execute:
-
+        with (
+            patch.object(scheduler, "_is_update_due", return_value=False),
+            patch.object(
+                scheduler, "_execute_scheduled_update", new_callable=AsyncMock
+            ) as mock_execute,
+        ):
             # Start scheduler
             await scheduler.start_scheduler()
 
@@ -346,9 +372,10 @@ class TestVersionUpdateSchedulerService:
     @pytest.mark.asyncio
     async def test_execute_scheduled_update_success(self, scheduler, mock_update_result):
         """Test successful scheduled update execution"""
-        with patch('app.versions.scheduler.SessionLocal') as mock_session_local, \
-             patch('app.versions.scheduler.VersionUpdateService') as mock_service_class:
-
+        with (
+            patch("app.versions.scheduler.SessionLocal") as mock_session_local,
+            patch("app.versions.scheduler.VersionUpdateService") as mock_service_class,
+        ):
             # Mock database session
             mock_session = Mock()
             mock_session_local.return_value = mock_session
@@ -364,14 +391,17 @@ class TestVersionUpdateSchedulerService:
             assert scheduler.last_error is None
 
     @pytest.mark.asyncio
-    async def test_execute_scheduled_update_with_retries(self, scheduler, mock_failed_update_result, mock_update_result):
+    async def test_execute_scheduled_update_with_retries(
+        self, scheduler, mock_failed_update_result, mock_update_result
+    ):
         """Test scheduled update with retry logic"""
         scheduler.set_retry_config(2, 60)  # 2 attempts, 60s base delay
 
-        with patch('app.versions.scheduler.SessionLocal') as mock_session_local, \
-             patch('app.versions.scheduler.VersionUpdateService') as mock_service_class, \
-             patch('asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
-
+        with (
+            patch("app.versions.scheduler.SessionLocal") as mock_session_local,
+            patch("app.versions.scheduler.VersionUpdateService") as mock_service_class,
+            patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        ):
             # Mock database session
             mock_session = Mock()
             mock_session_local.return_value = mock_session
@@ -379,7 +409,9 @@ class TestVersionUpdateSchedulerService:
             # Mock service to fail first time, succeed second time
             mock_service = Mock()
             mock_service_class.return_value = mock_service
-            mock_service.update_versions = AsyncMock(side_effect=[mock_failed_update_result, mock_update_result])
+            mock_service.update_versions = AsyncMock(
+                side_effect=[mock_failed_update_result, mock_update_result]
+            )
 
             await scheduler._execute_scheduled_update()
 
@@ -392,14 +424,17 @@ class TestVersionUpdateSchedulerService:
             mock_sleep.assert_called_once_with(60)  # Base delay for first retry
 
     @pytest.mark.asyncio
-    async def test_execute_scheduled_update_max_retries_exceeded(self, scheduler, mock_failed_update_result):
+    async def test_execute_scheduled_update_max_retries_exceeded(
+        self, scheduler, mock_failed_update_result
+    ):
         """Test scheduled update when max retries are exceeded"""
         scheduler.set_retry_config(2, 60)  # 2 attempts
 
-        with patch('app.versions.scheduler.SessionLocal') as mock_session_local, \
-             patch('app.versions.scheduler.VersionUpdateService') as mock_service_class, \
-             patch('asyncio.sleep', new_callable=AsyncMock):
-
+        with (
+            patch("app.versions.scheduler.SessionLocal") as mock_session_local,
+            patch("app.versions.scheduler.VersionUpdateService") as mock_service_class,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
             # Mock database session
             mock_session = Mock()
             mock_session_local.return_value = mock_session
@@ -407,7 +442,9 @@ class TestVersionUpdateSchedulerService:
             # Mock service to always fail
             mock_service = Mock()
             mock_service_class.return_value = mock_service
-            mock_service.update_versions = AsyncMock(return_value=mock_failed_update_result)
+            mock_service.update_versions = AsyncMock(
+                return_value=mock_failed_update_result
+            )
 
             await scheduler._execute_scheduled_update()
 

--- a/tests/unit/versions/test_service.py
+++ b/tests/unit/versions/test_service.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from app.core.datetime_utils import utcnow
 from app.servers.models import ServerType
 from app.services.version_manager import VersionInfo
 from app.versions.models import MinecraftVersion, VersionUpdateLog
@@ -278,7 +279,7 @@ class TestVersionUpdateService:
     async def test_cleanup_old_versions(self, service, db):
         """Test cleaning up old versions"""
         # Create old inactive version
-        old_date = datetime.utcnow() - timedelta(days=35)
+        old_date = utcnow() - timedelta(days=35)
         old_version = MinecraftVersion(
             server_type=ServerType.vanilla.value,
             version="1.20.0",
@@ -350,7 +351,7 @@ class TestVersionUpdateService:
         """Test last update time property"""
         assert service.last_update_time is None
 
-        test_time = datetime.utcnow()
+        test_time = utcnow()
         service._last_update_time = test_time
         assert service.last_update_time == test_time
 


### PR DESCRIPTION
## Summary

- 広域 `ignore::DeprecationWarning` / `ignore::PendingDeprecationWarning` を **`error` に昇格** し、新規 deprecation を CI で検出可能に
- 残す ignore は upstream のみ (passlib の `'crypt' is deprecated` 1 件)
- 昇格で露呈したプロジェクト起因の deprecation を全て修正 (Pydantic V1 → V2, `datetime.utcnow()`, `tarfile.extractall(filter=...)`)

## What changed

### `pyproject.toml` — filterwarnings
```diff
 filterwarnings = [
-    "ignore::DeprecationWarning",
-    "ignore::PendingDeprecationWarning",
-    "ignore:.*'crypt' is deprecated.*:DeprecationWarning",
-    "ignore:.*Support for class-based.*:DeprecationWarning",
+    "error::DeprecationWarning",
+    "error::PendingDeprecationWarning",
+    "ignore:'crypt' is deprecated:DeprecationWarning",
 ]
```

### App 側修正
| 種別 | 対象 |
|---|---|
| Pydantic V1 `class Config:` → `model_config = ConfigDict(...)` | `app/audit/router.py` (1), `app/core/visibility_schemas.py` (6) |
| Pydantic V1 `Field(example=...)` → `Field(json_schema_extra={"example": ...})` | `app/versions/schemas.py` |
| Pydantic V1 `@validator` → `@field_validator + @classmethod` | `app/core/daemon_config.py` (3) |
| `datetime.utcnow()` → `app.core.datetime_utils.utcnow()` | `app/files/models.py`, `app/backups/models.py`, `app/versions/{models,service,scheduler,management,repository}.py` |
| `tarfile.extractall()` → `extractall(..., filter="data")` | `app/services/template_service.py` |

新規ヘルパー `app/core/datetime_utils.py` は **naive UTC** を返す (`datetime.now(timezone.utc).replace(tzinfo=None)`)。これは廃止予定の `datetime.utcnow()` と完全に同じ意味論 (`DateTime` カラム上の保存値、ナイーブ同士の比較) を保持するための意図的な選択。tz-aware 化は別途のリファクタリング。

### Test 側修正
- 全ての `datetime.utcnow()` 呼び出しを `utcnow()` ヘルパーに置換 (`tests/unit/versions/` 全 6 ファイル、`tests/integration/test_server_{export_import,port_conflicts}.py`)
- ruff format による touch 済みファイルの整形 (`tests/integration/test_database_version_integration.py` 等)

## Out of scope (filed as #217)

`DeprecationWarning` 以外の警告カテゴリは本 PR の射程外。Issue #217 で別途対応:
- `RuntimeWarning: coroutine never awaited` (AsyncMock 不備 × 2 ファイル)
- `ResourceWarning: unclosed database` (SQLAlchemy engine cleanup 漏れ × 3 ファイル)
- `PytestUnraisableExceptionWarning` (WebSocket coroutine cleanup × 1 ファイル)

これらは現状 `--disable-warnings` でサマリ表示のみ抑止されており、機能的影響はない。`error::RuntimeWarning` / `error::ResourceWarning` への昇格は #217 の完了条件。

## Verification

| Stage | Result |
|---|---|
| pre-commit smoke (`tests/unit -m "not slow"`) | 1137 passed, 1 skipped, 9 warnings, 63s |
| pre-push smoke (`tests/unit tests/integration -m "not slow"`) | 1347 passed, 6 skipped, 8 warnings, 104s |
| Full suite (`uv run pytest`) | **1531 passed**, 6 skipped, 13 warnings, 108s |
| `uv run ruff check app/` | All checks passed |
| pre-commit hook (全 hook) | green |

残存 warning は全て #217 で扱う 3 カテゴリ。`DeprecationWarning` / `PendingDeprecationWarning` は 0 件。

## Test plan

- [ ] CI `Test` job: 1531 passed, no DeprecationWarning が出ない
- [ ] CI `Test` job: 既存の crypt 由来 `DeprecationWarning` のみが残存 (ignore 通過)
- [ ] 将来この PR 後に新規 deprecation が混入したら、CI で error として fail することを確認

Resolves #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)