### PR TITLE
fix(audit): warn when command.ip_address differs from tracker

### DIFF
--- a/app/audit/adapters/repository.py
+++ b/app/audit/adapters/repository.py
@@ -41,7 +41,14 @@ class AuditTrackerProtocol(Protocol):
     adapter layer. `app.middleware.audit_middleware.AuditTracker` satisfies
     this protocol structurally — no inheritance needed. Mypy will catch
     drift on either side without creating an import cycle.
+
+    `ip_address` is declared so the writer's mismatch warning path
+    (Resolves #239) can read it via static attribute access rather than
+    `getattr` — mypy then enforces the contract on every tracker
+    implementation.
     """
+
+    ip_address: Optional[str]
 
     def add_event(
         self,
@@ -246,10 +253,25 @@ class SqlAlchemyAuditWriter:
     def record(self, command: AuditEventCommand) -> None:
         try:
             if self._tracker is not None:
-                # Tracker is request-scoped — let the middleware flush
-                # the batch at request end. The tracker carries its own
-                # `ip_address`, so the one on the command is ignored
-                # here (matches pre-#223 behaviour).
+                # Tracker is request-scoped and carries its own
+                # `ip_address` from the middleware; that value wins
+                # (matches pre-#223 behaviour). Warn when the command
+                # disagrees so callers outside the request flow
+                # (WebSocket, queued events) can spot the mismatch
+                # early (Resolves #239).
+                if (
+                    command.ip_address is not None
+                    and command.ip_address != self._tracker.ip_address
+                ):
+                    logger.warning(
+                        "AuditEventCommand.ip_address differs from tracker — "
+                        "tracker value will be used",
+                        extra={
+                            "command_ip": command.ip_address,
+                            "tracker_ip": self._tracker.ip_address,
+                            "action": command.action,
+                        },
+                    )
                 self._tracker.add_event(
                     action=command.action,
                     resource_type=command.resource_type,

--- a/tests/integration/audit/test_audit_repository.py
+++ b/tests/integration/audit/test_audit_repository.py
@@ -10,6 +10,8 @@ Uses the real worker-scoped SQLite test session. Confirms:
 - Statistics aggregate consistently with the underlying rows.
 """
 
+import logging
+
 import pytest
 
 from app.audit.adapters.repository import (
@@ -124,6 +126,80 @@ async def test_writer_swallows_direct_write_errors(db) -> None:
     _ = db
     bad_writer = SqlAlchemyAuditWriter(tracker=None, session_factory=_ExplodingSession)
     bad_writer.record(AuditEventCommand(action="x", resource_type="t"))
+
+
+class _TrackerSpy:
+    """Captures `add_event` kwargs so the mismatch-warning tests can prove
+    the tracker value still wins after the warning is emitted (#239)."""
+
+    def __init__(self, ip_address: str | None) -> None:
+        self.ip_address = ip_address
+        self.calls: list[dict] = []
+
+    def add_event(self, **kwargs) -> None:
+        self.calls.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_writer_warns_on_ip_address_mismatch(caplog) -> None:
+    """Tracker path: divergent ip_address emits exactly one WARNING and
+    the tracker's value is still the one forwarded to `add_event`
+    (Resolves #239)."""
+    spy = _TrackerSpy(ip_address="1.2.3.4")
+    writer = SqlAlchemyAuditWriter(tracker=spy)
+
+    with caplog.at_level(logging.WARNING, logger="app.audit.adapters.repository"):
+        writer.record(
+            AuditEventCommand(action="y", resource_type="t", ip_address="10.0.0.99")
+        )
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    record = warnings[0]
+    assert record.command_ip == "10.0.0.99"
+    assert record.tracker_ip == "1.2.3.4"
+    assert record.action == "y"
+    # Tracker value still wins: add_event is invoked with the command's
+    # kwargs (which carry no ip_address) — tracker.ip_address is what
+    # `AuditTracker.add_event` stamps onto the event downstream.
+    assert spy.calls == [
+        {
+            "action": "y",
+            "resource_type": "t",
+            "resource_id": None,
+            "details": None,
+            "user_id": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_writer_does_not_warn_when_ip_address_matches(caplog) -> None:
+    """No warning when command and tracker agree on ip_address (#239)."""
+    spy = _TrackerSpy(ip_address="1.2.3.4")
+    writer = SqlAlchemyAuditWriter(tracker=spy)
+
+    with caplog.at_level(logging.WARNING, logger="app.audit.adapters.repository"):
+        writer.record(
+            AuditEventCommand(action="y", resource_type="t", ip_address="1.2.3.4")
+        )
+
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+    assert len(spy.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_writer_does_not_warn_when_command_ip_is_none(caplog) -> None:
+    """No warning when command carries no ip_address — the tracker
+    value is simply used and no comparison fires (#239)."""
+    spy = _TrackerSpy(ip_address="1.2.3.4")
+    writer = SqlAlchemyAuditWriter(tracker=spy)
+
+    with caplog.at_level(logging.WARNING, logger="app.audit.adapters.repository"):
+        writer.record(AuditEventCommand(action="y", resource_type="t"))
+
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+    assert len(spy.calls) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `SqlAlchemyAuditWriter.record` のトラッカーパスで `command.ip_address` がトラッカーの `ip_address` と異なる場合に構造化 `WARNING` ログを出力するよう変更（`extra={command_ip, tracker_ip, action}`）
- トラッカーの値が引き続き優先される（pre-#223 の動作を維持）が、WebSocket・キューイベントなどの呼び出し側が不一致を早期に発見できる
- `AuditTrackerProtocol` に `ip_address: Optional[str]` を追加して mypy で契約を強制
- テストを `_TrackerSpy` ベースに刷新し、単一 WARNING レコードの内容とトラッカー値が引き続き forward されることを検証。match / `None` ケースも追加

## Test plan

- [x] `uv run pytest tests/integration/audit/test_audit_repository.py` → 12 passed
- [x] `uv run ruff check app/audit/ tests/integration/audit/` → passed
- [x] `uv run mypy app/audit/ app/middleware/audit_middleware.py` → no issues

Resolves #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)