### PR TITLE
refactor(audit): remove unused db parameter from AuditService.log_* (Resolves #247)

### DIFF
--- a/app/audit/api/router.py
+++ b/app/audit/api/router.py
@@ -98,7 +98,6 @@ async def get_audit_logs(
         user_id = current_user.id
 
     AuditService.log_admin_action(
-        db=db,
         request=request,
         action="view_audit_logs",
         target_resource_type="audit_log",
@@ -148,7 +147,6 @@ async def get_security_alerts(
         )
 
     AuditService.log_admin_action(
-        db=db,
         request=request,
         action="view_security_alerts",
         target_resource_type="security_alert",
@@ -184,7 +182,6 @@ async def get_user_activity(
         raise HTTPException(status_code=404, detail="User not found")
 
     AuditService.log_admin_action(
-        db=db,
         request=request,
         action="view_user_activity",
         target_resource_type="user",
@@ -211,7 +208,6 @@ async def get_audit_statistics(
         )
 
     AuditService.log_admin_action(
-        db=db,
         request=request,
         action="view_audit_statistics",
         target_resource_type="audit_statistics",

--- a/app/audit/application/legacy_facade.py
+++ b/app/audit/application/legacy_facade.py
@@ -2,13 +2,13 @@
 
 The 30+ existing callers (in `app/auth/api/router.py`,
 `app/servers/routers/control.py`, `app/services/authorization_service.py`,
-and the audit router itself) invoke `AuditService.log_*(db=..., request=..., ...)`
+and the audit router itself) invoke `AuditService.log_*(request=..., ...)`
 synchronously. Migrating those callsites to FastAPI `Depends(AuditWriter)`
 is deferred to the per-domain refactors (#224-#228).
 
-Each `log_*` static method now builds a `SqlAlchemyAuditWriter` from
-`db` plus the request-scoped `AuditTracker` (preserves the middleware
-batch path) and delegates to `writer.record(...)`.
+Each `log_*` static method builds a `SqlAlchemyAuditWriter` from the
+request-scoped `AuditTracker` (preserves the middleware batch path)
+and delegates to `writer.record(...)`.
 
 The pre-#223 read methods (`get_audit_logs`, `get_security_alerts`,
 `get_user_activity`) are intentionally **not** carried over: their
@@ -21,7 +21,6 @@ import logging
 from typing import Any, Dict, Optional
 
 from fastapi import Request
-from sqlalchemy.orm import Session
 
 from app.audit.adapters.repository import SqlAlchemyAuditWriter
 from app.audit.domain.entities import AuditEventCommand
@@ -52,11 +51,8 @@ def _extract_ip_address(request: Request) -> Optional[str]:
 def _writer(request: Request) -> SqlAlchemyAuditWriter:
     """Build a writer for a single legacy call.
 
-    The caller's `db` is no longer threaded into the writer — see #240
+    The writer manages its own session via `session_factory` — see #240
     and `SqlAlchemyAuditWriter` for the transaction-isolation rationale.
-    The static `AuditService.log_*` signatures still accept `db` for
-    backward compatibility with 30+ existing callsites; the parameter
-    is intentionally unused.
     """
     return SqlAlchemyAuditWriter(tracker=get_audit_tracker(request))
 
@@ -66,7 +62,6 @@ class AuditService:
 
     @staticmethod
     def log_authentication_event(
-        db: Session,
         request: Request,
         action: str,
         user_id: Optional[int] = None,
@@ -90,7 +85,6 @@ class AuditService:
 
     @staticmethod
     def log_user_management_event(
-        db: Session,
         request: Request,
         action: str,
         target_user_id: int,
@@ -116,7 +110,6 @@ class AuditService:
 
     @staticmethod
     def log_server_event(
-        db: Session,
         request: Request,
         action: str,
         server_id: int,
@@ -138,7 +131,6 @@ class AuditService:
 
     @staticmethod
     def log_server_command_event(
-        db: Session,
         request: Request,
         server_id: int,
         command: str,
@@ -166,7 +158,6 @@ class AuditService:
 
     @staticmethod
     def log_backup_event(
-        db: Session,
         request: Request,
         action: str,
         server_id: Optional[int] = None,
@@ -193,7 +184,6 @@ class AuditService:
 
     @staticmethod
     def log_group_event(
-        db: Session,
         request: Request,
         action: str,
         group_id: int,
@@ -215,7 +205,6 @@ class AuditService:
 
     @staticmethod
     def log_template_event(
-        db: Session,
         request: Request,
         action: str,
         template_id: int,
@@ -237,7 +226,6 @@ class AuditService:
 
     @staticmethod
     def log_file_event(
-        db: Session,
         request: Request,
         action: str,
         server_id: int,
@@ -265,7 +253,6 @@ class AuditService:
 
     @staticmethod
     def log_permission_check(
-        db: Session,
         request: Request,
         resource_type: str,
         resource_id: Optional[int],
@@ -295,7 +282,6 @@ class AuditService:
 
     @staticmethod
     def log_admin_action(
-        db: Session,
         request: Request,
         action: str,
         target_resource_type: str,
@@ -323,7 +309,6 @@ class AuditService:
 
     @staticmethod
     def log_security_event(
-        db: Session,
         request: Request,
         event_type: str,
         severity: str,

--- a/app/auth/api/router.py
+++ b/app/auth/api/router.py
@@ -46,7 +46,6 @@ async def login(
         )
         if user_entity is None:
             AuditService.log_authentication_event(
-                db=db,
                 request=request,
                 action="login",
                 details={
@@ -64,7 +63,6 @@ async def login(
         refresh_token = await auth_service.create_refresh_token(user_entity.id)
 
         AuditService.log_authentication_event(
-            db=db,
             request=request,
             action="login",
             user_id=user_entity.id,
@@ -79,7 +77,6 @@ async def login(
     except HTTPException as e:
         if user_entity is None:
             AuditService.log_authentication_event(
-                db=db,
                 request=request,
                 action="login",
                 details={
@@ -103,7 +100,6 @@ async def refresh_access_token(
     user_id = await auth_service.verify_refresh_token(token_request.refresh_token)
     if not user_id:
         AuditService.log_authentication_event(
-            db=db,
             request=request,
             action="token_refresh",
             details={"reason": "invalid_refresh_token"},
@@ -117,7 +113,6 @@ async def refresh_access_token(
     user = await user_service.get_user_by_id(user_id)
     if user is None or not user.is_active:
         AuditService.log_authentication_event(
-            db=db,
             request=request,
             action="token_refresh",
             user_id=user_id,
@@ -133,7 +128,6 @@ async def refresh_access_token(
     new_refresh_token = await auth_service.create_refresh_token(user.id)
 
     AuditService.log_authentication_event(
-        db=db,
         request=request,
         action="token_refresh",
         user_id=user.id,
@@ -155,7 +149,6 @@ async def logout(
     success = await auth_service.revoke_refresh_token(token_request.refresh_token)
     if not success:
         AuditService.log_authentication_event(
-            db=db,
             request=request,
             action="logout",
             user_id=user_id,
@@ -167,7 +160,6 @@ async def logout(
         )
 
     AuditService.log_authentication_event(
-        db=db,
         request=request,
         action="logout",
         user_id=user_id,

--- a/app/servers/application/authorization.py
+++ b/app/servers/application/authorization.py
@@ -88,17 +88,9 @@ class AuthorizationService:
         server = await self._server_repo.get(server_id, include_deleted=True)
         if server is None:
             if log_access and request:
-                # The current ``AuditService.log_permission_check``
-                # signature still takes ``db`` for symmetry with its
-                # sibling methods, but the implementation does not
-                # touch the session (it dispatches via ``_writer(request)``
-                # — see ``app.audit.application.legacy_facade``). Passing
-                # ``None`` keeps the call working without dragging a
-                # ``Session`` dependency into this service.
                 from app.audit.service import AuditService
 
                 AuditService.log_permission_check(
-                    db=None,
                     request=request,
                     resource_type="server",
                     resource_id=server_id,
@@ -116,7 +108,6 @@ class AuthorizationService:
             from app.audit.service import AuditService
 
             AuditService.log_permission_check(
-                db=None,
                 request=request,
                 resource_type="server",
                 resource_id=server_id,

--- a/app/servers/routers/control.py
+++ b/app/servers/routers/control.py
@@ -70,7 +70,6 @@ async def start_server(
 
         # Log server start attempt
         AuditService.log_server_event(
-            db=db,
             request=request,
             action="start_attempt",
             server_id=server_id,
@@ -85,7 +84,6 @@ async def start_server(
         if current_status not in [ServerStatus.stopped, ServerStatus.error]:
             # Log failed start due to status
             AuditService.log_server_event(
-                db=db,
                 request=request,
                 action="start_failed",
                 server_id=server_id,
@@ -128,7 +126,6 @@ async def start_server(
                     )
                     # Log Java availability issue
                     AuditService.log_server_event(
-                        db=db,
                         request=request,
                         action="start_failed",
                         server_id=server_id,
@@ -152,7 +149,6 @@ async def start_server(
                 )
                 # Log Java executable issue
                 AuditService.log_server_event(
-                    db=db,
                     request=request,
                     action="start_failed",
                     server_id=server_id,
@@ -176,7 +172,6 @@ async def start_server(
                 logger.error(f"Server JAR missing: {jar_path}")
                 # Log missing JAR file
                 AuditService.log_server_event(
-                    db=db,
                     request=request,
                     action="start_failed",
                     server_id=server_id,
@@ -194,7 +189,6 @@ async def start_server(
 
             # Generic failure if we can't determine specific cause
             AuditService.log_server_event(
-                db=db,
                 request=request,
                 action="start_failed",
                 server_id=server_id,
@@ -211,7 +205,6 @@ async def start_server(
 
         # Log successful start
         AuditService.log_server_event(
-            db=db,
             request=request,
             action="start_success",
             server_id=server_id,
@@ -237,7 +230,6 @@ async def start_server(
     except Exception as e:
         # Log unexpected error
         AuditService.log_server_event(
-            db=db,
             request=request,
             action="start_failed",
             server_id=server_id,
@@ -432,7 +424,6 @@ async def send_server_command(
 
         # Log command attempt (CRITICAL SECURITY EVENT)
         AuditService.log_server_command_event(
-            db=db,
             request=http_request,
             server_id=server_id,
             command=command_request.command,
@@ -443,7 +434,6 @@ async def send_server_command(
         if server_status != ServerStatus.running:
             # Log failed command due to status
             AuditService.log_server_event(
-                db=db,
                 request=http_request,
                 action="command_failed",
                 server_id=server_id,
@@ -467,7 +457,6 @@ async def send_server_command(
         if not success:
             # Log failed command execution
             AuditService.log_server_command_event(
-                db=db,
                 request=http_request,
                 server_id=server_id,
                 command=command_request.command,
@@ -482,7 +471,6 @@ async def send_server_command(
 
         # Log successful command execution
         AuditService.log_server_command_event(
-            db=db,
             request=http_request,
             server_id=server_id,
             command=command_request.command,
@@ -498,7 +486,6 @@ async def send_server_command(
     except Exception as e:
         # Log unexpected error during command execution
         AuditService.log_server_command_event(
-            db=db,
             request=http_request,
             server_id=server_id,
             command=command_request.command,

--- a/tests/integration/test_audit.py
+++ b/tests/integration/test_audit.py
@@ -149,7 +149,6 @@ class TestAuditLogging:
 
         # Test authentication event logging
         AuditService.log_authentication_event(
-            db=db,
             request=mock_request,
             action="login",
             user_id=admin_user.id,
@@ -159,7 +158,6 @@ class TestAuditLogging:
 
         # Test server event logging
         AuditService.log_server_event(
-            db=db,
             request=mock_request,
             action="start",
             server_id=1,
@@ -169,7 +167,6 @@ class TestAuditLogging:
 
         # Test security event logging
         AuditService.log_security_event(
-            db=db,
             request=mock_request,
             event_type="suspicious_activity",
             severity="high",
@@ -333,7 +330,6 @@ class TestAuditLogging:
         db.commit()
 
         AuditService.log_security_event(
-            db=db,
             request=mock_request,
             event_type="failed_authentication",
             severity="critical",


### PR DESCRIPTION
## Summary
- Remove the unused `db: Session` first parameter from all 11
  `AuditService.log_*` static methods on `app/audit/application/legacy_facade.py`.
- Since #240/#246, the writer builds its own session via `session_factory`;
  the threaded-in `db` is dead weight that obscures the API.
- Resolves #247.

## Changes
- `app/audit/application/legacy_facade.py`: drop `db: Session` from 11
  signatures, drop now-unused `Session` import, refresh `_writer` docstring.
- Update 32 callsites across `app/auth/api/router.py` (8),
  `app/servers/routers/control.py` (13), `app/servers/application/authorization.py` (2),
  `app/audit/api/router.py` (4), and `tests/integration/test_audit.py` (4) to
  stop passing `db=db` / `db=None`.
- Remove the "db for symmetry" comment block in `authorization.py` that the
  refactor renders obsolete.

## Test plan
- [x] `uv run ruff check app/ && uv run ruff format --check app/`
- [x] `uv run pytest tests/unit -m "not slow"` (1095 passed, 5 skipped)
- [x] `uv run pytest tests/integration -m "not slow"` (427 passed, 5 skipped)
- [x] `uv run pytest tests/integration/test_audit.py` (13 passed)
- [x] `just test` (full suite: 1706 passed, 10 skipped, 0 failed)
- [x] `uv run pre-commit run --all-files` (all hooks passed)
- [x] `rg -n 'AuditService\.log_.*\bdb\s*=' app/ tests/` returns no hits
- [x] `rg -n 'db: Session' app/audit/application/legacy_facade.py` returns no hits