### PR TITLE
fix(users): reject duplicate email and inactive login attempts

### DIFF
--- a/app/users/application/service.py
+++ b/app/users/application/service.py
@@ -66,6 +66,13 @@ class UserService:
                     detail="Username already registered",
                 )
 
+            existing_email = await uow.users.get_by_email(email)
+            if existing_email is not None:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Email already registered",
+                )
+
             is_first_user = await uow.users.count() == 0
             role = Role.admin if is_first_user else Role.user
             is_approved = is_first_user
@@ -95,6 +102,11 @@ class UserService:
         async with self._uow as uow:
             user = await uow.users.get_by_username(username)
         if user is None or not pwd_context.verify(plain_password, user.hashed_password):
+            return None
+        # Deactivated accounts cannot authenticate. Mirrors the refresh-token
+        # path in `app/auth/api/router.py`, which treats `is_active=False` the
+        # same as "no such user" — the router maps `None` to 401.
+        if not user.is_active:
             return None
         if not user.is_approved:
             raise HTTPException(

--- a/tests/integration/api/test_auth_router.py
+++ b/tests/integration/api/test_auth_router.py
@@ -43,6 +43,24 @@ class TestAuthRouter:
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "Account pending approval" in response.json()["detail"]
 
+    def test_login_inactive_user(self, client, db, test_user):
+        """Deactivated user cannot authenticate (Resolves #232)."""
+        from app.users.models import User
+
+        # Deactivate the otherwise-valid, approved test user.
+        user = db.query(User).filter(User.id == test_user.id).first()
+        user.is_active = False
+        db.commit()
+
+        response = client.post(
+            "/api/v1/auth/token",
+            data={"username": "testuser", "password": "testpassword"},
+        )
+
+        # Service returns `None` → router maps to 401 (matches refresh-token
+        # path in `app/auth/api/router.py`).
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
     def test_login_admin_user(self, client, admin_user):
         """管理者ユーザーでのログイン成功"""
         response = client.post(

--- a/tests/integration/api/test_user_api.py
+++ b/tests/integration/api/test_user_api.py
@@ -66,6 +66,20 @@ class TestUserRegistrationAPI:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_register_duplicate_email(self, client, test_user):
+        """Test registration with duplicate email (Resolves #231)."""
+        response = client.post(
+            "/api/v1/users/register",
+            json={
+                "username": "newuser",
+                "email": "test@example.com",  # already used by test_user
+                "password": "password123",
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "email" in response.json()["detail"].lower()
+
 
 class TestUserProfileAPI:
     """Test user profile management API endpoints"""

--- a/tests/unit/users/test_service_with_fake.py
+++ b/tests/unit/users/test_service_with_fake.py
@@ -70,6 +70,14 @@ class TestRegisterUser:
             await service.register_user("alice", "alice2@x.com", "pw1234")
         assert exc.value.status_code == 400
 
+    @pytest.mark.asyncio
+    async def test_duplicate_email_rejected(self, service: UserService) -> None:
+        await service.register_user("alice", "shared@x.com", "pw1234")
+        with pytest.raises(HTTPException) as exc:
+            await service.register_user("bob", "shared@x.com", "pw1234")
+        assert exc.value.status_code == 400
+        assert "email" in exc.value.detail.lower()
+
 
 class TestAuthenticate:
     @pytest.mark.asyncio
@@ -98,6 +106,19 @@ class TestAuthenticate:
         with pytest.raises(HTTPException) as exc:
             await service.authenticate_user("alice", "pw1234")
         assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_inactive_user_returns_none(
+        self, service: UserService, uow: FakeUsersUnitOfWork
+    ) -> None:
+        from app.users.domain.entities import UpdateUserCommand
+
+        await service.register_user("admin", "admin@x.com", "pw1234")
+        admin = await uow.users.get_by_username("admin")
+        assert admin is not None and admin.id is not None
+        # Deactivating an otherwise-valid, approved account must block login.
+        await uow.users.update(admin.id, UpdateUserCommand(is_active=False))
+        assert await service.authenticate_user("admin", "pw1234") is None
 
 
 class TestAdminActions:


### PR DESCRIPTION
## Summary

Two latent security/UX bugs surfaced during the #222 (users + auth) refactor review and were tracked as follow-up issues. Both are fixed in `app/users/application/service.py`.

- **Resolves #231** — `register_user` did not check email uniqueness, so the second register with a duplicate email bubbled an `IntegrityError` against the `email UNIQUE` constraint to FastAPI's default 500 handler. Now it raises a clean `400 "Email already registered"`, matching the existing username-duplicate path.
- **Resolves #232** — `authenticate_user` did not consult `is_active`. A deactivated account could still trade valid credentials for an access token (the deactivation gate at `app/auth/dependencies.py:27` only fires on the *next* authenticated request). Now we short-circuit to `None` on `is_active=False`, matching the refresh-token path in `app/auth/api/router.py:118`. The router renders `None` as `401`.

The same bugs existed in the legacy `app/services/user.py` (still imported by `tests/integration/test_refresh_token.py` and `app/auth/dependencies.py` consumers); those callers do not exercise registration / authenticate, so the legacy shim is left untouched and will be removed when #233 / #234 land.

## Test plan

- [x] `pytest tests/unit/users tests/integration/users` (28 → 30 with new tests)
- [x] `pytest tests/unit/auth tests/integration/auth` (regression check)
- [x] `pytest tests/integration/api/test_user_api.py tests/integration/test_approval_messages.py` (router contract)
- [x] `pytest tests/integration/test_refresh_token.py tests/unit/services/test_user_service.py` (legacy callers)
- [x] `just lint && just format`

New tests:
- `test_duplicate_email_rejected` — second register with shared email -> 400 with email-mentioning detail.
- `test_inactive_user_returns_none` — register then `update(is_active=False)`, then `authenticate_user(...)` returns `None`.

## Notes for reviewers

- The `is_active` short-circuit returns `None` rather than raising 403 to mirror the refresh-token precedent and avoid leaking the "deactivated vs nonexistent" distinction at the public login surface. Already-authenticated requests still get the more informative `400 Inactive user` via `app/auth/dependencies.py`.
- Email-duplicate check fires *after* the username check to preserve the existing error precedence (matching the legacy 500-error flow's implicit order via the column ordering in the UNIQUE constraints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)