### PR TITLE
refactor(users): relocate Role enum to domain-pure module (Resolves part of #235)

### DIFF
--- a/app/backups/router.py
+++ b/app/backups/router.py
@@ -37,7 +37,8 @@ from app.core.exceptions import (
 from app.servers.models import BackupStatus, BackupType
 from app.services.authorization_service import authorization_service
 from app.services.backup_service import backup_service
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 router = APIRouter(tags=["backups"])
 

--- a/app/backups/scheduler_router.py
+++ b/app/backups/scheduler_router.py
@@ -20,7 +20,8 @@ from app.backups.schemas import (
 from app.core.database import get_db
 from app.services.authorization_service import authorization_service
 from app.services.backup_scheduler import backup_scheduler
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 router = APIRouter(tags=["backup-scheduler"])
 

--- a/app/core/visibility.py
+++ b/app/core/visibility.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
 from app.core.database import Base
-from app.users.models import Role
+from app.users.domain.value_objects import Role
 
 
 class VisibilityType(str, Enum):

--- a/app/core/visibility_router.py
+++ b/app/core/visibility_router.py
@@ -24,7 +24,8 @@ from app.groups.models import Group
 from app.servers.models import Server
 from app.services.visibility_migration_service import VisibilityMigrationService
 from app.services.visibility_service import VisibilityService
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 logger = logging.getLogger(__name__)
 

--- a/app/core/visibility_schemas.py
+++ b/app/core/visibility_schemas.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.core.visibility import ResourceType, VisibilityType
-from app.users.models import Role
+from app.users.domain.value_objects import Role
 
 
 class VisibilityUpdateRequest(BaseModel):

--- a/app/files/router.py
+++ b/app/files/router.py
@@ -31,7 +31,8 @@ from app.services.authorization_service import authorization_service
 from app.services.file_history_service import file_history_service
 from app.services.file_management_service import file_management_service
 from app.types import FileType
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 router = APIRouter()
 

--- a/app/servers/routers/utilities.py
+++ b/app/servers/routers/utilities.py
@@ -12,7 +12,8 @@ from app.servers.models import ServerType
 from app.servers.schemas import SupportedVersionsResponse
 from app.services.jar_cache_manager import jar_cache_manager
 from app.services.java_compatibility import java_compatibility_service
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 logger = logging.getLogger(__name__)
 

--- a/app/services/authorization_service.py
+++ b/app/services/authorization_service.py
@@ -5,7 +5,8 @@ from fastapi import HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from app.servers.models import Backup, Server
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 class AuthorizationService:

--- a/app/services/file_management_service.py
+++ b/app/services/file_management_service.py
@@ -20,7 +20,8 @@ from app.servers.models import Server
 from app.services.encoding_handler import EncodingHandler
 from app.services.file_history_service import file_history_service
 from app.types import FileType
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 logger = logging.getLogger(__name__)
 

--- a/app/services/group_service.py
+++ b/app/services/group_service.py
@@ -13,7 +13,8 @@ from app.core.security import PathValidator, SecurityError
 from app.groups.models import Group, GroupType, ServerGroup
 from app.servers.models import Server
 from app.services.real_time_server_commands import real_time_server_commands
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 logger = logging.getLogger(__name__)
 

--- a/app/services/server_service.py
+++ b/app/services/server_service.py
@@ -9,7 +9,8 @@ from sqlalchemy.orm import Session
 
 from app.servers.models import Server, ServerStatus, ServerType
 from app.services.minecraft_server import minecraft_server_manager
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 logger = logging.getLogger(__name__)
 

--- a/app/services/template_service.py
+++ b/app/services/template_service.py
@@ -8,7 +8,8 @@ from sqlalchemy import and_
 from sqlalchemy.orm import Session
 
 from app.servers.models import Server, ServerType, Template
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 logger = logging.getLogger(__name__)
 

--- a/app/services/visibility_service.py
+++ b/app/services/visibility_service.py
@@ -17,7 +17,8 @@ from app.core.visibility import (
     ResourceVisibility,
     VisibilityType,
 )
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 logger = logging.getLogger(__name__)
 

--- a/app/users/adapters/repository.py
+++ b/app/users/adapters/repository.py
@@ -16,7 +16,8 @@ from app.users.domain.entities import (
     UpdateUserCommand,
     UserEntity,
 )
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 def _user_to_entity(u: User) -> UserEntity:

--- a/app/users/application/service.py
+++ b/app/users/application/service.py
@@ -21,7 +21,7 @@ from app.users.domain.entities import (
     UserEntity,
 )
 from app.users.domain.ports import UsersUnitOfWork
-from app.users.models import Role
+from app.users.domain.value_objects import Role
 
 # The password hasher is a pure CPU operation with no I/O — its presence
 # in the application layer does not violate the framework-isolation rule.

--- a/app/users/domain/__init__.py
+++ b/app/users/domain/__init__.py
@@ -2,11 +2,4 @@
 
 Contains pure domain entities, value objects, and Port (Protocol) definitions.
 Must not import any framework, database driver, or HTTP client.
-
-**Known pilot deviation** (same as `app/versions/`): `Role` is imported
-from `app.users.models`, which transitively loads SQLAlchemy. `Role` is
-itself a stdlib `enum.Enum` so the surface stays framework-free; the
-side-effect cleanup happens when the `users/` model file is split between
-`domain/value_objects.py` and `adapters/models.py` (deferred to a
-follow-up). See `docs/ARCHITECTURE.md` §4.1.
 """

--- a/app/users/domain/entities.py
+++ b/app/users/domain/entities.py
@@ -1,16 +1,14 @@
 """Pure domain entities for the users module.
 
 These dataclasses are the language the application layer speaks. They have
-no SQLAlchemy, Pydantic, FastAPI, or any framework dependency beyond
-`Role` (a stdlib `enum.Enum` whose import-site happens to be the ORM
-module — see `__init__.py`).
+no SQLAlchemy, Pydantic, FastAPI, or any framework dependency.
 """
 
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
 
-from app.users.models import Role
+from app.users.domain.value_objects import Role
 
 
 @dataclass(frozen=True)

--- a/app/users/domain/ports.py
+++ b/app/users/domain/ports.py
@@ -21,7 +21,7 @@ from app.users.domain.entities import (
     UpdateUserCommand,
     UserEntity,
 )
-from app.users.models import Role
+from app.users.domain.value_objects import Role
 
 
 class UserRepository(Protocol):

--- a/app/users/domain/value_objects.py
+++ b/app/users/domain/value_objects.py
@@ -1,0 +1,14 @@
+"""Domain-pure value objects for the users module.
+
+Per `docs/ARCHITECTURE.md` §4.1, this module must not import from any
+framework, database driver, or HTTP client. Only the Python standard
+library is allowed.
+"""
+
+import enum
+
+
+class Role(enum.Enum):
+    admin = "admin"
+    operator = "operator"
+    user = "user"

--- a/app/users/models.py
+++ b/app/users/models.py
@@ -1,4 +1,3 @@
-import enum
 from datetime import datetime, timezone
 
 from sqlalchemy import Boolean, Column, DateTime, Enum, ForeignKey, Integer, String, Text
@@ -6,12 +5,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
 from app.core.database import Base
-
-
-class Role(enum.Enum):
-    admin = "admin"
-    operator = "operator"
-    user = "user"
+from app.users.domain.value_objects import Role
 
 
 class User(Base):

--- a/app/versions/api/router.py
+++ b/app/versions/api/router.py
@@ -11,7 +11,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.auth.dependencies import get_current_user
 from app.servers.models import ServerType
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 from app.versions.api.dependencies import get_version_service
 from app.versions.application.service import VersionUpdateService
 from app.versions.domain.entities import MinecraftVersionEntity

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,8 @@ from app.core.database import Base, get_db  # noqa: E402
 from app.main import app  # noqa: E402
 from app.users.adapters.uow import SqlAlchemyUsersUnitOfWork  # noqa: E402
 from app.users.application.service import UserService  # noqa: E402
-from app.users.models import Role, User  # noqa: E402
+from app.users.domain.value_objects import Role  # noqa: E402
+from app.users.models import User  # noqa: E402
 
 SQLALCHEMY_DATABASE_URL = f"sqlite:///{test_db_path}"
 

--- a/tests/infrastructure/test_parallel_execution_isolation.py
+++ b/tests/infrastructure/test_parallel_execution_isolation.py
@@ -37,7 +37,8 @@ def test_test_isolation_simple_data(db):
     """テスト間でのデータ分離を確認（シンプルテスト1）"""
     from passlib.context import CryptContext
 
-    from app.users.models import Role, User
+    from app.users.domain.value_objects import Role
+    from app.users.models import User
 
     pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto", bcrypt__rounds=4)
 
@@ -62,7 +63,8 @@ def test_test_isolation_different_data(db):
     """テスト間でのデータ分離を確認（シンプルテスト2）"""
     from passlib.context import CryptContext
 
-    from app.users.models import Role, User
+    from app.users.domain.value_objects import Role
+    from app.users.models import User
 
     pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto", bcrypt__rounds=4)
 

--- a/tests/integration/api/test_backup_router_comprehensive.py
+++ b/tests/integration/api/test_backup_router_comprehensive.py
@@ -12,7 +12,8 @@ from app.core.exceptions import (
     ServerNotFoundException,
 )
 from app.servers.models import Backup, BackupStatus, BackupType, Server, ServerType
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 def get_auth_headers(username: str):

--- a/tests/integration/api/test_backup_scheduler_api_permissions.py
+++ b/tests/integration/api/test_backup_scheduler_api_permissions.py
@@ -6,7 +6,8 @@ from app.auth.auth import create_access_token
 from app.backups.models import BackupSchedule
 from app.main import app
 from app.servers.models import Server
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 class TestBackupSchedulerAPIPermissions:

--- a/tests/integration/audit/test_audit_repository.py
+++ b/tests/integration/audit/test_audit_repository.py
@@ -20,7 +20,8 @@ from app.audit.adapters.repository import (
 )
 from app.audit.domain.entities import AuditEventCommand, LogFilters
 from app.audit.models import AuditLog
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 @pytest.fixture

--- a/tests/integration/test_database_version_integration.py
+++ b/tests/integration/test_database_version_integration.py
@@ -14,7 +14,8 @@ from app.core.exceptions import FileOperationException
 from app.servers.models import ServerType
 from app.servers.schemas import ServerCreateRequest
 from app.servers.service import ServerJarService, ServerService
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 from app.versions.models import MinecraftVersion
 
 

--- a/tests/integration/test_refresh_token.py
+++ b/tests/integration/test_refresh_token.py
@@ -6,7 +6,8 @@ from sqlalchemy.orm import Session
 
 from app.auth.adapters.uow import SqlAlchemyAuthUnitOfWork
 from app.auth.application.service import AuthService
-from app.users.models import RefreshToken, Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import RefreshToken, User
 
 
 def _make_auth_service(db: Session) -> AuthService:

--- a/tests/integration/users/test_user_repository.py
+++ b/tests/integration/users/test_user_repository.py
@@ -10,7 +10,8 @@ import pytest
 
 from app.users.adapters.repository import SqlAlchemyUserRepository
 from app.users.domain.entities import CreateUserCommand, UpdateUserCommand
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 @pytest.fixture
@@ -134,9 +135,7 @@ async def test_update_sparse(repository, existing_user, db):
 
 @pytest.mark.asyncio
 async def test_update_missing_returns_none(repository):
-    assert (
-        await repository.update(9999, UpdateUserCommand(email="x@example.com")) is None
-    )
+    assert await repository.update(9999, UpdateUserCommand(email="x@example.com")) is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/models/test_backup_schedule_models.py
+++ b/tests/unit/models/test_backup_schedule_models.py
@@ -4,7 +4,8 @@ from sqlalchemy.orm import Session
 
 from app.backups.models import BackupSchedule, BackupScheduleLog, ScheduleAction
 from app.servers.models import Server
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 class TestBackupScheduleModel:

--- a/tests/unit/servers/test_control_router.py
+++ b/tests/unit/servers/test_control_router.py
@@ -19,7 +19,8 @@ from app.servers.routers.control import (
     stop_server,
 )
 from app.servers.schemas import ServerCommandRequest
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 class TestServerControlRouter:

--- a/tests/unit/servers/test_port_synchronization.py
+++ b/tests/unit/servers/test_port_synchronization.py
@@ -13,7 +13,8 @@ from app.servers.models import Server, ServerStatus, ServerType
 from app.servers.schemas import ServerUpdateRequest
 from app.servers.service import server_service
 from app.services.minecraft_server import minecraft_server_manager
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 @pytest.fixture

--- a/tests/unit/servers/test_service.py
+++ b/tests/unit/servers/test_service.py
@@ -24,7 +24,8 @@ from app.servers.service import (
     ServerTemplateService,
     ServerValidationService,
 )
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 class TestServerSecurityValidator:

--- a/tests/unit/servers/test_simplified_sync.py
+++ b/tests/unit/servers/test_simplified_sync.py
@@ -13,7 +13,8 @@ from app.servers.models import Server, ServerStatus, ServerType
 from app.servers.schemas import ServerUpdateRequest
 from app.servers.service import server_service
 from app.services.simplified_sync import simplified_sync_service
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 @pytest.fixture

--- a/tests/unit/services/test_authorization_service.py
+++ b/tests/unit/services/test_authorization_service.py
@@ -13,7 +13,8 @@ from sqlalchemy.orm import Session
 
 from app.servers.models import Backup, Server, ServerStatus, ServerType
 from app.services.authorization_service import AuthorizationService, authorization_service
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 @pytest.fixture

--- a/tests/unit/services/test_authorization_service_phase2.py
+++ b/tests/unit/services/test_authorization_service_phase2.py
@@ -16,7 +16,8 @@ from app.core.visibility import (
     VisibilityType,
 )
 from app.services.authorization_service import AuthorizationService
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 class TestAuthorizationServicePhase2Visibility:

--- a/tests/unit/services/test_backup_schedule_service.py
+++ b/tests/unit/services/test_backup_schedule_service.py
@@ -5,7 +5,8 @@ from sqlalchemy.orm import Session
 
 from app.backups.models import BackupSchedule, BackupScheduleLog, ScheduleAction
 from app.servers.models import Server
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 class TestBackupScheduleService:

--- a/tests/unit/services/test_file_management_service.py
+++ b/tests/unit/services/test_file_management_service.py
@@ -11,7 +11,8 @@ from app.core.exceptions import (
 )
 from app.servers.models import Server
 from app.services.file_management_service import file_management_service
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 class TestFileManagementService:

--- a/tests/unit/services/test_phase1_compliance.py
+++ b/tests/unit/services/test_phase1_compliance.py
@@ -17,7 +17,8 @@ from sqlalchemy.orm import Session
 
 from app.servers.models import Server, ServerStatus, ServerType
 from app.services.authorization_service import AuthorizationService
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 class TestPhase1ComplianceBasicOperations:

--- a/tests/unit/services/test_server_service.py
+++ b/tests/unit/services/test_server_service.py
@@ -5,7 +5,8 @@ from fastapi import HTTPException
 
 from app.servers.models import Server, ServerStatus, ServerType
 from app.services.server_service import ServerService, server_service
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 class TestServerService:

--- a/tests/unit/services/test_template_service.py
+++ b/tests/unit/services/test_template_service.py
@@ -18,7 +18,8 @@ from app.services.template_service import (
     TemplateService,
     template_service,
 )
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 class TestTemplateServiceEnhancedCoverage:

--- a/tests/unit/services/test_user_service.py
+++ b/tests/unit/services/test_user_service.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi import HTTPException
 
-from app.users.models import Role
+from app.users.domain.value_objects import Role
 
 
 class TestUserService:

--- a/tests/unit/services/test_visibility_service.py
+++ b/tests/unit/services/test_visibility_service.py
@@ -17,7 +17,8 @@ from app.core.visibility import (
     VisibilityType,
 )
 from app.services.visibility_service import VisibilityService
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 class TestVisibilityServiceResourceAccess:
@@ -556,7 +557,7 @@ class TestVisibilityServiceEdgeCases:
 
     def test_role_hierarchy_edge_cases(self, visibility_service, db):
         """Test role hierarchy edge cases"""
-        from app.users.models import Role
+        from app.users.domain.value_objects import Role
 
         # Create users with different roles
         admin_user = User(id=1, role=Role.admin, username="admin", email="admin@test.com")

--- a/tests/unit/services/test_visibility_service_role_validation.py
+++ b/tests/unit/services/test_visibility_service_role_validation.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 
 from app.core.visibility import ResourceType, VisibilityType
 from app.services.visibility_service import VisibilityService
-from app.users.models import Role
+from app.users.domain.value_objects import Role
 
 
 class TestVisibilityServiceRoleValidation:

--- a/tests/unit/services/test_websocket_service_fixed.py
+++ b/tests/unit/services/test_websocket_service_fixed.py
@@ -15,7 +15,8 @@ from app.services.websocket_service import (
     WebSocketService,
     websocket_service,
 )
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 
 
 class TestConnectionManagerFixed:

--- a/tests/unit/users/fakes.py
+++ b/tests/unit/users/fakes.py
@@ -10,7 +10,7 @@ from app.users.domain.entities import (
     UpdateUserCommand,
     UserEntity,
 )
-from app.users.models import Role
+from app.users.domain.value_objects import Role
 
 
 class FakeUserRepository:
@@ -51,9 +51,7 @@ class FakeUserRepository:
     async def count_by_role(self, role: Role) -> int:
         return sum(1 for u in self._users.values() if u.role == role)
 
-    async def email_exists_for_other_user(
-        self, email: str, exclude_user_id: int
-    ) -> bool:
+    async def email_exists_for_other_user(self, email: str, exclude_user_id: int) -> bool:
         return any(
             u.email == email and u.id != exclude_user_id for u in self._users.values()
         )
@@ -99,9 +97,7 @@ class FakeUsersUnitOfWork:
     counts the call but does not unwind in-memory state.
     """
 
-    def __init__(
-        self, users: Optional[FakeUserRepository] = None
-    ) -> None:
+    def __init__(self, users: Optional[FakeUserRepository] = None) -> None:
         self.users: FakeUserRepository = users or FakeUserRepository()
         self.committed = 0
         self.rolled_back = 0

--- a/tests/unit/users/test_service_with_fake.py
+++ b/tests/unit/users/test_service_with_fake.py
@@ -9,7 +9,7 @@ from fastapi import HTTPException
 
 from app.users.application.service import UserService, pwd_context
 from app.users.domain.entities import UserEntity
-from app.users.models import Role
+from app.users.domain.value_objects import Role
 from tests.unit.users.fakes import FakeUsersUnitOfWork
 
 

--- a/tests/unit/websockets/test_router.py
+++ b/tests/unit/websockets/test_router.py
@@ -10,7 +10,8 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from fastapi import HTTPException, WebSocket
 
-from app.users.models import Role, User
+from app.users.domain.value_objects import Role
+from app.users.models import User
 from app.websockets.router import (
     websocket_notifications,
     websocket_server_logs,


### PR DESCRIPTION
## Summary

- `Role` enum moved from `app/users/models.py` (which transitively loads SQLAlchemy) to a new stdlib-only module `app/users/domain/value_objects.py`, so `app/users/domain/` no longer depends on the ORM module.
- ~45 callsites across `app/` and `tests/` updated to import `Role` from `app.users.domain.value_objects`.
- Pilot-deviation docstrings removed from `app/users/domain/__init__.py` and `app/users/domain/entities.py`.

`models.py` still imports `Role` (one line) for its SQLAlchemy `Enum` column — that's a unidirectional adapter → domain reference, which is the intended direction per `docs/ARCHITECTURE.md` §4.1.

## Scope

This PR addresses the **`Role` half** of #235, per the issue's recommended approach B. The `ServerType` half is deferred to land alongside #228 (servers domain repository introduction), since `app/servers/domain/` does not exist yet.

## Definition of Done (issue #235, partial)

- [x] `Role` defined in a domain-pure module (`app/users/domain/value_objects.py`)
- [x] `app/users/domain/__init__.py` deviation note removed
- [x] No `app/users/domain/` file imports from `app/users/models.py`
- [x] `just lint` / `mypy app/users/` / unit + integration smoke tests pass
- [ ] `ServerType` relocation — deferred to #228

## Test plan

- [x] `uv run ruff check app/ tests/` — no new errors (baseline 36 unchanged)
- [x] `uv run ruff format app/ tests/` — clean
- [x] `uv run mypy app/users/` — Success
- [x] `uv run pytest tests/unit -m "not slow"` — 1168 passed, 2 skipped
- [x] `uv run pytest tests/integration -m "not slow"` — 259 passed, 5 skipped
- [x] Pre-commit hooks pass (ruff, ruff format, pytest smoke, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)