### PR TITLE
docs: clarify _LegacyGroupFacade cross-boundary import in test_legacy_shim (Resolves #277)

### DIFF
--- a/tests/unit/groups/test_legacy_shim.py
+++ b/tests/unit/groups/test_legacy_shim.py
@@ -7,9 +7,19 @@ The pre-#228 contract that the facade's `attach_server_to_group`
 attribute raise `NotImplementedError` has been removed because the
 latent bug it guarded was fixed in #228 PR 2c — the create-server
 flow now uses the correct `attach_group_to_server` call via DI.
+
+Note on the `_LegacyGroupFacade` import below: the underscore prefix is
+intentional. These tests verify the shim's *internal* contract — that
+`GroupService` is an alias to the facade class object itself, not merely
+a callable with matching behavior — so we must reach past the public
+`GroupService` alias to the underlying class. The symbol is listed in
+`legacy.__all__` precisely so this cross-boundary test import remains
+valid; do not "fix" it to the public alias.
 """
 
 from app.groups.application import legacy as shim_module
+
+# Intentional private import: shim contract verification (see module docstring).
 from app.groups.application.legacy import _LegacyGroupFacade
 from app.groups.domain.exceptions import (
     GroupAccessError,


### PR DESCRIPTION
## Summary
Document the intent behind the private `_LegacyGroupFacade` import in
`tests/unit/groups/test_legacy_shim.py` so future readers/reviewers do not
mistake it for a convention violation. Per discussion on #277, we keep the
underscore-prefixed symbol (no rename) and rely on docstring + comment to
convey intent.

Note: the issue body's premise that `_LegacyGroupFacade` is missing from
`__all__` is outdated — it's already listed in
`app/groups/application/legacy.py:__all__`. So no production-code change
is needed.

Resolves #277.

## Changes
- `tests/unit/groups/test_legacy_shim.py`
  - Module docstring extended with a paragraph explaining that the
    `_LegacyGroupFacade` import is an intentional cross-boundary access
    required to verify the shim's *identity* contract.
  - One-line inline comment above the import points back to the docstring.

## Test plan
- [x] `uv run pre-commit run --files tests/unit/groups/test_legacy_shim.py`
- [x] `uv run pytest tests/unit/groups/test_legacy_shim.py` (5/5 passed)
- [x] `uv run pytest tests/unit/groups -m "not slow"` (65/65 passed)