### PR TITLE
test: eliminate Runtime/Resource warning leaks and tighten filterwarnings (Resolves #217)

### DIFF
--- a/app/services/minecraft_server.py
+++ b/app/services/minecraft_server.py
@@ -75,21 +75,27 @@ class MinecraftServerManager:
             log_file_path.touch(exist_ok=True)
             error_file_path.touch(exist_ok=True)
 
-            # Create the process with proper detachment
+            # Create the process with proper detachment. Open the log files
+            # in a with-block so the parent's file handles are released even
+            # when Popen raises — the child inherits via FD duplication.
             import subprocess
 
-            process = subprocess.Popen(
-                cmd,
-                cwd=cwd,
-                env=env,
-                stdout=open(log_file_path, "w"),
-                stderr=open(error_file_path, "w"),
-                stdin=subprocess.DEVNULL,
-                start_new_session=True,  # Detach from parent session
-                preexec_fn=(
-                    os.setsid if hasattr(os, "setsid") else None
-                ),  # Create new process group
-            )
+            with (
+                open(log_file_path, "w") as stdout_f,
+                open(error_file_path, "w") as stderr_f,
+            ):
+                process = subprocess.Popen(
+                    cmd,
+                    cwd=cwd,
+                    env=env,
+                    stdout=stdout_f,
+                    stderr=stderr_f,
+                    stdin=subprocess.DEVNULL,
+                    start_new_session=True,  # Detach from parent session
+                    preexec_fn=(
+                        os.setsid if hasattr(os, "setsid") else None
+                    ),  # Create new process group
+                )
 
             daemon_pid = process.pid
             logger.info(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = [
     "--tb=short",
-    "--disable-warnings",
     "-q",
     "-n", "auto",
     "--dist", "loadscope",
@@ -86,6 +85,8 @@ markers = [
 filterwarnings = [
     "error::DeprecationWarning",
     "error::PendingDeprecationWarning",
+    "error::RuntimeWarning",
+    "error::ResourceWarning",
     "ignore:'crypt' is deprecated:DeprecationWarning",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,8 +67,12 @@ def pytest_sessionfinish(session, exitstatus):
     # ResourceWarning under `-W error::ResourceWarning`).
     try:
         engine.dispose()
-    except Exception:
-        pass
+    except Exception as e:
+        # Surface failures via the warning summary so a real dispose regression
+        # is not silently swallowed during session teardown.
+        import warnings
+
+        warnings.warn(f"Failed to dispose testing engine: {e}")
     try:
         current_worker_db = get_worker_db_path()
         if os.path.exists(current_worker_db):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,13 @@ def pytest_sessionfinish(session, exitstatus):
     テストセッション終了時にworker固有のテストデータベースファイルを削除
     Race conditionを避けるため、各workerが自分のファイルのみを削除
     """
+    # Dispose the shared SQLAlchemy engine so its pooled sqlite connections are
+    # closed deterministically rather than reaped by GC (which emits
+    # ResourceWarning under `-W error::ResourceWarning`).
+    try:
+        engine.dispose()
+    except Exception:
+        pass
     try:
         current_worker_db = get_worker_db_path()
         if os.path.exists(current_worker_db):

--- a/tests/integration/test_daemon_lifecycle_comprehensive.py
+++ b/tests/integration/test_daemon_lifecycle_comprehensive.py
@@ -17,6 +17,23 @@ from app.services.minecraft_server import MinecraftServerManager, ServerProcess
 pytestmark = pytest.mark.slow
 
 
+def _fake_create_task(coro, *args, **kwargs):
+    """Stand-in for asyncio.create_task in tests that patch it out.
+
+    The production code passes a freshly-built coroutine in. If we simply return
+    a Mock, that coroutine is never scheduled and Python emits
+    "coroutine was never awaited" at GC. Closing the coroutine here suppresses
+    that warning while still returning a sync task-like Mock for cleanup helpers
+    (whose `.done()` returns True to short-circuit the cancel/await loop).
+    """
+    if asyncio.iscoroutine(coro):
+        coro.close()
+    fake_task = Mock()
+    fake_task.done = Mock(return_value=True)
+    fake_task.cancel = Mock()
+    return fake_task
+
+
 class TestDaemonLifecycleComprehensive:
     """Comprehensive tests for daemon process lifecycle management"""
 
@@ -143,12 +160,15 @@ class TestDaemonLifecycleComprehensive:
                                     with patch.object(
                                         manager, "_is_process_running", return_value=True
                                     ):
-                                        # Mock background task creation
+                                        # Mock background task creation. The fake
+                                        # create_task closes the production coroutine to avoid
+                                        # "never awaited" warnings, and returns a sync task-like
+                                        # Mock whose .done() returns True so the cleanup helper
+                                        # short-circuits.
                                         with patch(
-                                            "asyncio.create_task"
-                                        ) as mock_create_task:
-                                            mock_create_task.return_value = AsyncMock()
-
+                                            "asyncio.create_task",
+                                            side_effect=_fake_create_task,
+                                        ):
                                             result = await manager.start_server(
                                                 daemon_test_server, mock_db_session
                                             )
@@ -304,10 +324,8 @@ class TestDaemonLifecycleComprehensive:
             with patch.object(
                 manager, "_restore_process_from_pid", return_value=True
             ) as mock_restore:
-                # Mock background task creation
-                with patch("asyncio.create_task") as mock_create_task:
-                    mock_create_task.return_value = AsyncMock()
-
+                # Mock background task creation; see _fake_create_task for why.
+                with patch("asyncio.create_task", side_effect=_fake_create_task):
                     results = await manager.discover_and_restore_processes()
 
                     # Basic verification
@@ -409,12 +427,11 @@ class TestDaemonLifecycleComprehensive:
                                     with patch.object(
                                         manager, "_is_process_running", return_value=True
                                     ):
-                                        # Mock background tasks
+                                        # Mock background task creation; see _fake_create_task.
                                         with patch(
-                                            "asyncio.create_task"
-                                        ) as mock_create_task:
-                                            mock_create_task.return_value = AsyncMock()
-
+                                            "asyncio.create_task",
+                                            side_effect=_fake_create_task,
+                                        ):
                                             # Start server
                                             result = await manager.start_server(
                                                 daemon_test_server, mock_db_session

--- a/tests/unit/servers/test_control_router.py
+++ b/tests/unit/servers/test_control_router.py
@@ -971,21 +971,23 @@ class TestServerControlRouter:
         mock_manager.start_server = AsyncMock(return_value=False)
         mock_settings.JAVA_CHECK_TIMEOUT = 1
 
-        with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError("Timeout")):
-            mock_process = Mock()
-            mock_process.communicate = AsyncMock(return_value=(b"Java 17", b""))
-            mock_subprocess.return_value = mock_process
+        # Raise TimeoutError from process.communicate() itself rather than
+        # patching asyncio.wait_for. Patching wait_for would short-circuit the
+        # await on communicate() and leave the inner coroutine un-awaited.
+        mock_process = Mock()
+        mock_process.communicate = AsyncMock(side_effect=asyncio.TimeoutError("Timeout"))
+        mock_subprocess.return_value = mock_process
 
-            with pytest.raises(HTTPException) as exc_info:
-                await start_server(
-                    server_id=mock_server.id,
-                    request=mock_request,
-                    current_user=admin_user,
-                    db=mock_db_session,
-                )
+        with pytest.raises(HTTPException) as exc_info:
+            await start_server(
+                server_id=mock_server.id,
+                request=mock_request,
+                current_user=admin_user,
+                db=mock_db_session,
+            )
 
-            assert exc_info.value.status_code == 500
-            assert "java executable not found" in exc_info.value.detail.lower()
+        assert exc_info.value.status_code == 500
+        assert "java executable not found" in exc_info.value.detail.lower()
 
     @pytest.mark.asyncio
     @patch("app.servers.routers.control.authorization_service")

--- a/tests/unit/servers/test_port_synchronization.py
+++ b/tests/unit/servers/test_port_synchronization.py
@@ -27,6 +27,9 @@ def test_db():
         yield db
     finally:
         db.close()
+        # Dispose the engine so the underlying sqlite connections are released
+        # promptly instead of being reaped by GC (which emits ResourceWarning).
+        engine.dispose()
 
 
 @pytest.fixture

--- a/tests/unit/servers/test_simplified_sync.py
+++ b/tests/unit/servers/test_simplified_sync.py
@@ -27,6 +27,9 @@ def test_db():
         yield db
     finally:
         db.close()
+        # Dispose the engine so the underlying sqlite connections are released
+        # promptly instead of being reaped by GC (which emits ResourceWarning).
+        engine.dispose()
 
 
 @pytest.fixture

--- a/tests/unit/services/test_version_manager.py
+++ b/tests/unit/services/test_version_manager.py
@@ -359,14 +359,20 @@ class TestMinecraftVersionManagerMissingCoverage:
             }
         )
 
-        # Mock gather to return an exception using AsyncMock
-        with patch("aiohttp.ClientSession", return_value=mock_session):
-            with patch("asyncio.gather", new_callable=AsyncMock) as mock_gather:
-                mock_gather.return_value = [Exception("Network error")]
-                result = await manager._get_vanilla_versions()
+        # Replace the per-version fetch helpers with plain Mocks so the list
+        # comprehensions inside _get_vanilla_versions do not produce real
+        # coroutines that the patched asyncio.gather will leave un-awaited.
+        with (
+            patch("aiohttp.ClientSession", return_value=mock_session),
+            patch.object(manager, "_fetch_vanilla_version_info", new=Mock()),
+            patch.object(manager, "_fetch_with_semaphore", new=Mock()),
+            patch("asyncio.gather", new_callable=AsyncMock) as mock_gather,
+        ):
+            mock_gather.return_value = [Exception("Network error")]
+            result = await manager._get_vanilla_versions()
 
-                # Should return empty list when all tasks fail
-                assert result == []
+            # Should return empty list when all tasks fail
+            assert result == []
 
     @pytest.mark.asyncio
     async def test_fetch_vanilla_version_info_no_server_download(self, manager):
@@ -411,17 +417,23 @@ class TestMinecraftVersionManagerMissingCoverage:
             {"https://api.papermc.io/v2/projects/paper": mock_response}
         )
 
-        # Mock gather to return exceptions using AsyncMock
-        with patch("aiohttp.ClientSession", return_value=mock_session):
-            with patch("asyncio.gather", new_callable=AsyncMock) as mock_gather:
-                mock_gather.return_value = [
-                    Exception("Network error"),
-                    Exception("Another error"),
-                ]
-                result = await manager._get_paper_versions()
+        # Replace the per-version fetch helpers with plain Mocks so the list
+        # comprehensions inside _get_paper_versions do not produce real
+        # coroutines that the patched asyncio.gather will leave un-awaited.
+        with (
+            patch("aiohttp.ClientSession", return_value=mock_session),
+            patch.object(manager, "_fetch_paper_version_info", new=Mock()),
+            patch.object(manager, "_fetch_with_semaphore", new=Mock()),
+            patch("asyncio.gather", new_callable=AsyncMock) as mock_gather,
+        ):
+            mock_gather.return_value = [
+                Exception("Network error"),
+                Exception("Another error"),
+            ]
+            result = await manager._get_paper_versions()
 
-                # Should return empty list when all tasks fail
-                assert result == []
+            # Should return empty list when all tasks fail
+            assert result == []
 
     @pytest.mark.asyncio
     async def test_fetch_paper_version_info_no_builds(self, manager):
@@ -468,11 +480,12 @@ class TestMinecraftVersionManagerMissingCoverage:
     async def test_get_forge_versions_raises_error_on_failure(self, manager):
         """Test _get_forge_versions raises RuntimeError when API fails"""
         with patch("aiohttp.ClientSession") as mock_session_class:
-            # Create a mock session that raises an exception during get()
+            # Create a mock session whose .get() returns a plain (non-async)
+            # context manager whose __aenter__ raises. session.get itself must
+            # be a sync Mock so it does not produce an un-awaited coroutine.
             mock_session = AsyncMock()
             mock_session_class.return_value.__aenter__.return_value = mock_session
 
-            # Create a proper mock response context manager
             class MockResponse:
                 async def __aenter__(self):
                     raise aiohttp.ClientError("API Error")
@@ -480,7 +493,7 @@ class TestMinecraftVersionManagerMissingCoverage:
                 async def __aexit__(self, *args):
                     pass
 
-            mock_session.get.return_value = MockResponse()
+            mock_session.get = Mock(return_value=MockResponse())
 
             with pytest.raises(RuntimeError, match="Error processing forge versions"):
                 await manager._get_forge_versions()

--- a/tests/unit/services/test_websocket_service_fixed.py
+++ b/tests/unit/services/test_websocket_service_fixed.py
@@ -57,9 +57,14 @@ class TestConnectionManagerFixed:
         """Test successful user connection to server"""
         server_id = 1
 
-        with patch(
-            "app.services.websocket_service.asyncio.create_task"
-        ) as mock_create_task:
+        # Replace _stream_server_logs with a sync Mock so connect() does not
+        # build a real coroutine that the patched create_task leaves un-awaited.
+        with (
+            patch.object(connection_manager, "_stream_server_logs", new=Mock()),
+            patch(
+                "app.services.websocket_service.asyncio.create_task"
+            ) as mock_create_task,
+        ):
             mock_task = Mock()
             mock_create_task.return_value = mock_task
 
@@ -98,7 +103,10 @@ class TestConnectionManagerFixed:
         user2 = Mock(spec=User)
         user2.username = "user2"
 
-        with patch("app.services.websocket_service.asyncio.create_task"):
+        with (
+            patch.object(connection_manager, "_stream_server_logs", new=Mock()),
+            patch("app.services.websocket_service.asyncio.create_task"),
+        ):
             await connection_manager.connect(ws1, server_id, user1)
             await connection_manager.connect(ws2, server_id, user2)
 
@@ -352,7 +360,13 @@ class TestWebSocketServiceFixed:
     @pytest.mark.asyncio
     async def test_start_monitoring_creates_task(self, ws_service):
         """Test starting monitoring creates background task"""
-        with patch("asyncio.create_task") as mock_create_task:
+        # Replace _monitor_server_status with a sync Mock so start_monitoring
+        # does not build a real coroutine that the patched create_task leaves
+        # un-awaited.
+        with (
+            patch.object(ws_service, "_monitor_server_status", new=Mock()),
+            patch("asyncio.create_task") as mock_create_task,
+        ):
             mock_task = Mock()
             mock_create_task.return_value = mock_task
 


### PR DESCRIPTION
## Summary

- `filterwarnings` を **`error::RuntimeWarning` / `error::ResourceWarning` に昇格** し、`addopts` から `--disable-warnings` を除去。新規 leak を CI で検出可能に
- 昇格で露呈した **テスト側の coroutine leak / DB engine leak を全件修正**
- 同時に露呈した **app 側のファイルハンドル漏れ** (`_create_daemon_process_alternative`) を修正

## What changed

### `pyproject.toml`
```diff
 addopts = [
     "--tb=short",
-    "--disable-warnings",
     "-q",
     ...
 ]
 filterwarnings = [
     "error::DeprecationWarning",
     "error::PendingDeprecationWarning",
+    "error::RuntimeWarning",
+    "error::ResourceWarning",
     "ignore:'crypt' is deprecated:DeprecationWarning",
 ]
```

### Test 側修正 (RuntimeWarning: coroutine never awaited)

| ファイル | 修正内容 |
|---|---|
| `test_version_manager.py` (vanilla/paper parallel processing) | `asyncio.gather` をモックする際に `_fetch_*_version_info` / `_fetch_with_semaphore` を sync Mock に差し替え、list comprehension が orphan coroutine を生まないように |
| `test_version_manager::test_get_forge_versions_raises_error_on_failure` | `mock_session.get` を sync `Mock(return_value=MockResponse())` に変更 (AsyncMock 自動 coroutine 化を回避) |
| `test_websocket_service_fixed` (connect × 2, start_monitoring) | `_stream_server_logs` / `_monitor_server_status` を sync Mock 化して、patch された `asyncio.create_task` に渡される coroutine の生成自体を阻止 |
| `test_control_router::test_start_server_java_timeout_error` | `asyncio.wait_for` を patch するのをやめ、`process.communicate` 側に `AsyncMock(side_effect=asyncio.TimeoutError)` を仕込むことで、inner await を経由してから raise させる |
| `test_daemon_lifecycle_comprehensive` (3 箇所) | 共通の `_fake_create_task` ヘルパーを追加。production が `asyncio.create_task(coro)` に渡す coroutine を `coro.close()` で明示閉鎖し、sync task-like Mock を返す |

### Test 側修正 (ResourceWarning: unclosed database)

| ファイル | 修正内容 |
|---|---|
| `tests/unit/servers/test_simplified_sync.py` | `engine.dispose()` を fixture teardown に追加 |
| `tests/unit/servers/test_port_synchronization.py` | 同上 |
| `tests/conftest.py` | 共有 testing engine を `pytest_sessionfinish` で dispose |

### App 側修正

| ファイル | 修正内容 |
|---|---|
| `app/services/minecraft_server.py` (`_create_daemon_process_alternative`) | `open(log_file_path, "w")` / `open(error_file_path, "w")` をインライン渡しから `with` ブロックに移行。`subprocess.Popen` 失敗時の **親側ファイルハンドル漏れを修正** (子プロセスは FD duplication で継承するため副作用なし) |

## Verification

| Stage | Result |
|---|---|
| Full suite (`uv run pytest`) | **1531 passed**, 6 skipped, exit 0, **0 in-test warnings** |
| pre-commit (all-files) | green |

修正前: 12 件の `RuntimeWarning: coroutine never awaited` がフルスイートで観測
修正後: **0 件**

## Out of scope

xdist worker shutdown 時の post-session GC 由来の `PytestUnraisableExceptionWarning` (内訳: `unclosed socket`, `unclosed event loop`) は warning summary に 3 件残存しますが、これは `_pytest/unraisableexception.py` が pytest-xdist の worker 終了タイミングで GC を強制した時の副作用で、テスト実行中の警告ではありません (exit 0)。本 PR の射程外。

## Test plan

- [ ] CI `Test` job: 1531 passed, exit 0
- [ ] 将来 `RuntimeWarning` / `ResourceWarning` を伴うコードが混入した場合に CI が fail することを確認

Resolves #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)