### PR TITLE
fix(audit): dialect-aware severity filter for SQLite

### DIFF
--- a/app/audit/adapters/repository.py
+++ b/app/audit/adapters/repository.py
@@ -111,10 +111,15 @@ class SqlAlchemyAuditRepository:
             .filter(AuditLog.resource_type == "security")
         )
         if severity:
-            # Matches the legacy JSON-path filter exactly. Works on
-            # Postgres (`->>` operator); SQLite falls back to a no-op
-            # match — the legacy behaviour kept this same caveat.
-            query = query.filter(AuditLog.details.op("->>")('"severity"') == severity)
+            # Dialect-aware JSON path: SQLite uses json_extract(), Postgres
+            # uses the native ->> operator (Resolves #241).
+            dialect = self._db.bind.dialect.name if self._db.bind else "sqlite"
+            if dialect == "postgresql":
+                query = query.filter(AuditLog.details.op("->>")('"severity"') == severity)
+            else:
+                query = query.filter(
+                    func.json_extract(AuditLog.details, "$.severity") == severity
+                )
         rows = query.order_by(AuditLog.created_at.desc()).limit(limit).all()
         return [_log_to_entity(r) for r in rows]
 

--- a/tests/integration/audit/test_audit_repository.py
+++ b/tests/integration/audit/test_audit_repository.py
@@ -351,17 +351,24 @@ async def test_security_alerts_severity_emits_postgres_operator() -> None:
     repo = SqlAlchemyAuditRepository(db)
     await repo.list_security_alerts(severity="critical", limit=10)
 
-    # First filter call is resource_type=='security'; the severity
-    # filter is the second one. Compile against the postgresql dialect
-    # so the operator renders as plain SQL text.
-    severity_expr = query.filter.call_args_list[1].args[0]
-    compiled = str(
-        severity_expr.compile(
-            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+    # Locate the severity filter by inspecting the compiled SQL of each
+    # `.filter(...)` call rather than by positional index — survives
+    # future refactors that reorder filters or fold them into a helper.
+    def _compile(expr) -> str:
+        return str(
+            expr.compile(
+                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+            )
         )
-    )
-    assert "->>" in compiled
-    assert "json_extract" not in compiled
+
+    severity_compiled = [
+        _compile(call.args[0])
+        for call in query.filter.call_args_list
+        if "severity" in _compile(call.args[0])
+    ]
+    assert len(severity_compiled) == 1, query.filter.call_args_list
+    assert "->>" in severity_compiled[0]
+    assert "json_extract" not in severity_compiled[0]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/audit/test_audit_repository.py
+++ b/tests/integration/audit/test_audit_repository.py
@@ -10,7 +10,7 @@ Uses the real worker-scoped SQLite test session. Confirms:
 - Statistics aggregate consistently with the underlying rows.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 import pytest
 
@@ -129,15 +129,11 @@ async def test_writer_does_not_commit_callers_session(db) -> None:
     db.add(extra)
     db.flush()  # assigns an id but stays inside the open transaction
 
-    writer.record(
-        AuditEventCommand(action="server_start_240", resource_type="server")
-    )
+    writer.record(AuditEventCommand(action="server_start_240", resource_type="server"))
 
     db.rollback()
 
-    assert (
-        db.query(User).filter(User.username == "must-not-persist").first() is None
-    )
+    assert db.query(User).filter(User.username == "must-not-persist").first() is None
 
 
 @pytest.mark.asyncio
@@ -151,9 +147,7 @@ async def test_list_logs_returns_entities_with_user_email(
             user_id=seeded_user.id,
         )
     )
-    logs = await repository.list_logs(
-        LogFilters(action="user_event"), limit=10, offset=0
-    )
+    logs = await repository.list_logs(LogFilters(action="user_event"), limit=10, offset=0)
     assert len(logs) == 1
     assert logs[0].user_id == seeded_user.id
     assert logs[0].user_email == seeded_user.email
@@ -163,9 +157,7 @@ async def test_list_logs_returns_entities_with_user_email(
 async def test_count_logs_matches_list(db, writer, repository) -> None:
     for i in range(3):
         writer.record(
-            AuditEventCommand(
-                action=f"countable_{i}", resource_type="t", user_id=99
-            )
+            AuditEventCommand(action=f"countable_{i}", resource_type="t", user_id=99)
         )
     n = await repository.count_logs(LogFilters(user_id=99, action="countable"))
     assert n == 3
@@ -188,9 +180,7 @@ async def test_list_user_activity(db, writer, repository, seeded_user) -> None:
 
 
 @pytest.mark.asyncio
-async def test_security_alerts_filtered_by_resource_type(
-    db, writer, repository
-) -> None:
+async def test_security_alerts_filtered_by_resource_type(db, writer, repository) -> None:
     writer.record(
         AuditEventCommand(
             action="security_x",
@@ -198,12 +188,32 @@ async def test_security_alerts_filtered_by_resource_type(
             details={"severity": "critical"},
         )
     )
-    writer.record(
-        AuditEventCommand(action="other", resource_type="server")
-    )
+    writer.record(AuditEventCommand(action="other", resource_type="server"))
     alerts = await repository.list_security_alerts(severity=None, limit=10)
     assert all(a.resource_type == "security" for a in alerts)
     assert any(a.action == "security_x" for a in alerts)
+
+
+@pytest.mark.asyncio
+async def test_security_alerts_filtered_by_severity(db, writer, repository) -> None:
+    """Severity filter must work on SQLite (json_extract path — Resolves #241)."""
+    writer.record(
+        AuditEventCommand(
+            action="sev_critical",
+            resource_type="security",
+            details={"severity": "critical"},
+        )
+    )
+    writer.record(
+        AuditEventCommand(
+            action="sev_warning",
+            resource_type="security",
+            details={"severity": "warning"},
+        )
+    )
+    critical_alerts = await repository.list_security_alerts(severity="critical", limit=10)
+    assert any(a.action == "sev_critical" for a in critical_alerts)
+    assert not any(a.action == "sev_warning" for a in critical_alerts)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `list_security_alerts` の severity フィルタが Postgres 専用の `->>` JSON パス演算子を使用しており、SQLite では常に空を返すバグを修正
- `Session.bind.dialect.name` でダイアレクトを判定し、SQLite は `func.json_extract(details, '$.severity')`、PostgreSQL は従来の `->>` 演算子を使用
- `test_security_alerts_filtered_by_severity` を追加して SQLite 上での動作を検証

## Test plan

- [ ] `pytest tests/integration/audit/test_audit_repository.py::test_security_alerts_filtered_by_severity` → 1 passed
- [ ] `uv run ruff check app/audit/` → passed
- [ ] `uv run mypy app/audit/` → no issues

Resolves #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)