### PR TITLE
chore(typing): enable mypy in pre-commit with relaxed config (Resolves #86)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,14 +53,38 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
-# MyPy type checking - currently disabled due to extensive type annotation work needed
-# Will be re-enabled gradually as type coverage improves
-# - repo: https://github.com/pre-commit/mirrors-mypy
-#   rev: v1.13.0
-#   hooks:
-#     - id: mypy
-#       additional_dependencies:
-#         - types-python-dateutil
-#         - types-requests
-#       exclude: ^(tests/|migrations/)
-#       args: [--ignore-missing-imports, --scripts-are-modules, --no-strict-optional, --allow-untyped-defs, --allow-incomplete-defs, --no-warn-return-any, --allow-untyped-calls]
+  # MyPy type checking — re-enabled per Issue #86 with a relaxed config.
+  # Runs as a local hook against the project's uv-managed venv so plugins
+  # (pydantic.mypy) and runtime deps resolve correctly.
+  #
+  # Real-bug-class error codes (return / call-arg / var-annotated) are kept on;
+  # the disabled codes below are predominantly SQLAlchemy Column[T]-vs-T
+  # and Pydantic-schema noise that requires deeper refactors (tracked separately).
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy (relaxed)
+        entry: uv run mypy app/
+        language: system
+        types: [python]
+        pass_filenames: false
+        args:
+          - --ignore-missing-imports
+          - --scripts-are-modules
+          - --no-strict-optional
+          - --allow-untyped-defs
+          - --allow-incomplete-defs
+          - --no-warn-return-any
+          - --allow-untyped-calls
+          - --disable-error-code=arg-type
+          - --disable-error-code=assignment
+          - --disable-error-code=return-value
+          - --disable-error-code=attr-defined
+          - --disable-error-code=index
+          - --disable-error-code=operator
+          - --disable-error-code=call-overload
+          - --disable-error-code=method-assign
+          - --disable-error-code=valid-type
+          - --disable-error-code=type-var
+          - --disable-error-code=typeddict-unknown-key
+          - --disable-error-code=import-untyped

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,11 +55,9 @@ repos:
 
   # MyPy type checking — re-enabled per Issue #86 with a relaxed config.
   # Runs as a local hook against the project's uv-managed venv so plugins
-  # (pydantic.mypy) and runtime deps resolve correctly.
-  #
-  # Real-bug-class error codes (return / call-arg / var-annotated) are kept on;
-  # the disabled codes below are predominantly SQLAlchemy Column[T]-vs-T
-  # and Pydantic-schema noise that requires deeper refactors (tracked separately).
+  # (pydantic.mypy) and runtime deps resolve correctly. All mypy options
+  # live in pyproject.toml [tool.mypy] so direct invocation
+  # (`uv run mypy app/`) and this hook produce identical results.
   - repo: local
     hooks:
       - id: mypy
@@ -68,23 +66,3 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
-        args:
-          - --ignore-missing-imports
-          - --scripts-are-modules
-          - --no-strict-optional
-          - --allow-untyped-defs
-          - --allow-incomplete-defs
-          - --no-warn-return-any
-          - --allow-untyped-calls
-          - --disable-error-code=arg-type
-          - --disable-error-code=assignment
-          - --disable-error-code=return-value
-          - --disable-error-code=attr-defined
-          - --disable-error-code=index
-          - --disable-error-code=operator
-          - --disable-error-code=call-overload
-          - --disable-error-code=method-assign
-          - --disable-error-code=valid-type
-          - --disable-error-code=type-var
-          - --disable-error-code=typeddict-unknown-key
-          - --disable-error-code=import-untyped

--- a/app/backups/models.py
+++ b/app/backups/models.py
@@ -87,7 +87,7 @@ class BackupScheduleLog(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     server_id = Column(Integer, ForeignKey("servers.id"), nullable=False, index=True)
-    action: "Column[ScheduleAction]" = Column(
+    action: Column[ScheduleAction] = Column(
         Enum(ScheduleAction), nullable=False, index=True
     )
     reason = Column(String(255), nullable=True)

--- a/app/backups/models.py
+++ b/app/backups/models.py
@@ -87,7 +87,9 @@ class BackupScheduleLog(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     server_id = Column(Integer, ForeignKey("servers.id"), nullable=False, index=True)
-    action = Column(Enum(ScheduleAction), nullable=False, index=True)
+    action: "Column[ScheduleAction]" = Column(
+        Enum(ScheduleAction), nullable=False, index=True
+    )
     reason = Column(String(255), nullable=True)
     old_config = Column(JSON, nullable=True)
     new_config = Column(JSON, nullable=True)

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, NoReturn, Optional
 
 from fastapi import HTTPException, status
 
@@ -151,13 +151,13 @@ class MinecraftServerException(APIException):
         super().__init__(status.HTTP_500_INTERNAL_SERVER_ERROR, detail, log_level="error")
 
 
-def handle_database_error(operation: str, table: str, error: Exception) -> None:
+def handle_database_error(operation: str, table: str, error: Exception) -> NoReturn:
     """Utility function to handle and raise database errors consistently."""
     logger.error(f"Database {operation} failed for {table}: {str(error)}")
     raise DatabaseOperationException(operation, table, str(error))
 
 
-def handle_file_error(operation: str, file_path: str, error: Exception) -> None:
+def handle_file_error(operation: str, file_path: str, error: Exception) -> NoReturn:
     """Utility function to handle and raise file operation errors consistently."""
     logger.error(f"File {operation} failed for {file_path}: {str(error)}")
     raise FileOperationException(operation, file_path, str(error))

--- a/app/core/visibility.py
+++ b/app/core/visibility.py
@@ -56,14 +56,18 @@ class ResourceVisibility(Base):
     id = Column(Integer, primary_key=True, index=True)
 
     # Resource identification
-    resource_type = Column(SQLEnum(ResourceType), nullable=False, index=True)
+    resource_type: "Column[ResourceType]" = Column(
+        SQLEnum(ResourceType), nullable=False, index=True
+    )
     resource_id = Column(Integer, nullable=False, index=True)
 
     # Visibility configuration
-    visibility_type = Column(
+    visibility_type: "Column[VisibilityType]" = Column(
         SQLEnum(VisibilityType), nullable=False, default=VisibilityType.PRIVATE
     )
-    role_restriction = Column(SQLEnum(Role), nullable=True)  # For role_based visibility
+    role_restriction: "Column[Role]" = Column(
+        SQLEnum(Role), nullable=True
+    )  # For role_based visibility
 
     # Metadata
     created_at = Column(

--- a/app/core/visibility.py
+++ b/app/core/visibility.py
@@ -56,16 +56,16 @@ class ResourceVisibility(Base):
     id = Column(Integer, primary_key=True, index=True)
 
     # Resource identification
-    resource_type: "Column[ResourceType]" = Column(
+    resource_type: Column[ResourceType] = Column(
         SQLEnum(ResourceType), nullable=False, index=True
     )
     resource_id = Column(Integer, nullable=False, index=True)
 
     # Visibility configuration
-    visibility_type: "Column[VisibilityType]" = Column(
+    visibility_type: Column[VisibilityType] = Column(
         SQLEnum(VisibilityType), nullable=False, default=VisibilityType.PRIVATE
     )
-    role_restriction: "Column[Role]" = Column(
+    role_restriction: Column[Role] = Column(
         SQLEnum(Role), nullable=True
     )  # For role_based visibility
 

--- a/app/groups/models.py
+++ b/app/groups/models.py
@@ -31,7 +31,7 @@ class Group(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(100), nullable=False)
     description = Column(Text)
-    type: "Column[GroupType]" = Column(Enum(GroupType), nullable=False)
+    type: Column[GroupType] = Column(Enum(GroupType), nullable=False)
     players = Column(JSON, nullable=False)  # Array of player objects
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     is_template = Column(Boolean, default=False)

--- a/app/groups/models.py
+++ b/app/groups/models.py
@@ -31,7 +31,7 @@ class Group(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(100), nullable=False)
     description = Column(Text)
-    type = Column(Enum(GroupType), nullable=False)
+    type: "Column[GroupType]" = Column(Enum(GroupType), nullable=False)
     players = Column(JSON, nullable=False)  # Array of player objects
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     is_template = Column(Boolean, default=False)

--- a/app/servers/models.py
+++ b/app/servers/models.py
@@ -42,8 +42,10 @@ class Server(Base):
     name = Column(String(100), nullable=False)
     description = Column(Text)
     minecraft_version = Column(String(20), nullable=False)
-    server_type = Column(Enum(ServerType), nullable=False)
-    status = Column(Enum(ServerStatus), default=ServerStatus.stopped)
+    server_type: "Column[ServerType]" = Column(Enum(ServerType), nullable=False)
+    status: "Column[ServerStatus]" = Column(
+        Enum(ServerStatus), default=ServerStatus.stopped
+    )
     directory_path = Column(String(500), nullable=False)
     port = Column(Integer, default=25565)
     max_memory = Column(Integer, default=1024)  # MB
@@ -100,8 +102,12 @@ class Backup(Base):
     description = Column(Text)
     file_path = Column(String(500), nullable=False)
     file_size = Column(BigInteger, nullable=False)  # bytes
-    backup_type = Column(Enum(BackupType), default=BackupType.manual)
-    status = Column(Enum(BackupStatus), default=BackupStatus.creating)
+    backup_type: "Column[BackupType]" = Column(
+        Enum(BackupType), default=BackupType.manual
+    )
+    status: "Column[BackupStatus]" = Column(
+        Enum(BackupStatus), default=BackupStatus.creating
+    )
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     # Relationships
@@ -132,7 +138,7 @@ class Template(Base):
     name = Column(String(100), nullable=False)
     description = Column(Text)
     minecraft_version = Column(String(20), nullable=False)
-    server_type = Column(Enum(ServerType), nullable=False)
+    server_type: "Column[ServerType]" = Column(Enum(ServerType), nullable=False)
     configuration = Column(JSON, nullable=False)  # server.properties and other settings
     default_groups = Column(JSON)  # Default group attachments
     created_by = Column(Integer, ForeignKey("users.id"), nullable=False)

--- a/app/servers/models.py
+++ b/app/servers/models.py
@@ -42,8 +42,8 @@ class Server(Base):
     name = Column(String(100), nullable=False)
     description = Column(Text)
     minecraft_version = Column(String(20), nullable=False)
-    server_type: "Column[ServerType]" = Column(Enum(ServerType), nullable=False)
-    status: "Column[ServerStatus]" = Column(
+    server_type: Column[ServerType] = Column(Enum(ServerType), nullable=False)
+    status: Column[ServerStatus] = Column(
         Enum(ServerStatus), default=ServerStatus.stopped
     )
     directory_path = Column(String(500), nullable=False)
@@ -102,10 +102,8 @@ class Backup(Base):
     description = Column(Text)
     file_path = Column(String(500), nullable=False)
     file_size = Column(BigInteger, nullable=False)  # bytes
-    backup_type: "Column[BackupType]" = Column(
-        Enum(BackupType), default=BackupType.manual
-    )
-    status: "Column[BackupStatus]" = Column(
+    backup_type: Column[BackupType] = Column(Enum(BackupType), default=BackupType.manual)
+    status: Column[BackupStatus] = Column(
         Enum(BackupStatus), default=BackupStatus.creating
     )
     created_at = Column(DateTime(timezone=True), server_default=func.now())
@@ -138,7 +136,7 @@ class Template(Base):
     name = Column(String(100), nullable=False)
     description = Column(Text)
     minecraft_version = Column(String(20), nullable=False)
-    server_type: "Column[ServerType]" = Column(Enum(ServerType), nullable=False)
+    server_type: Column[ServerType] = Column(Enum(ServerType), nullable=False)
     configuration = Column(JSON, nullable=False)  # server.properties and other settings
     default_groups = Column(JSON)  # Default group attachments
     created_by = Column(Integer, ForeignKey("users.id"), nullable=False)

--- a/app/servers/service.py
+++ b/app/servers/service.py
@@ -693,7 +693,7 @@ class ServerService:
 
             # Attach groups if provided
             if request.attach_groups:
-                group_service = GroupService()
+                group_service = GroupService(db)
                 for group_type, group_ids in request.attach_groups.items():
                     for group_id in group_ids:
                         await group_service.attach_server_to_group(

--- a/app/services/encoding_handler.py
+++ b/app/services/encoding_handler.py
@@ -34,8 +34,10 @@ class EncodingHandler:
             Tuple of (file_content, detected_encoding)
 
         Raises:
-            UnicodeDecodeError: If no encoding works
+            RuntimeError: If the fallback (utf-8 with errors="replace") itself fails
+                (typically because the file became unreadable, not a decode error).
             FileNotFoundError: If file doesn't exist
+            OSError: For other underlying I/O errors raised by the read path
         """
         # First, try to detect encoding using chardet
         try:

--- a/app/services/encoding_handler.py
+++ b/app/services/encoding_handler.py
@@ -76,7 +76,7 @@ class EncodingHandler:
                 content = f.read()
             return content, "utf-8 (with replacement)"
         except Exception as e:
-            raise UnicodeDecodeError(
+            raise RuntimeError(
                 f"Could not decode file {file_path} with any common encoding"
             ) from e
 

--- a/app/services/file_management_service.py
+++ b/app/services/file_management_service.py
@@ -487,6 +487,8 @@ class FileOperationService:
             elif path.is_dir():
                 shutil.rmtree(path)
                 return "directory"
+            else:
+                raise FileNotFoundError(f"Path does not exist: {path}")
         except Exception as e:
             handle_file_error("delete", str(path), e)
 
@@ -601,7 +603,7 @@ class FileSearchService:
         max_results: int,
     ) -> List[Dict[str, Any]]:
         """Search files by filename"""
-        results = []
+        results: list[dict] = []
 
         for file_path in server_path.rglob("*"):
             if len(results) >= max_results:
@@ -628,7 +630,7 @@ class FileSearchService:
         max_results: int,
     ) -> List[Dict[str, Any]]:
         """Search in file content"""
-        results = []
+        results: list[dict] = []
 
         for file_path in server_path.rglob("*"):
             if len(results) >= max_results:

--- a/app/services/file_management_service.py
+++ b/app/services/file_management_service.py
@@ -603,7 +603,7 @@ class FileSearchService:
         max_results: int,
     ) -> List[Dict[str, Any]]:
         """Search files by filename"""
-        results: list[dict] = []
+        results: list[dict[str, Any]] = []
 
         for file_path in server_path.rglob("*"):
             if len(results) >= max_results:
@@ -630,7 +630,7 @@ class FileSearchService:
         max_results: int,
     ) -> List[Dict[str, Any]]:
         """Search in file content"""
-        results: list[dict] = []
+        results: list[dict[str, Any]] = []
 
         for file_path in server_path.rglob("*"):
             if len(results) >= max_results:

--- a/app/services/group_service.py
+++ b/app/services/group_service.py
@@ -127,8 +127,8 @@ class GroupFileService:
             )
 
             # Build ops and whitelist data
-            ops_data: list[dict] = []
-            whitelist_data: list[dict] = []
+            ops_data: list[dict[str, Any]] = []
+            whitelist_data: list[dict[str, Any]] = []
 
             for group in server_groups:
                 players = group.get_players()

--- a/app/services/group_service.py
+++ b/app/services/group_service.py
@@ -127,8 +127,8 @@ class GroupFileService:
             )
 
             # Build ops and whitelist data
-            ops_data = []
-            whitelist_data = []
+            ops_data: list[dict] = []
+            whitelist_data: list[dict] = []
 
             for group in server_groups:
                 players = group.get_players()

--- a/app/services/minecraft_api_service.py
+++ b/app/services/minecraft_api_service.py
@@ -53,6 +53,7 @@ class MinecraftAPIService:
         except Exception as e:
             logger.error(f"Error fetching UUID for username {username}: {str(e)}")
             return None
+        return None
 
     @staticmethod
     async def get_username_from_uuid(uuid: str) -> Optional[str]:

--- a/app/services/minecraft_server.py
+++ b/app/services/minecraft_server.py
@@ -28,7 +28,7 @@ class ServerProcess:
 
     server_id: int
     process: asyncio.subprocess.Process
-    log_queue: asyncio.Queue
+    log_queue: asyncio.Queue[str]
     status: ServerStatus
     started_at: datetime
     pid: Optional[int] = None
@@ -518,7 +518,7 @@ class MinecraftServerManager:
 
             # Create a pseudo subprocess object for monitoring
             # Note: We can't fully recreate the original subprocess, but we can monitor the PID
-            log_queue: asyncio.Queue = asyncio.Queue(maxsize=self.log_queue_size)
+            log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=self.log_queue_size)
 
             # Parse started_at time
             try:
@@ -1516,7 +1516,7 @@ class MinecraftServerManager:
                 )
 
             # Create server process tracking (without process object for daemon)
-            log_queue: asyncio.Queue = asyncio.Queue(maxsize=self.log_queue_size)
+            log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=self.log_queue_size)
             server_process = ServerProcess(
                 server_id=server.id,
                 process=None,  # No process object for daemon processes

--- a/app/services/minecraft_server.py
+++ b/app/services/minecraft_server.py
@@ -518,7 +518,7 @@ class MinecraftServerManager:
 
             # Create a pseudo subprocess object for monitoring
             # Note: We can't fully recreate the original subprocess, but we can monitor the PID
-            log_queue = asyncio.Queue(maxsize=self.log_queue_size)
+            log_queue: asyncio.Queue = asyncio.Queue(maxsize=self.log_queue_size)
 
             # Parse started_at time
             try:
@@ -1516,7 +1516,7 @@ class MinecraftServerManager:
                 )
 
             # Create server process tracking (without process object for daemon)
-            log_queue = asyncio.Queue(maxsize=self.log_queue_size)
+            log_queue: asyncio.Queue = asyncio.Queue(maxsize=self.log_queue_size)
             server_process = ServerProcess(
                 server_id=server.id,
                 process=None,  # No process object for daemon processes

--- a/app/services/real_time_server_commands.py
+++ b/app/services/real_time_server_commands.py
@@ -382,7 +382,7 @@ class RealTimeServerCommandService:
                                     removed_player_names.add(player_name)
 
                     if removed_player_names:
-                        added_players = set()
+                        added_players: set[str] = set()
 
                         # Apply the diff to send deop commands for removed players
                         diff_success = await self.apply_op_diff_if_running(

--- a/app/services/version_manager.py
+++ b/app/services/version_manager.py
@@ -192,6 +192,7 @@ class MinecraftVersionManager:
                         release_date=release_date,
                         is_stable=True,
                     )
+                return None
         except Exception as e:
             logger.warning(
                 f"Failed to fetch vanilla version {version_data.get('id', 'unknown')}: {e}"
@@ -292,6 +293,7 @@ class MinecraftVersionManager:
                     is_stable=True,
                     build_number=latest_build["build"],
                 )
+            return None
         except aiohttp.ClientError as e:
             logger.warning(
                 f"HTTP error fetching Paper build for version {version_id}: {e}"

--- a/app/users/models.py
+++ b/app/users/models.py
@@ -21,7 +21,7 @@ class User(Base):
     username = Column(String(50), unique=True, index=True)
     email = Column(String(255), unique=True, index=True)
     hashed_password = Column(String(255))
-    role: "Column[Role]" = Column(Enum(Role), default=Role.user)
+    role: Column[Role] = Column(Enum(Role), default=Role.user)
     is_active = Column(Boolean, default=True)
     is_approved = Column(Boolean, default=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/app/users/models.py
+++ b/app/users/models.py
@@ -21,7 +21,7 @@ class User(Base):
     username = Column(String(50), unique=True, index=True)
     email = Column(String(255), unique=True, index=True)
     hashed_password = Column(String(255))
-    role = Column(Enum(Role), default=Role.user)
+    role: "Column[Role]" = Column(Enum(Role), default=Role.user)
     is_active = Column(Boolean, default=True)
     is_approved = Column(Boolean, default=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,17 +121,41 @@ precision = 2
 directory = "htmlcov"
 
 [tool.mypy]
+# Relaxed configuration re-enabling mypy in pre-commit (Issue #86).
+# Single source of truth: `uv run mypy app/` and the pre-commit hook share
+# this config so direct invocation and hook produce identical results.
+# Stricter settings will be re-introduced incrementally as follow-up issues
+# address the disabled error codes.
 python_version = "3.13"
+plugins = ["pydantic.mypy"]
+ignore_missing_imports = true
+scripts_are_modules = true
 check_untyped_defs = true
 disallow_untyped_defs = false
-disallow_incomplete_defs = true
+disallow_incomplete_defs = false
 disallow_untyped_decorators = false
 warn_redundant_casts = true
 warn_unused_ignores = true
-warn_return_any = true
-strict_optional = true
+warn_return_any = false
+strict_optional = false
 show_error_codes = true
-plugins = ["pydantic.mypy"]
+# Codes disabled at this stage are dominated by SQLAlchemy Column[T]-vs-T
+# mismatches and Pydantic schema artifacts that require dedicated refactors.
+# Each should be re-enabled by a follow-up issue.
+disable_error_code = [
+    "arg-type",
+    "assignment",
+    "return-value",
+    "attr-defined",
+    "index",
+    "operator",
+    "call-overload",
+    "method-assign",
+    "valid-type",
+    "type-var",
+    "typeddict-unknown-key",
+    "import-untyped",
+]
 
 [[tool.mypy.overrides]]
 module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ warn_unused_ignores = true
 warn_return_any = true
 strict_optional = true
 show_error_codes = true
+plugins = ["pydantic.mypy"]
 
 [[tool.mypy.overrides]]
 module = [


### PR DESCRIPTION
## Summary
- Re-enables the previously-disabled MyPy pre-commit hook (Issue #86) with the relaxed config originally proposed in the issue, plus per-error-code suppression for the categories that require deeper refactors.
- Hook runs as a **local** entry against the project's uv venv so the `pydantic.mypy` plugin and runtime deps resolve correctly (mirrors-mypy in an isolated venv could not see them).
- Fixes 53 real-bug-class errors surfaced by the relaxed config (`[return]`, `[call-arg]`, `[var-annotated]`) so the harness catches new occurrences going forward.
- Remaining noise codes (`arg-type`, `assignment`, `return-value`, `attr-defined`, `index`, `operator`, `call-overload`, `method-assign`, `valid-type`, `type-var`, `typeddict-unknown-key`, `import-untyped`) are disabled at the hook — these are dominated by SQLAlchemy `Column[T]` ↔ `T` mismatches and Pydantic-schema field-type artifacts. Tracked for follow-up issues.

## Notable code fixes (not just annotations)
- `app/core/exceptions.py`: `handle_database_error` / `handle_file_error` now annotated `-> NoReturn` (they always `raise`). Eliminates 16 spurious `[return]` errors in callers.
- `app/servers/service.py:696`: `GroupService()` was instantiated without the required `db` argument — **actual bug**, now passes `db`.
- `app/services/encoding_handler.py:79`: invalid `UnicodeDecodeError(msg)` call (the exception takes 5 args) replaced with `RuntimeError`.
- `app/services/minecraft_api_service.py`, `version_manager.py`, `file_management_service.py`: missing explicit fall-through `return None` / `raise` on functions whose code paths could exit without returning.
- SQLAlchemy `Column(Enum(...))` fields annotated as `Column[T]` across models so MyPy can infer var types.
- `log_queue`, `ops_data`, `whitelist_data`, `added_players`, `results`: explicit generic annotations.
- `pyproject.toml`: added `plugins = ["pydantic.mypy"]` — silences ~13 false-positive `[call-arg]` reports on Pydantic models with `Field()` defaults.

## Why the relaxed config?
The Issue's original premise (78 errors / 21 files) is now stale — the codebase shows 628 errors total / 347 with the Issue's lax args. Per discussion with the maintainer we adopted **option 1b**: enable now with relaxed config + disabled noise codes, fix the real-bug-class errors immediately, and leave SQLAlchemy/Pydantic refactor work to dedicated future issues.

## Test plan
- [x] `uv run pre-commit run --all-files` — all hooks pass including new `mypy (relaxed)`
- [x] `uv run pytest tests/unit tests/integration -m "not slow"` — 1347 passed, 6 skipped
- [x] `uv run ruff check app/` / `uv run ruff format --check app/`
- [ ] CI workflows green on push

## Follow-ups (not in scope for this PR)
- Migrate SQLAlchemy models to `Mapped[]` / `mapped_column()` to fix `arg-type` noise at the source.
- Address `Column[T]` ↔ `T` mismatches at API/service boundaries (most of the remaining 98 `[arg-type]` + 59 `[assignment]`).
- Re-enable disabled error codes incrementally as the above land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)