### PR TITLE
fix: TOCTOU on file_history version_number + port-conflict regression (PR 2a/?, #228)

### DIFF
--- a/app/core/database_utils.py
+++ b/app/core/database_utils.py
@@ -206,6 +206,78 @@ def batch_query(
     return results
 
 
+def migrate_file_history_unique_index(engine: Any) -> None:
+    """Idempotent migration: ensure `uq_file_edit_history_server_path_version`
+    is present on `file_edit_history (server_id, file_path, version_number)`.
+
+    Behaviour:
+    1. SELECT existing duplicate rows. If any are found, log a
+       maintainer-actionable error listing the first 10 offenders and
+       raise `RuntimeError` to abort startup before any DDL is issued
+       — installing a UNIQUE index on a table with duplicates would
+       fail anyway, but failing fast with a readable message saves
+       operators from chasing a cryptic SQLite/MySQL error.
+    2. If no duplicates exist, execute
+       `CREATE UNIQUE INDEX IF NOT EXISTS` so the migration is safe
+       to re-run on already-migrated databases.
+
+    Called once during application startup, immediately after
+    `Base.metadata.create_all`.
+    """
+    from sqlalchemy import text
+
+    with engine.connect() as conn:
+        # Pre-check: detect any existing duplicate (server_id, file_path,
+        # version_number) tuples that would block the unique index.
+        dup_check = conn.execute(
+            text(
+                "SELECT server_id, file_path, version_number, COUNT(*) AS cnt "
+                "FROM file_edit_history "
+                "GROUP BY server_id, file_path, version_number "
+                "HAVING COUNT(*) > 1 "
+                "LIMIT 10"
+            )
+        ).fetchall()
+
+        if dup_check:
+            sample = "\n".join(
+                f"  server_id={row[0]}, file_path={row[1]!r}, "
+                f"version_number={row[2]}, count={row[3]}"
+                for row in dup_check
+            )
+            error_msg = (
+                "Cannot create UNIQUE INDEX on file_edit_history: existing "
+                "duplicate rows detected.\n"
+                "Maintainer action required: manually deduplicate before "
+                "next deploy.\n"
+                "Affected rows (first 10):\n"
+                f"{sample}\n\n"
+                "Suggested inspection query:\n"
+                "  SELECT * FROM file_edit_history\n"
+                "   WHERE (server_id, file_path, version_number) IN (\n"
+                "     SELECT server_id, file_path, version_number\n"
+                "       FROM file_edit_history\n"
+                "      GROUP BY server_id, file_path, version_number\n"
+                "      HAVING COUNT(*) > 1\n"
+                "   );\n"
+            )
+            logger.error(error_msg)
+            raise RuntimeError(
+                "file_edit_history contains duplicate (server_id, file_path, "
+                "version_number) rows; migration aborted"
+            )
+
+        # No duplicates — safe to (re)create the unique index.
+        conn.execute(
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS "
+                "uq_file_edit_history_server_path_version "
+                "ON file_edit_history (server_id, file_path, version_number)"
+            )
+        )
+        conn.commit()
+
+
 def safe_commit(session: Session, raise_on_error: bool = False) -> bool:
     """
     Safely commit a session with proper error handling.

--- a/app/core/database_utils.py
+++ b/app/core/database_utils.py
@@ -240,17 +240,35 @@ def migrate_file_history_unique_index(engine: Any) -> None:
         ).fetchall()
 
         if dup_check:
+            # Total distinct duplicate-key groups, so the operator-facing
+            # message can report "showing first 10 of N" instead of just
+            # the first slice (operators were anchoring on the sample
+            # length and underestimating the scope of the cleanup).
+            total_dup_count = (
+                conn.execute(
+                    text(
+                        "SELECT COUNT(*) FROM ("
+                        "  SELECT 1 FROM file_edit_history"
+                        "   GROUP BY server_id, file_path, version_number"
+                        "  HAVING COUNT(*) > 1"
+                        ") AS dup_groups"
+                    )
+                ).scalar()
+                or 0
+            )
+
             sample = "\n".join(
                 f"  server_id={row[0]}, file_path={row[1]!r}, "
                 f"version_number={row[2]}, count={row[3]}"
                 for row in dup_check
             )
+            shown = min(len(dup_check), total_dup_count)
             error_msg = (
-                "Cannot create UNIQUE INDEX on file_edit_history: existing "
-                "duplicate rows detected.\n"
+                f"Cannot create UNIQUE INDEX on file_edit_history: "
+                f"{total_dup_count} duplicate row group(s) detected.\n"
                 "Maintainer action required: manually deduplicate before "
                 "next deploy.\n"
-                "Affected rows (first 10):\n"
+                f"Affected rows (showing first {shown} of {total_dup_count}):\n"
                 f"{sample}\n\n"
                 "Suggested inspection query:\n"
                 "  SELECT * FROM file_edit_history\n"

--- a/app/files/adapters/repository.py
+++ b/app/files/adapters/repository.py
@@ -120,6 +120,24 @@ class SqlAlchemyFileHistoryRepository:
         )
         return latest or 0
 
+    async def reserve_next_version_number(self, server_id: int, file_path: str) -> int:
+        """Return the next available version number for the given key.
+
+        Wraps `MAX(version_number) + 1` via `COALESCE` so an empty
+        result set yields `1`. Caller must be inside an active UoW
+        transaction; the surrounding UNIQUE constraint catches any
+        race that slips between this read and the corresponding INSERT.
+        """
+        max_version = (
+            self.db.query(func.coalesce(func.max(FileEditHistory.version_number), 0))
+            .filter(
+                FileEditHistory.server_id == server_id,
+                FileEditHistory.file_path == file_path,
+            )
+            .scalar()
+        )
+        return int(max_version or 0) + 1
+
     async def get_excess_versions(
         self, server_id: int, file_path: str, keep: int
     ) -> List[FileHistoryEntity]:

--- a/app/files/application/service.py
+++ b/app/files/application/service.py
@@ -40,6 +40,36 @@ _VERSION_RESERVATION_RETRIES = 3
 _VERSION_UNIQUE_INDEX_NAME = "uq_file_edit_history_server_path_version"
 
 
+def _is_version_unique_violation(e: IntegrityError) -> bool:
+    """Detect that an `IntegrityError` stems from the file_edit_history
+    UNIQUE constraint on `(server_id, file_path, version_number)`.
+
+    Works for both SQLite and Postgres/MySQL:
+
+    - **Postgres / MySQL** name the constraint in the error message, so
+      the index name (`uq_file_edit_history_server_path_version`)
+      appears verbatim.
+    - **SQLite** only reports the affected columns, e.g.::
+
+          UNIQUE constraint failed: file_edit_history.server_id,
+              file_edit_history.file_path,
+              file_edit_history.version_number
+
+      so we additionally match the column-list shape. Without this
+      branch the retry loop never engages on SQLite — which is the
+      development and test default dialect — and the regression that
+      motivated PR #266 silently re-appears.
+    """
+    err_text = str(e.orig) + " " + str(e)
+    if _VERSION_UNIQUE_INDEX_NAME in err_text:
+        return True
+    return (
+        "UNIQUE constraint failed" in err_text
+        and "file_edit_history" in err_text
+        and "version_number" in err_text
+    )
+
+
 class FileHistoryService:
     """Use cases over the file-history catalogue.
 
@@ -205,9 +235,9 @@ class FileHistoryService:
                             f"{backup_file_path}: {unlink_err}"
                         )
                 if (
-                    _VERSION_UNIQUE_INDEX_NAME in str(e.orig)
-                    or _VERSION_UNIQUE_INDEX_NAME in str(e)
-                ) and attempt < _VERSION_RESERVATION_RETRIES - 1:
+                    _is_version_unique_violation(e)
+                    and attempt < _VERSION_RESERVATION_RETRIES - 1
+                ):
                     logger.warning(
                         f"TOCTOU collision on version_number for "
                         f"{normalized_path} (attempt {attempt + 1}/"

--- a/app/files/application/service.py
+++ b/app/files/application/service.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 
 import aiofiles
+from sqlalchemy.exc import IntegrityError
 
 from app.core.datetime_utils import utcnow
 from app.core.exceptions import (
@@ -31,6 +32,12 @@ from app.files.domain.ports import FilesUnitOfWork
 from app.servers.domain.ports import ServerReadPort
 
 logger = logging.getLogger(__name__)
+
+# Maximum attempts when retrying after a TOCTOU collision on
+# file_edit_history.version_number. Three attempts cover any realistic
+# concurrent-writer pile-up; beyond that we surface the IntegrityError.
+_VERSION_RESERVATION_RETRIES = 3
+_VERSION_UNIQUE_INDEX_NAME = "uq_file_edit_history_server_path_version"
 
 
 class FileHistoryService:
@@ -74,6 +81,14 @@ class FileHistoryService:
 
         Returns the persisted entity, or `None` if the content matches
         the latest version (no backup was created).
+
+        Concurrency: reserve-and-insert of `version_number` is wrapped
+        in a single UoW with retries. The UNIQUE constraint
+        `uq_file_edit_history_server_path_version` is the final guard
+        against the TOCTOU race between two writers reserving the same
+        number simultaneously. Each retry recomputes the version number
+        and writes a new on-disk backup file (orphans from the prior
+        attempt are unlinked best-effort).
         """
         try:
             normalized_path = self._normalize_file_path(file_path)
@@ -82,41 +97,22 @@ class FileHistoryService:
             history_dir.mkdir(parents=True, exist_ok=True)
 
             content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
-
-            async with self._uow as uow:
-                latest = await uow.files_history.get_latest(server_id, normalized_path)
-                if latest is not None and latest.content_hash == content_hash:
-                    logger.info(f"Skipping backup for {file_path} - content unchanged")
-                    return None
-
-                max_version = await uow.files_history.get_max_version_number(
-                    server_id, normalized_path
-                )
-                version_num = max_version + 1
-
-            file_extension = Path(normalized_path).suffix
-            timestamp = utcnow().strftime("%Y%m%d_%H%M%S")
-            backup_filename = f"v{version_num:03d}_{timestamp}{file_extension}"
-            backup_file_path = history_dir / backup_filename
-
-            async with aiofiles.open(backup_file_path, "w", encoding="utf-8") as f:
-                await f.write(content)
-
             file_size = len(content.encode("utf-8"))
-            command = CreateHistoryCommand(
+
+            entity, version_num = await self._reserve_and_persist(
                 server_id=server_id,
-                file_path=normalized_path,
-                version_number=version_num,
-                backup_file_path=str(backup_file_path),
-                file_size=file_size,
+                file_path=file_path,
+                normalized_path=normalized_path,
+                history_dir=history_dir,
+                content=content,
                 content_hash=content_hash,
-                editor_user_id=user_id,
+                file_size=file_size,
+                user_id=user_id,
                 description=description,
             )
-
-            async with self._uow as uow:
-                entity = await uow.files_history.add(command)
-                await uow.commit()
+            if entity is None:
+                # Content matched the latest version — nothing persisted.
+                return None
 
             await self._cleanup_excess_versions(server_id, normalized_path)
 
@@ -126,6 +122,105 @@ class FileHistoryService:
         except Exception as e:
             logger.error(f"Failed to create backup for {file_path}: {e}")
             raise FileOperationException("backup", file_path, str(e))
+
+    async def _reserve_and_persist(
+        self,
+        *,
+        server_id: int,
+        file_path: str,
+        normalized_path: str,
+        history_dir: Path,
+        content: str,
+        content_hash: str,
+        file_size: int,
+        user_id: Optional[int],
+        description: Optional[str],
+    ) -> Tuple[Optional[FileHistoryEntity], int]:
+        """Reserve next version + write backup file + INSERT row,
+        retrying on UNIQUE-constraint races.
+
+        Returns `(entity, version_num)`, or `(None, 0)` when the
+        latest stored version already matches `content_hash` (i.e.
+        no backup was created).
+        """
+        last_error: Optional[IntegrityError] = None
+        for attempt in range(_VERSION_RESERVATION_RETRIES):
+            backup_file_path: Optional[Path] = None
+            try:
+                async with self._uow as uow:
+                    # 1. Skip when the existing latest already matches.
+                    latest = await uow.files_history.get_latest(
+                        server_id, normalized_path
+                    )
+                    if latest is not None and latest.content_hash == content_hash:
+                        logger.info(
+                            f"Skipping backup for {file_path} - content unchanged"
+                        )
+                        return None, 0
+
+                    # 2. Reserve the version number inside the same tx.
+                    version_num = await uow.files_history.reserve_next_version_number(
+                        server_id, normalized_path
+                    )
+
+                    # 3. Write the backup file to disk. This happens
+                    # inside the UoW context but outside the SQL tx
+                    # itself; on retry we will unlink and rewrite.
+                    file_extension = Path(normalized_path).suffix
+                    timestamp = utcnow().strftime("%Y%m%d_%H%M%S")
+                    backup_filename = f"v{version_num:03d}_{timestamp}{file_extension}"
+                    backup_file_path = history_dir / backup_filename
+                    async with aiofiles.open(
+                        backup_file_path, "w", encoding="utf-8"
+                    ) as f:
+                        await f.write(content)
+
+                    # 4. Stage the INSERT — UNIQUE constraint catches
+                    # any concurrent writer that snuck in before us.
+                    command = CreateHistoryCommand(
+                        server_id=server_id,
+                        file_path=normalized_path,
+                        version_number=version_num,
+                        backup_file_path=str(backup_file_path),
+                        file_size=file_size,
+                        content_hash=content_hash,
+                        editor_user_id=user_id,
+                        description=description,
+                    )
+                    entity = await uow.files_history.add(command)
+                    await uow.commit()
+                    return entity, version_num
+
+            except IntegrityError as e:
+                last_error = e
+                # Best-effort cleanup of the orphan backup file from
+                # this failed attempt — the row never landed so the
+                # on-disk file is unreferenced.
+                if backup_file_path is not None:
+                    try:
+                        backup_file_path.unlink(missing_ok=True)
+                    except OSError as unlink_err:
+                        logger.warning(
+                            f"Failed to clean up orphan backup file "
+                            f"{backup_file_path}: {unlink_err}"
+                        )
+                if (
+                    _VERSION_UNIQUE_INDEX_NAME in str(e.orig)
+                    or _VERSION_UNIQUE_INDEX_NAME in str(e)
+                ) and attempt < _VERSION_RESERVATION_RETRIES - 1:
+                    logger.warning(
+                        f"TOCTOU collision on version_number for "
+                        f"{normalized_path} (attempt {attempt + 1}/"
+                        f"{_VERSION_RESERVATION_RETRIES}); retrying"
+                    )
+                    continue
+                raise
+
+        # Should not be reachable — the loop either returns or raises —
+        # but defensively re-raise the last error if it ever falls
+        # through. `assert` would be silently dropped under -O.
+        assert last_error is not None
+        raise last_error
 
     async def get_file_history(
         self,

--- a/app/files/domain/ports.py
+++ b/app/files/domain/ports.py
@@ -50,6 +50,23 @@ class FileHistoryRepository(Protocol):
 
     async def get_max_version_number(self, server_id: int, file_path: str) -> int: ...
 
+    async def reserve_next_version_number(self, server_id: int, file_path: str) -> int:
+        """Compute the next available `version_number` for the given
+        (server_id, file_path).
+
+        Callers MUST use this inside an active `FilesUnitOfWork`
+        transaction. The returned value is race-free at the time of
+        CALL, but the surrounding UoW commit may still raise
+        `IntegrityError` if a concurrent writer reserves the same
+        number first — the UNIQUE constraint
+        `uq_file_edit_history_server_path_version` is the final guard.
+
+        Application code is expected to catch that `IntegrityError`
+        and retry. See `FileHistoryService.create_version_backup`
+        for the canonical retry pattern.
+        """
+        ...
+
     async def get_excess_versions(
         self, server_id: int, file_path: str, keep: int
     ) -> List[FileHistoryEntity]: ...

--- a/app/files/models.py
+++ b/app/files/models.py
@@ -2,7 +2,16 @@
 File edit history models for tracking file changes.
 """
 
-from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import relationship
 
 from app.core.database import Base
@@ -13,6 +22,18 @@ class FileEditHistory(Base):
     """File edit history tracking model"""
 
     __tablename__ = "file_edit_history"
+    __table_args__ = (
+        # Guards the TOCTOU race in `reserve_next_version_number` →
+        # `add`. Two concurrent writers could each compute the same
+        # MAX+1; the surrounding application-layer retry catches the
+        # `IntegrityError` raised on commit.
+        UniqueConstraint(
+            "server_id",
+            "file_path",
+            "version_number",
+            name="uq_file_edit_history_server_path_version",
+        ),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     server_id = Column(

--- a/app/main.py
+++ b/app/main.py
@@ -116,6 +116,15 @@ async def _initialize_database():
     try:
         logger.info("Initializing database tables...")
         Base.metadata.create_all(bind=engine)
+
+        # Idempotent migration: add UNIQUE index protecting
+        # file_edit_history.version_number against TOCTOU races.
+        # Aborts startup if pre-existing duplicates are detected so
+        # operators can deduplicate before retrying.
+        from app.core.database_utils import migrate_file_history_unique_index
+
+        migrate_file_history_unique_index(engine)
+
         service_status.database_ready = True
         logger.info("Database tables initialized successfully")
     except Exception as e:

--- a/app/servers/routers/import_export.py
+++ b/app/servers/routers/import_export.py
@@ -17,12 +17,13 @@ from fastapi import (
     status,
 )
 from fastapi.responses import FileResponse
-from sqlalchemy import and_
 from sqlalchemy.orm import Session
 
 from app.auth.dependencies import get_current_user
 from app.core.database import get_db
-from app.servers.models import Server, ServerStatus, ServerType
+from app.servers.api.dependencies import get_server_repository
+from app.servers.domain.ports import ServerRepository
+from app.servers.models import ServerStatus, ServerType
 from app.servers.schemas import (
     ServerCreateRequest,
     ServerImportRequest,
@@ -155,6 +156,7 @@ async def import_server(
     background_tasks: BackgroundTasks = None,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
+    server_repo: ServerRepository = Depends(get_server_repository),
 ):
     """
     Import a server from an exported ZIP file
@@ -241,18 +243,19 @@ async def import_server(
                         detail=f"Invalid export file: missing {field} in metadata",
                     )
 
-            # Find available port (only check running servers)
-            used_ports = (
-                db.query(Server.port)
-                .filter(
-                    and_(
-                        not Server.is_deleted,
-                        Server.status.in_([ServerStatus.running, ServerStatus.starting]),
-                    )
-                )
-                .all()
+            # Find available port (only check running servers).
+            # Previous implementation applied Python's `not` to the
+            # SQLAlchemy is_deleted Column, which always evaluates to
+            # False, so `used_ports` was permanently empty and port
+            # 25565 was always offered even when occupied. Route
+            # through the Server Repository's
+            # `list_by_port(port=None, statuses=...)` which excludes
+            # soft-deleted rows by default.
+            used_servers = await server_repo.list_by_port(
+                port=None,
+                statuses=[ServerStatus.running, ServerStatus.starting],
             )
-            used_ports = {port[0] for port in used_ports}
+            used_ports = {s.port for s in used_servers}
 
             port = 25565
             while port in used_ports:

--- a/tests/integration/files/test_toctou.py
+++ b/tests/integration/files/test_toctou.py
@@ -1,0 +1,166 @@
+"""TOCTOU / migration tests for `file_edit_history.version_number`.
+
+Covers:
+- Concurrent writers racing through `create_version_backup` do not
+  produce duplicate `(server_id, file_path, version_number)` rows
+  thanks to the UNIQUE constraint + application-layer retry.
+- `migrate_file_history_unique_index` pre-checks for existing
+  duplicate rows and aborts startup with a maintainer-actionable error
+  instead of issuing DDL that would fail with a cryptic driver error.
+"""
+
+import asyncio
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from app.core.database import Base
+from app.core.database_utils import migrate_file_history_unique_index
+from app.files.adapters.uow import SqlAlchemyFilesUnitOfWork
+from app.files.application.service import FileHistoryService
+from app.files.models import FileEditHistory
+from app.servers.adapters.read_port import SqlAlchemyServerReadPort
+from app.servers.models import Server, ServerStatus, ServerType
+
+
+@pytest.fixture
+def server(db, admin_user) -> Server:
+    s = Server(
+        name="TOCTOU Test Server",
+        description="for file-history TOCTOU tests",
+        minecraft_version="1.20.1",
+        server_type=ServerType.vanilla,
+        status=ServerStatus.stopped,
+        directory_path="./servers/toctou",
+        port=25700,
+        max_memory=1024,
+        max_players=20,
+        owner_id=admin_user.id,
+    )
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    return s
+
+
+@pytest.mark.asyncio
+async def test_concurrent_create_version_backup_no_duplicates(
+    db, tmp_path, server, admin_user
+):
+    """20 concurrent writers share a session — they must produce
+    distinct version numbers (no duplicate rows), and either succeed
+    or raise after exhausting retries. The UNIQUE constraint plus the
+    in-service retry are the only safety net.
+    """
+    # Build one service per writer, each with its own UoW bound to the
+    # same SQLite session (matches per-request DI shape in production).
+    uow = SqlAlchemyFilesUnitOfWork(db=db)
+    server_read = SqlAlchemyServerReadPort(db=db)
+    service = FileHistoryService(
+        uow=uow,
+        server_read=server_read,
+        history_base_dir=tmp_path,
+        max_versions_per_file=1000,
+        auto_cleanup_days=999,
+    )
+
+    async def writer(i: int):
+        try:
+            return await service.create_version_backup(
+                server_id=server.id,
+                file_path="server.properties",
+                content=f"writer-{i}-content",
+                user_id=admin_user.id,
+                description=f"writer-{i}",
+            )
+        except Exception as e:  # pragma: no cover - surfaced in assertions
+            return e
+
+    results = await asyncio.gather(*(writer(i) for i in range(20)))
+
+    # No duplicate version_numbers landed.
+    rows = (
+        db.query(FileEditHistory)
+        .filter_by(server_id=server.id, file_path="server.properties")
+        .all()
+    )
+    version_numbers = [r.version_number for r in rows]
+    assert len(version_numbers) == len(set(version_numbers)), (
+        f"Duplicate version numbers persisted: {version_numbers}"
+    )
+
+    # SQLite + a shared synchronous session serialises writes, so at
+    # least one writer must succeed; we keep the assertion permissive
+    # because the retry policy may legitimately surface IntegrityError
+    # to a few writers under contention.
+    successful = [r for r in results if not isinstance(r, Exception)]
+    assert successful, "Expected at least one writer to persist a backup"
+
+
+@pytest.mark.asyncio
+async def test_migrate_aborts_on_existing_duplicates(tmp_path):
+    """`migrate_file_history_unique_index` must reject a table that
+    already contains duplicate `(server_id, file_path, version_number)`
+    rows so operators can deduplicate before re-running deploy.
+
+    We hand-build a `file_edit_history` table *without* the UNIQUE
+    constraint so we can seed the duplicates. SQLite cannot DROP a
+    table-level UNIQUE constraint after the fact, so building the
+    schema manually is simpler than tearing it down.
+    """
+    db_path = tmp_path / "dup.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+    )
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE TABLE file_edit_history ("
+                    "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                    "  server_id INTEGER NOT NULL,"
+                    "  file_path VARCHAR(500) NOT NULL,"
+                    "  version_number INTEGER NOT NULL,"
+                    "  backup_file_path VARCHAR(500) NOT NULL,"
+                    "  file_size BIGINT NOT NULL,"
+                    "  content_hash VARCHAR(64),"
+                    "  editor_user_id INTEGER,"
+                    "  created_at DATETIME NOT NULL,"
+                    "  description TEXT"
+                    ")"
+                )
+            )
+            for _ in range(2):
+                conn.execute(
+                    text(
+                        "INSERT INTO file_edit_history "
+                        "(server_id, file_path, version_number, "
+                        " backup_file_path, file_size, content_hash, "
+                        " editor_user_id, created_at) "
+                        "VALUES (1, 'x.txt', 1, '/tmp/x', 10, NULL, "
+                        " NULL, CURRENT_TIMESTAMP)"
+                    )
+                )
+
+        with pytest.raises(RuntimeError, match="duplicate"):
+            migrate_file_history_unique_index(engine)
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_migrate_is_idempotent_on_clean_table(tmp_path):
+    """Running the migration twice in a row is a no-op on a clean
+    table — the second call must not raise."""
+    db_path = tmp_path / "clean.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+    )
+    try:
+        Base.metadata.create_all(bind=engine)
+        migrate_file_history_unique_index(engine)
+        migrate_file_history_unique_index(engine)
+    finally:
+        engine.dispose()

--- a/tests/integration/files/test_toctou.py
+++ b/tests/integration/files/test_toctou.py
@@ -164,3 +164,100 @@ async def test_migrate_is_idempotent_on_clean_table(tmp_path):
         migrate_file_history_unique_index(engine)
     finally:
         engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_toctou_retry_fires_on_sqlite_unique_violation(
+    db, tmp_path, server, admin_user, monkeypatch
+):
+    """Regression: the retry loop must engage when SQLite reports a
+    UNIQUE-constraint failure on `file_edit_history`.
+
+    Reviewer feedback on PR #266 flagged that the original detector did
+    a substring match for the index name
+    `uq_file_edit_history_server_path_version`, which is fine for
+    Postgres/MySQL (they name the constraint in the error message) but
+    silently failed on SQLite — SQLite's message only lists the
+    columns:
+
+        UNIQUE constraint failed:
+            file_edit_history.server_id,
+            file_edit_history.file_path,
+            file_edit_history.version_number
+
+    With that substring-only matcher the retry path was effectively
+    dead code on the project's development & test dialect. This test
+    pins the SQLite shape by forcing `reserve_next_version_number` to
+    return a colliding value on the first attempt and the next free
+    one on the second; the persisted `version_number` and the call
+    count together prove (a) the IntegrityError was recognised as a
+    version-collision and (b) exactly one retry occurred.
+    """
+    from app.files.adapters.repository import SqlAlchemyFileHistoryRepository
+
+    # Pre-seed (server_id=server.id, file_path="x.txt", version_number=1)
+    # so that any insert reusing version_number=1 fails the UNIQUE check.
+    db.add(
+        FileEditHistory(
+            server_id=server.id,
+            file_path="x.txt",
+            version_number=1,
+            backup_file_path="/tmp/seed",
+            file_size=1,
+            content_hash="seed",
+            editor_user_id=admin_user.id,
+        )
+    )
+    db.commit()
+
+    counter = {"n": 0}
+    original_reserve = SqlAlchemyFileHistoryRepository.reserve_next_version_number
+
+    async def fake_reserve(self, server_id: int, file_path: str) -> int:
+        counter["n"] += 1
+        if counter["n"] == 1:
+            return 1  # collision with the seeded row
+        # Defer to the real implementation for subsequent attempts so
+        # we exercise the genuine MAX+1 path on retry.
+        return await original_reserve(self, server_id, file_path)
+
+    monkeypatch.setattr(
+        SqlAlchemyFileHistoryRepository,
+        "reserve_next_version_number",
+        fake_reserve,
+    )
+
+    uow = SqlAlchemyFilesUnitOfWork(db=db)
+    server_read = SqlAlchemyServerReadPort(db=db)
+    service = FileHistoryService(
+        uow=uow,
+        server_read=server_read,
+        history_base_dir=tmp_path,
+        max_versions_per_file=1000,
+        auto_cleanup_days=999,
+    )
+
+    result = await service.create_version_backup(
+        server_id=server.id,
+        file_path="x.txt",
+        content="retry-me",
+        user_id=admin_user.id,
+    )
+
+    assert result is not None, "Retry succeeded — second attempt should persist"
+    assert result.version_number == 2, (
+        "Second attempt must advance to the next free version number"
+    )
+    assert counter["n"] == 2, (
+        f"Expected exactly 2 reservations (collision + retry); got {counter['n']}"
+    )
+
+    # Both the seeded row and the retried insert should be present, with
+    # distinct version_numbers — no duplicates landed.
+    rows = (
+        db.query(FileEditHistory)
+        .filter_by(server_id=server.id, file_path="x.txt")
+        .order_by(FileEditHistory.version_number)
+        .all()
+    )
+    assert [r.version_number for r in rows] == [1, 2]

--- a/tests/unit/files/fakes.py
+++ b/tests/unit/files/fakes.py
@@ -73,6 +73,10 @@ class FakeFileHistoryRepository:
         latest = await self.get_latest(server_id, file_path)
         return latest.version_number if latest else 0
 
+    async def reserve_next_version_number(self, server_id: int, file_path: str) -> int:
+        """Mirror the SQL adapter's `MAX + 1` semantics in-memory."""
+        return await self.get_max_version_number(server_id, file_path) + 1
+
     async def get_excess_versions(
         self, server_id: int, file_path: str, keep: int
     ) -> List[FileHistoryEntity]:

--- a/tests/unit/servers/routers/test_import_export.py
+++ b/tests/unit/servers/routers/test_import_export.py
@@ -3,10 +3,26 @@ Essential test coverage for import_export router
 Focus on critical edge cases for improved coverage
 """
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi import HTTPException, UploadFile
+
+from app.servers.domain.ports import ServerRepository
+
+
+@pytest.fixture
+def mock_server_repo() -> AsyncMock:
+    """Defensive `ServerRepository` mock for import_server unit tests.
+
+    `import_server` accepts a `server_repo: ServerRepository =
+    Depends(get_server_repository)` parameter (added in PR #266 to
+    replace the broken port-conflict scan). When unit tests invoke the
+    handler directly they must supply this Port explicitly — otherwise
+    they implicitly rely on the FastAPI Depends default value, which
+    only resolves through the framework.
+    """
+    return AsyncMock(spec=ServerRepository)
 
 
 class TestImportExportRouter:
@@ -30,7 +46,7 @@ class TestImportExportRouter:
         assert "Failed to export server" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
-    async def test_import_server_file_too_large(self, admin_user):
+    async def test_import_server_file_too_large(self, admin_user, mock_server_repo):
         """Test import server with file size exceeding limit (176 line)"""
         from app.servers.routers.import_export import import_server
 
@@ -46,13 +62,16 @@ class TestImportExportRouter:
                 file=mock_file,
                 current_user=admin_user,
                 db=Mock(),
+                server_repo=mock_server_repo,
             )
 
         assert exc_info.value.status_code == 413
         assert "File too large" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
-    async def test_import_server_invalid_file_extension(self, admin_user):
+    async def test_import_server_invalid_file_extension(
+        self, admin_user, mock_server_repo
+    ):
         """Test import server with invalid file extension"""
         from app.servers.routers.import_export import import_server
 
@@ -68,6 +87,7 @@ class TestImportExportRouter:
                 file=mock_file,
                 current_user=admin_user,
                 db=Mock(),
+                server_repo=mock_server_repo,
             )
 
         assert exc_info.value.status_code == 400


### PR DESCRIPTION
## Summary

PR 2a of the Issue #228 split. Two bug fixes only — no refactor, no `db.query` cleanup.

1. **Punch-list A — TOCTOU on `file_edit_history.version_number`**: `FileHistoryService.create_version_backup` used two separate UoWs (read MAX → disk write → INSERT) which let concurrent writers race and produce duplicate rows.
   - New `FileHistoryRepository.reserve_next_version_number` Port method (+ SQLAlchemy adapter + in-memory Fake).
   - `UniqueConstraint("server_id", "file_path", "version_number")` added to `FileEditHistory`.
   - New `migrate_file_history_unique_index` helper wired into startup. **Pre-checks for existing duplicate rows and aborts startup with a maintainer-actionable error** before any DDL runs; otherwise issues `CREATE UNIQUE INDEX IF NOT EXISTS ...`, so it is safe to re-run on already-migrated databases.
   - `create_version_backup` collapsed to a single-UoW seam with up-to-3 retries on `IntegrityError` matching the unique index name. Orphan backup files from failed attempts are best-effort unlinked.

2. **H-3 real bug at `app/servers/routers/import_export.py:249`**: Python `not` on a SQLAlchemy Column always evaluates to `False`, so `used_ports` was permanently empty and port 25565 was always offered even when occupied. Replaced the whole query block with `await server_repo.list_by_port(port=None, statuses=[running, starting])`, wired through `Depends(get_server_repository)`.

### Behavioural notes

- **TOCTOU fix preserves legacy parity** when no race occurs: a single writer sees identical numbering.
- **Migration helper is safe**: aborts with an explicit operator-action message if duplicates exist.
- **H-3 fix changes behaviour**: legacy code silently bypassed port collisions; new code correctly excludes running ports. This is a bug fix, not a regression.

## Review fixups (commit 23465b1)

Addresses feedback on the initial commit:

- **SQLite UNIQUE-error detection (Concern #2 — Blocker-near)**: the substring-match on the index name `uq_file_edit_history_server_path_version` worked for Postgres/MySQL but silently failed on SQLite, which only reports affected columns in the error message. The retry loop was effectively dead code on the project's default dialect. Extracted `_is_version_unique_violation(e)` that matches both shapes; added `test_toctou_retry_fires_on_sqlite_unique_violation` regression test that forces a collision and asserts the retry advances `version_number` on SQLite.
- **Migration error message (Concern #7)**: the duplicate-row message now reports total group count (`Cannot create UNIQUE INDEX on file_edit_history: {N} duplicate row group(s) detected` and `Affected rows (showing first {shown} of {N})`) so operators know the cleanup scope.
- **Defensive `server_repo` arg in unit tests (Concern #6)**: `import_server` accepts a new `server_repo: ServerRepository = Depends(...)` parameter. Unit tests that invoke the handler directly must supply this Port explicitly; added a `mock_server_repo` fixture and threaded it through `test_import_export.py`.

## Follow-up issues

Filed for items intentionally deferred from this PR (kept the diff focused on the two reported bugs):

- #267 — `test: add true TOCTOU regression test for file_history with separate-session writers`. The shared-session test in this PR proves no duplicates land but does not actually exercise the UNIQUE constraint under contention. Tracks adding a per-writer `session_factory` (and optionally a Postgres-backed variant) so the race genuinely surfaces.
- #268 — `refactor: move file-specific migration helper to app/files/adapters/migrations.py`. The new `migrate_file_history_unique_index` is domain-specific but currently lives in cross-cutting `app/core/`; tracks moving it to `app/files/adapters/migrations.py` and establishing the same pattern for the other domains under #149.

### Acceptance gates (verified locally)

- [x] `rg -n 'not Server\.is_deleted' app/` → 0 hits
- [x] `rg -n 'reserve_next_version_number' app/files/` → 4 hits (Port + Adapter docs and impl)
- [x] `rg -n 'migrate_file_history_unique_index' app/` → 3 hits (definition + lifespan call + comment)
- [x] `rg -n '_is_version_unique_violation' app/files/application/service.py` → 2 hits (definition + use)
- [x] `uv run ruff check app/ tests/unit/files/ tests/unit/servers/routers/ tests/integration/files/` → clean
- [x] `uv run ruff format app/` → 201 files left unchanged
- [x] `uv run mypy app/files/ app/servers/ app/core/` → 0 errors
- [x] `uv run pytest tests/unit/files tests/integration/files -m "not slow"` → 45 passed
- [x] `uv run pytest tests/unit/servers/routers/test_import_export.py` → 5 passed
- [x] `uv run pytest tests/unit tests/integration -m "not slow"` → 1588 passed, 7 skipped
- [x] `uv run pre-commit run --all-files` → all hooks pass
- [x] `just test` → **1772 passed, 7 skipped in 2m 15s**

Refs #228 (PR 2a/?)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
