### PR TITLE
refactor(audit): isolate writer session; codify sync-port rule

### DIFF
--- a/app/audit/adapters/repository.py
+++ b/app/audit/adapters/repository.py
@@ -196,6 +196,15 @@ class SqlAlchemyAuditWriter:
     The tracker path is unchanged: when an `AuditTracker` is present
     (typical FastAPI request flow), events are appended to the
     tracker and flushed by the middleware at request end.
+
+    **SQLite caveat**: when the *caller* holds an open write transaction
+    (e.g. a pending `INSERT` in the request's session), the fresh session
+    used by the direct-write path will block on SQLite's file-level lock.
+    The `except` swallow then silently drops the audit record.  In practice
+    the tracker path dominates all FastAPI request flows, so the direct-write
+    path is only hit when there is no `AuditTracker` (e.g. background jobs or
+    tests).  Production deployments on PostgreSQL are unaffected — row-level
+    locking means the two sessions do not contend.
     """
 
     def __init__(

--- a/app/audit/adapters/repository.py
+++ b/app/audit/adapters/repository.py
@@ -18,7 +18,7 @@ preserves the pre-#223 behaviour:
 import json
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
@@ -186,19 +186,38 @@ class SqlAlchemyAuditRepository:
 class SqlAlchemyAuditWriter:
     """SQLAlchemy-backed `AuditWriter`.
 
-    Construction is per-request (or per-call from the legacy facade)
-    because the optional `tracker` is request-scoped. The class is
-    intentionally tiny — it does no formatting; callers (or the
-    legacy facade) compose `AuditEventCommand` and hand it over.
+    The direct-write path uses a **fresh** session (via
+    `app.core.database.SessionLocal`) so the audit insert is
+    transactionally isolated from any caller-side pending writes.
+    Previously the writer reused the caller's session and called
+    `commit()` on it, which silently committed any in-flight business
+    operation state (Resolves #240).
+
+    The tracker path is unchanged: when an `AuditTracker` is present
+    (typical FastAPI request flow), events are appended to the
+    tracker and flushed by the middleware at request end.
     """
 
-    def __init__(self, db: Session, tracker: Optional[object] = None) -> None:
+    def __init__(
+        self,
+        tracker: Optional[object] = None,
+        session_factory: Optional[Callable[[], Session]] = None,
+    ) -> None:
         # `tracker` is typed as `object` to avoid a hard import from the
         # middleware layer into the domain adapter — duck-typed on
         # `add_event`. The concrete type is
         # `app.middleware.audit_middleware.AuditTracker`.
-        self._db = db
         self._tracker = tracker
+        # `session_factory` is injectable so tests can point the
+        # direct-write path at a known engine. Defaults to the
+        # application `SessionLocal`, which conftest binds to the
+        # worker-scoped test SQLite via `DATABASE_URL`.
+        if session_factory is None:
+            from app.core.database import SessionLocal as _SessionLocal
+
+            self._session_factory: Callable[[], Session] = _SessionLocal
+        else:
+            self._session_factory = session_factory
 
     def record(self, command: AuditEventCommand) -> None:
         try:
@@ -216,23 +235,29 @@ class SqlAlchemyAuditWriter:
                 )
                 return
 
-            audit_log = AuditLog.create_log(
-                action=command.action,
-                resource_type=command.resource_type,
-                user_id=command.user_id,
-                resource_id=command.resource_id,
-                details=command.details,
-                ip_address=command.ip_address,
-            )
-            self._db.add(audit_log)
-            self._db.commit()
-            logger.debug(
-                "Created audit log: %s on %s:%s by user %s",
-                command.action,
-                command.resource_type,
-                command.resource_id,
-                command.user_id,
-            )
+            # Separate session so audit writes never commit the
+            # caller's pending transaction state.
+            db = self._session_factory()
+            try:
+                audit_log = AuditLog.create_log(
+                    action=command.action,
+                    resource_type=command.resource_type,
+                    user_id=command.user_id,
+                    resource_id=command.resource_id,
+                    details=command.details,
+                    ip_address=command.ip_address,
+                )
+                db.add(audit_log)
+                db.commit()
+                logger.debug(
+                    "Created audit log: %s on %s:%s by user %s",
+                    command.action,
+                    command.resource_type,
+                    command.resource_id,
+                    command.user_id,
+                )
+            finally:
+                db.close()
         except Exception as exc:
             # Audit must never break the caller — log and swallow.
             logger.error(
@@ -242,10 +267,6 @@ class SqlAlchemyAuditWriter:
                 command.resource_id,
                 exc,
             )
-            # Roll back any partial write; ignore everything (the
-            # session may itself be the source of the original
-            # exception, in which case `rollback` may also throw).
-            try:
-                self._db.rollback()
-            except Exception:
-                pass
+            # No rollback needed: the direct-write path owns a fresh
+            # session that was closed in `finally`; the tracker path
+            # mutates only in-memory state.

--- a/app/audit/application/legacy_facade.py
+++ b/app/audit/application/legacy_facade.py
@@ -49,8 +49,16 @@ def _extract_ip_address(request: Request) -> Optional[str]:
     return None
 
 
-def _writer(db: Session, request: Request) -> SqlAlchemyAuditWriter:
-    return SqlAlchemyAuditWriter(db=db, tracker=get_audit_tracker(request))
+def _writer(request: Request) -> SqlAlchemyAuditWriter:
+    """Build a writer for a single legacy call.
+
+    The caller's `db` is no longer threaded into the writer — see #240
+    and `SqlAlchemyAuditWriter` for the transaction-isolation rationale.
+    The static `AuditService.log_*` signatures still accept `db` for
+    backward compatibility with 30+ existing callsites; the parameter
+    is intentionally unused.
+    """
+    return SqlAlchemyAuditWriter(tracker=get_audit_tracker(request))
 
 
 class AuditService:
@@ -70,7 +78,7 @@ class AuditService:
             "success": success,
             **(details or {}),
         }
-        _writer(db, request).record(
+        _writer(request).record(
             AuditEventCommand(
                 action=f"auth_{action}_{'success' if success else 'failure'}",
                 resource_type="authentication",
@@ -95,7 +103,7 @@ class AuditService:
             "performed_by": current_user_id,
             **(details or {}),
         }
-        _writer(db, request).record(
+        _writer(request).record(
             AuditEventCommand(
                 action=f"user_{action}",
                 resource_type="user",
@@ -117,7 +125,7 @@ class AuditService:
     ):
         user_id = user_id or get_current_user_id()
         audit_details = {"server_id": server_id, **(details or {})}
-        _writer(db, request).record(
+        _writer(request).record(
             AuditEventCommand(
                 action=f"server_{action}",
                 resource_type="server",
@@ -145,7 +153,7 @@ class AuditService:
             "success": success,
             "output_length": len(output) if output else 0,
         }
-        _writer(db, request).record(
+        _writer(request).record(
             AuditEventCommand(
                 action=f"server_command_{'success' if success else 'failure'}",
                 resource_type="server",
@@ -172,7 +180,7 @@ class AuditService:
             "backup_id": backup_id,
             **(details or {}),
         }
-        _writer(db, request).record(
+        _writer(request).record(
             AuditEventCommand(
                 action=f"backup_{action}",
                 resource_type="backup",
@@ -194,7 +202,7 @@ class AuditService:
     ):
         user_id = user_id or get_current_user_id()
         audit_details = {"group_id": group_id, **(details or {})}
-        _writer(db, request).record(
+        _writer(request).record(
             AuditEventCommand(
                 action=f"group_{action}",
                 resource_type="group",
@@ -216,7 +224,7 @@ class AuditService:
     ):
         user_id = user_id or get_current_user_id()
         audit_details = {"template_id": template_id, **(details or {})}
-        _writer(db, request).record(
+        _writer(request).record(
             AuditEventCommand(
                 action=f"template_{action}",
                 resource_type="template",
@@ -244,7 +252,7 @@ class AuditService:
             "file_name": file_path.split("/")[-1] if "/" in file_path else file_path,
             **(details or {}),
         }
-        _writer(db, request).record(
+        _writer(request).record(
             AuditEventCommand(
                 action=f"file_{action}",
                 resource_type="file",
@@ -274,7 +282,7 @@ class AuditService:
             "resource_id": resource_id,
             **(details or {}),
         }
-        _writer(db, request).record(
+        _writer(request).record(
             AuditEventCommand(
                 action=f"permission_check_{'granted' if granted else 'denied'}",
                 resource_type="permission",
@@ -302,7 +310,7 @@ class AuditService:
             "admin_action": action,
             **(details or {}),
         }
-        _writer(db, request).record(
+        _writer(request).record(
             AuditEventCommand(
                 action=f"admin_{action}",
                 resource_type="admin_action",
@@ -330,7 +338,7 @@ class AuditService:
             "user_agent": request.headers.get("User-Agent", "Unknown"),
             **(details or {}),
         }
-        _writer(db, request).record(
+        _writer(request).record(
             AuditEventCommand(
                 action=f"security_{event_type}",
                 resource_type="security",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,6 +81,22 @@ class ServerRepository(Protocol):
     async def save(self, server: Server) -> None: ...
 ```
 
+#### Port method signatures: `async` by default, sync when justified
+
+Public methods on `domain/ports.py` Protocols are `async def` by default. This keeps the application layer compatible with future migration to async SQLAlchemy and matches the FastAPI route-handler shape.
+
+A Port **may** declare **sync** methods if all three of the following hold:
+
+1. The operation is fire-and-forget — callers do not need to await a result and the operation does not yield to other tasks.
+2. The underlying I/O is sync and migration to async is not on the roadmap for that adapter.
+3. Every existing callsite is already sync, so declaring `async def` would force `asyncio.run` shims at the call sites with no payoff.
+
+If only some of the above hold, default to `async def`.
+
+The canonical exception today is `AuditWriter.record` in `app/audit/domain/ports.py`: audit writes are fire-and-forget against a sync SQLAlchemy session, issued from 30+ existing sync callsites that already live inside `async def` route handlers. The rationale is documented in that Port's docstring, and `tests/unit/audit/test_protocol_conformance.py::test_writer_methods_are_sync` pins the choice so a future refactor cannot silently flip it.
+
+When introducing a new sync Port, mirror that pattern: explain the three-condition justification in the Port's docstring, and add a conformance test that asserts the sync shape.
+
 ### 4.2 `application/` — Use cases
 
 **Responsibility**: Orchestrate domain logic into application use cases.

--- a/tests/integration/audit/test_audit_repository.py
+++ b/tests/integration/audit/test_audit_repository.py
@@ -30,7 +30,13 @@ def repository(db):
 
 @pytest.fixture
 def writer(db):
-    return SqlAlchemyAuditWriter(db=db, tracker=None)
+    """Writer pointed at the worker-scoped test SQLite.
+
+    The fixture takes `db` purely to ensure conftest's `Base.metadata.create_all`
+    has run before the writer's first call constructs its own session.
+    """
+    _ = db
+    return SqlAlchemyAuditWriter(tracker=None)
 
 
 @pytest.fixture
@@ -70,19 +76,68 @@ async def test_writer_persists_event(db, writer, seeded_user) -> None:
 
 
 @pytest.mark.asyncio
-async def test_writer_swallows_errors(db, writer) -> None:
-    """A bad command must not raise — audit is fire-and-forget."""
+async def test_writer_swallows_errors(db) -> None:
+    """Audit is fire-and-forget: failures on either path must not propagate.
 
-    class _Bomb:
-        def __getattr__(self, name):
+    Exercised here on the tracker path (the cheaper of the two — a
+    fault-injecting `session_factory` for the direct path is the
+    target of #244).
+    """
+
+    class _ExplodingTracker:
+        def add_event(self, **_):
             raise RuntimeError("boom")
 
-    # Hand the writer something that explodes on attribute access; the
-    # writer's try/except must keep this from propagating.
-    writer._db = _Bomb()  # type: ignore[attr-defined]
+    _ = db
+    bad_writer = SqlAlchemyAuditWriter(tracker=_ExplodingTracker())
+    # Must not raise; failure logged and discarded.
+    bad_writer.record(AuditEventCommand(action="x", resource_type="t"))
+
+
+@pytest.mark.asyncio
+async def test_writer_does_not_commit_callers_session(db) -> None:
+    """#240: audit must not commit caller's pending transaction.
+
+    Scenario:
+      1. Caller stages an uncommitted row.
+      2. Caller invokes the audit writer (direct path — no tracker).
+      3. Caller rolls back.
+
+    Expected: caller's row is **not** persisted. (Pre-#240 the writer
+    called `commit()` on the caller's session, which persisted the
+    caller's pending row as a side effect.)
+
+    The audit row's own persistence is not asserted here: on SQLite
+    the caller's pending write holds a file-level lock, so the
+    writer's fresh session blocks and the fire-and-forget swallow
+    drops the audit row. Postgres avoids the lock contention. This
+    test focuses on the property that matters for #240 — caller
+    transaction isolation — and leaves the SQLite-vs-Postgres
+    persistence story to integration runs against the production
+    backend.
+    """
+    writer = SqlAlchemyAuditWriter(tracker=None)
+
+    extra = User(
+        username="must-not-persist",
+        email="must-not-persist@example.com",
+        hashed_password="x",
+        role=Role.user,
+        is_active=True,
+        is_approved=True,
+    )
+    db.add(extra)
+    db.flush()  # assigns an id but stays inside the open transaction
+
     writer.record(
-        AuditEventCommand(action="x", resource_type="t")
-    )  # must not raise
+        AuditEventCommand(action="server_start_240", resource_type="server")
+    )
+
+    db.rollback()
+
+    assert (
+        db.query(User).filter(User.username == "must-not-persist").first() is None
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/audit/test_protocol_conformance.py
+++ b/tests/unit/audit/test_protocol_conformance.py
@@ -24,7 +24,7 @@ from tests.unit.audit.fakes import FakeAuditRepository, FakeAuditWriter
 if TYPE_CHECKING:
     _real_repo: AuditRepository = SqlAlchemyAuditRepository(db=MagicMock(spec=Session))
     _fake_repo: AuditRepository = FakeAuditRepository()
-    _real_writer: AuditWriter = SqlAlchemyAuditWriter(db=MagicMock(spec=Session))
+    _real_writer: AuditWriter = SqlAlchemyAuditWriter()
     _fake_writer: AuditWriter = FakeAuditWriter()
 
 
@@ -60,7 +60,7 @@ def _build_writer(name: str) -> AuditWriter:
     if name == "fake":
         return FakeAuditWriter()
     if name == "sqlalchemy":
-        return SqlAlchemyAuditWriter(db=MagicMock(spec=Session))
+        return SqlAlchemyAuditWriter()
     raise ValueError(f"unknown writer implementation: {name}")
 
 


### PR DESCRIPTION
## Summary

Bundles two audit follow-ups from PR #238 that both need to land before #224-#228 (the per-domain Repository migrations).

- **Resolves #240** — `SqlAlchemyAuditWriter` no longer commits the caller's session. The direct-write path now builds a fresh session via `SessionLocal()`; the tracker path was already isolated.
- **Resolves #243** — `docs/ARCHITECTURE.md` §4.1 gets a new "Port method signatures: async by default, sync when justified" rule, naming `AuditWriter.record` as the canonical exception.

## #240 — Writer transaction isolation

### The bug

Pre-#223 `_log_event` and post-#223 `SqlAlchemyAuditWriter.record` both did `self._db.commit()` on the caller's session for the direct-write path:

```python
self._db.add(audit_log)
self._db.commit()  # commits everything else the route handler had staged too
```

A route handler that did `db.add(server)` → `audit log "creating server"` → `validation fails` → `db.rollback()` would persist the server row anyway, because the audit's `commit()` had already flushed it.

### The fix

Writer's direct-write path now uses a fresh session:

```python
db = self._session_factory()  # defaults to app.core.database.SessionLocal
try:
    db.add(audit_log)
    db.commit()
finally:
    db.close()
```

Constructor accepts an optional `session_factory: Callable[[], Session]` so tests can route to a known engine (default = `SessionLocal`, conftest binds it to the worker-scoped test SQLite via `DATABASE_URL`).

### API impact

`SqlAlchemyAuditWriter.__init__(db: Session, tracker=None)` → `__init__(tracker=None, session_factory=None)`. The **30+ legacy callers untouched** — they go through `AuditService.log_*`, and the facade builds the writer internally.

### Test

New `test_writer_does_not_commit_callers_session` asserts the caller-isolation property: caller stages an uncommitted `User` row, calls the writer, rolls back, and the row must not persist. The audit row's own persistence is **not** asserted here — on SQLite the caller's pending write holds the file lock and the writer's fresh session blocks, so the fire-and-forget swallow drops the audit row. Postgres avoids the contention; that path is left to environment-specific runs. The scoped assertion captures what #240 actually wanted.

### Bonus: `test_writer_swallows_errors` migrated off private-attribute touch

The previous `writer._db = _Bomb()` is gone. The replacement uses an `_ExplodingTracker` whose `add_event` raises — exercises the swallow contract on the tracker path without poking internals. #244 will add an analogous direct-path fault via a fault-injecting `session_factory`.

## #243 — Sync-port rule in ARCHITECTURE.md

New subsection under §4.1:

> Public methods on `domain/ports.py` Protocols are `async def` by default. […]
>
> A Port may declare sync methods if all three of the following hold:
> 1. The operation is fire-and-forget — callers do not need to await a result and the operation does not yield to other tasks.
> 2. The underlying I/O is sync and migration to async is not on the roadmap for that adapter.
> 3. Every existing callsite is already sync, so declaring `async def` would force `asyncio.run` shims at the call sites with no payoff.
>
> The canonical exception today is `AuditWriter.record` […]

Cross-references the conformance test that pins the sync shape.

## Test plan

- [x] `pytest tests/unit/audit tests/integration/audit tests/integration/test_audit.py` → **36 passed** (+1 new isolation test)
- [x] `pytest tests/integration/api/test_auth_router.py tests/integration/api/test_user_api.py tests/integration/test_approval_messages.py tests/integration/test_refresh_token.py` → **62 passed** (legacy writer callers regression-safe)
- [x] `uv run mypy app/audit/` → no issues
- [x] `just lint && just format`

## Risk / scope

- **Behavioural change at the writer**, but the production callers all flow through `AuditService.log_*` which builds the writer per-call → no signature break.
- **SQLite caveat noted in the new test docstring**: under caller-side write contention the audit row may be dropped on SQLite. Production typically runs Postgres; the caller-isolation property is what matters and works on both.
- Documentation-only change for #243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)