### PR TITLE
test: add true TOCTOU regression test for file_history with separate-session writers (Resolves #267)

### DIFF
--- a/tests/integration/files/test_toctou.py
+++ b/tests/integration/files/test_toctou.py
@@ -10,6 +10,7 @@ Covers:
 """
 
 import asyncio
+import logging
 
 import pytest
 from sqlalchemy import create_engine, text
@@ -21,6 +22,7 @@ from app.files.application.service import FileHistoryService
 from app.files.models import FileEditHistory
 from app.servers.adapters.read_port import SqlAlchemyServerReadPort
 from app.servers.models import Server, ServerStatus, ServerType
+from tests.conftest import TestingSessionLocal
 
 
 @pytest.fixture
@@ -261,3 +263,113 @@ async def test_toctou_retry_fires_on_sqlite_unique_violation(
         .all()
     )
     assert [r.version_number for r in rows] == [1, 2]
+
+
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_concurrent_create_version_backup_separate_sessions_fire_retry(
+    db, tmp_path, server, admin_user, caplog
+):
+    """True TOCTOU regression: concurrent writers, **each with its
+    own SQLAlchemy session**, must collide on the UNIQUE constraint
+    and exercise the application-layer retry path.
+
+    The sibling
+    :func:`test_concurrent_create_version_backup_no_duplicates` test
+    re-uses a single session across writers, which under SQLite's
+    synchronous session behaviour serialises writes and never actually
+    fires the UNIQUE constraint — so it can only prove "no duplicates"
+    rather than "retry path engages". Per-writer sessions break that
+    serialisation: while writer A is inside ``aiofiles.open(...)``
+    (the first real await in ``_reserve_and_persist``), writer B's
+    own session reads the same ``MAX(version_number)`` and races to
+    INSERT, so at least one writer sees an
+    :class:`sqlalchemy.exc.IntegrityError` and falls into the
+    in-service retry loop.
+
+    Assertions:
+        * No duplicate ``version_number`` rows landed (UNIQUE held).
+        * At least one writer succeeded.
+        * The retry log line (`logger.warning("TOCTOU collision ..."`)
+          fired at least once — concrete evidence the retry path was
+          taken, not just that the result happened to be unique by
+          luck of scheduling.
+
+    Marked ``slow`` because contention on a shared SQLite file (one
+    writer at a time at the dialect level) plus real ``aiofiles`` I/O
+    makes this several seconds even with a modest writer count — only
+    needed in the full-suite CI lane, not the pre-commit smoke. We
+    cap writers at 8 to keep the test under ~90 s on a developer
+    laptop while still reliably exercising the contention window;
+    raising it does not change the assertion semantics, only the
+    test wall time.
+    """
+    writer_count = 8
+    server_id = server.id
+    user_id = admin_user.id
+
+    async def writer(i: int):
+        # Each writer gets its own UoW backed by an independent
+        # session, mirroring per-request DI in production. The UoW
+        # owns the session via ``from_session_factory`` and will close
+        # it on ``__aexit__``.
+        uow = SqlAlchemyFilesUnitOfWork.from_session_factory(TestingSessionLocal)
+        # ServerReadPort only reads (no writes), so it can share the
+        # outer fixture's session safely; it is also called once per
+        # writer outside the inner write transaction.
+        server_read = SqlAlchemyServerReadPort(db=db)
+        service = FileHistoryService(
+            uow=uow,
+            server_read=server_read,
+            history_base_dir=tmp_path,
+            max_versions_per_file=1000,
+            auto_cleanup_days=999,
+        )
+        try:
+            return await service.create_version_backup(
+                server_id=server_id,
+                file_path="server.properties",
+                content=f"writer-{i}-content",
+                user_id=user_id,
+                description=f"writer-{i}",
+            )
+        except Exception as e:  # pragma: no cover - surfaced in assertions
+            return e
+
+    # Capture the retry-path log emitted by ``app.files.application.service``.
+    with caplog.at_level(logging.WARNING, logger="app.files.application.service"):
+        results = await asyncio.gather(*(writer(i) for i in range(writer_count)))
+
+    # UNIQUE constraint held: no duplicate version_numbers persisted.
+    rows = (
+        db.query(FileEditHistory)
+        .filter_by(server_id=server_id, file_path="server.properties")
+        .all()
+    )
+    version_numbers = [r.version_number for r in rows]
+    assert len(version_numbers) == len(set(version_numbers)), (
+        f"Duplicate version numbers persisted under per-writer sessions: "
+        f"{version_numbers}"
+    )
+
+    # At least one writer must have persisted a row.
+    successful = [r for r in results if not isinstance(r, Exception)]
+    assert successful, "Expected at least one writer to persist a backup"
+
+    # Retry path engaged: at least one TOCTOU collision warning must
+    # have been logged. This is the load-bearing assertion of this
+    # regression test — without it we only prove "no duplicates", not
+    # "the UNIQUE-violation retry path is wired up correctly".
+    toctou_warnings = [
+        r
+        for r in caplog.records
+        if r.name == "app.files.application.service"
+        and r.levelno == logging.WARNING
+        and "TOCTOU collision" in r.getMessage()
+    ]
+    assert toctou_warnings, (
+        f"Expected at least one TOCTOU collision warning from the retry "
+        f"loop with {writer_count} writers on independent sessions; got "
+        f"none. Either the retry path is unreachable on this dialect or "
+        f"the writers did not actually contend."
+    )

--- a/tests/unit/files/test_service_retry_with_fake.py
+++ b/tests/unit/files/test_service_retry_with_fake.py
@@ -1,0 +1,212 @@
+"""Unit-level regression for the file-history UNIQUE-violation retry path.
+
+Complements
+:func:`tests.integration.files.test_toctou.test_concurrent_create_version_backup_separate_sessions_fire_retry`
+— the integration test proves the retry path engages under real
+SQLite contention, but it costs tens of seconds because contended
+writers serialise at the dialect level. This file pins the same
+behaviour against the in-memory fakes in
+:mod:`tests.unit.files.fakes` so the retry contract is verified in
+~milliseconds and runs in the pre-commit smoke lane (no
+``@pytest.mark.slow``).
+
+Strategy:
+    1. Subclass :class:`FakeFileHistoryRepository` so its ``add``
+       raises a synthetic :class:`sqlalchemy.exc.IntegrityError`
+       carrying the SQLite-shaped column-list message exactly once,
+       then defers to the real in-memory implementation. This is the
+       fake-side analogue of the SQLite monkeypatch in
+       :func:`tests.integration.files.test_toctou.test_toctou_retry_fires_on_sqlite_unique_violation`.
+    2. Drive :meth:`FileHistoryService.create_version_backup` and
+       assert that
+       (a) the call succeeds (retry recovered),
+       (b) ``add`` was invoked exactly twice (one failure + one
+       success — no infinite loop, no over-retry), and
+       (c) the persisted row carries ``version_number=1`` (the retry
+       reservation collapses back to the next free slot because the
+       failed first attempt rolled back).
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.files.application.service import FileHistoryService
+from app.files.domain.entities import CreateHistoryCommand, FileHistoryEntity
+from tests.unit.files.fakes import (
+    FakeFileHistoryRepository,
+    FakeFilesUnitOfWork,
+    FakeServerReadPort,
+)
+
+
+class _FailOnceFileHistoryRepository(FakeFileHistoryRepository):
+    """Fake that raises a SQLite-shaped UNIQUE :class:`IntegrityError`
+    on the first ``add`` call, then delegates to the real fake.
+
+    The error text deliberately matches the column-list shape SQLite
+    emits — ``UNIQUE constraint failed:
+    file_edit_history.server_id, file_edit_history.file_path,
+    file_edit_history.version_number`` — so the production-side
+    detector :func:`app.files.application.service._is_version_unique_violation`
+    must classify it as a version-collision (and not a generic
+    integrity error that surfaces to the caller).
+    """
+
+    _UNIQUE_MSG = (
+        "UNIQUE constraint failed: "
+        "file_edit_history.server_id, "
+        "file_edit_history.file_path, "
+        "file_edit_history.version_number"
+    )
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.add_calls = 0
+
+    async def add(self, command: CreateHistoryCommand) -> FileHistoryEntity:
+        self.add_calls += 1
+        if self.add_calls == 1:
+            # SQLAlchemy's IntegrityError carries the driver-level
+            # exception as `orig`; the production detector inspects
+            # both `str(e.orig)` and `str(e)`, so it is enough to
+            # stash the SQLite-shaped message as `orig`.
+            raise IntegrityError(
+                statement="INSERT INTO file_edit_history ...",
+                params={},
+                orig=Exception(self._UNIQUE_MSG),
+            )
+        return await super().add(command)
+
+
+@pytest.fixture
+def fail_once_repo() -> _FailOnceFileHistoryRepository:
+    return _FailOnceFileHistoryRepository()
+
+
+@pytest.fixture
+def service(
+    fail_once_repo: _FailOnceFileHistoryRepository,
+    tmp_path: Path,
+) -> FileHistoryService:
+    return FileHistoryService(
+        uow=FakeFilesUnitOfWork(files_history=fail_once_repo),
+        server_read=FakeServerReadPort({1: "./servers/1"}),
+        history_base_dir=tmp_path / "file_history",
+        max_versions_per_file=10,
+        auto_cleanup_days=30,
+    )
+
+
+@pytest.mark.asyncio
+async def test_retry_recovers_from_single_unique_violation(
+    service: FileHistoryService,
+    fail_once_repo: _FailOnceFileHistoryRepository,
+    caplog,
+):
+    """``create_version_backup`` retries past a one-shot
+    SQLite-shaped UNIQUE failure and persists exactly one row.
+
+    Together with the integration sibling this pins the retry
+    contract on **both** the real SQLAlchemy path and the in-memory
+    fake path, so future refactors that move the retry loop or
+    reshape the detector cannot quietly break the recovery
+    behaviour.
+    """
+    with caplog.at_level(logging.WARNING, logger="app.files.application.service"):
+        entity = await service.create_version_backup(
+            server_id=1,
+            file_path="server.properties",
+            content="content-v1\n",
+            user_id=42,
+            description="first",
+        )
+
+    assert entity is not None, (
+        "Retry should have succeeded; got None (= 'content unchanged' "
+        "short-circuit), which is impossible on an empty history."
+    )
+    assert entity.version_number == 1, (
+        "Second attempt re-reserves the next free version number — on "
+        "an empty file this is still 1 because the first attempt rolled "
+        "back."
+    )
+    assert fail_once_repo.add_calls == 2, (
+        f"Expected exactly two add() calls (1 collision + 1 retry); "
+        f"got {fail_once_repo.add_calls}. A higher count would mean "
+        f"the retry loop is over-retrying; a lower one would mean the "
+        f"first failure was not actually classified as a UNIQUE "
+        f"violation."
+    )
+
+    toctou_warnings = [
+        r
+        for r in caplog.records
+        if r.name == "app.files.application.service"
+        and r.levelno == logging.WARNING
+        and "TOCTOU collision" in r.getMessage()
+    ]
+    assert len(toctou_warnings) == 1, (
+        f"Expected exactly one TOCTOU collision warning matching the "
+        f"single induced failure; got {len(toctou_warnings)}: "
+        f"{[r.getMessage() for r in toctou_warnings]}."
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_version_integrity_error_is_not_retried(
+    tmp_path: Path,
+):
+    """A non-version :class:`IntegrityError` (e.g. a foreign-key
+    failure) must bubble out as a domain exception instead of being
+    silently retried.
+
+    This pins the negative side of the
+    :func:`app.files.application.service._is_version_unique_violation`
+    classifier: misclassifying an arbitrary integrity error as a
+    version collision would cause spurious retries (and at worst
+    silently lose data after the third attempt also fails).
+    """
+    from app.core.exceptions import FileOperationException
+
+    class _UnrelatedIntegrityRepo(FakeFileHistoryRepository):
+        def __init__(self) -> None:
+            super().__init__()
+            self.add_calls = 0
+
+        async def add(self, command: CreateHistoryCommand) -> FileHistoryEntity:
+            self.add_calls += 1
+            raise IntegrityError(
+                statement="INSERT INTO file_edit_history ...",
+                params={},
+                # Unrelated message — does not match the version-collision
+                # detector on either the index-name or column-list branch.
+                orig=Exception("FOREIGN KEY constraint failed"),
+            )
+
+    repo = _UnrelatedIntegrityRepo()
+    service = FileHistoryService(
+        uow=FakeFilesUnitOfWork(files_history=repo),
+        server_read=FakeServerReadPort({1: "./servers/1"}),
+        history_base_dir=tmp_path / "file_history",
+        max_versions_per_file=10,
+        auto_cleanup_days=30,
+    )
+
+    # The service wraps unexpected errors in FileOperationException
+    # (see `create_version_backup`'s outer try/except), so we assert on
+    # the wrapper rather than IntegrityError directly.
+    with pytest.raises(FileOperationException):
+        await service.create_version_backup(
+            server_id=1,
+            file_path="server.properties",
+            content="content-v1\n",
+            user_id=42,
+        )
+
+    assert repo.add_calls == 1, (
+        f"Non-version IntegrityError must not be retried; got "
+        f"{repo.add_calls} add() calls."
+    )


### PR DESCRIPTION
## Summary

Addresses reviewer feedback on PR #266 that the existing parallel-writer test in `tests/integration/files/test_toctou.py` re-uses a single SQLite session across all 20 writers — SQLite + a shared synchronous session serialises writes, so the UNIQUE constraint never actually fires and the test can only prove "no duplicates", not "the retry path engages under contention".

This PR adds two complementary regression tests that pin the `file_edit_history` UNIQUE-violation retry path:

- **Integration**: 8 concurrent writers with **per-writer sessions** via `SqlAlchemyFilesUnitOfWork.from_session_factory(TestingSessionLocal)`. The load-bearing assertion is on a `caplog`-captured `TOCTOU collision` warning, proving the retry path was actually taken.
- **Unit (fake-based)**: `_FailOnceFileHistoryRepository` raises a SQLite-shaped UNIQUE `IntegrityError` exactly once, then delegates to the real fake. Pins recovery, exact retry count, and that non-version `IntegrityError`s (e.g. FK failures) are **not** retried.

No production code is modified — this is test-only.

## Changes

- `tests/integration/files/test_toctou.py`:
  - new `test_concurrent_create_version_backup_separate_sessions_fire_retry` (`@pytest.mark.slow`)
  - imports `TestingSessionLocal` from `tests.conftest` so each writer gets its own session
  - asserts (a) no duplicate `version_number` rows, (b) at least one writer succeeded, (c) at least one `TOCTOU collision` warning landed in `caplog`
- `tests/unit/files/test_service_retry_with_fake.py` (new):
  - `test_retry_recovers_from_single_unique_violation`: SQLite-shaped UNIQUE `IntegrityError` raised once via subclassed fake; asserts retry recovers, exactly 2 `add()` calls, exactly 1 TOCTOU warning
  - `test_non_version_integrity_error_is_not_retried`: FK-shaped `IntegrityError` bubbles as `FileOperationException` after a single attempt

## Test plan

- [x] `uv run ruff check tests/integration/files/test_toctou.py tests/unit/files/test_service_retry_with_fake.py` — clean
- [x] `uv run ruff format` — clean
- [x] `uv run pytest tests/integration/files/test_toctou.py -m "not slow"` — 4 passed
- [x] `uv run pytest tests/integration/files/test_toctou.py::test_concurrent_create_version_backup_separate_sessions_fire_retry` — 1 passed (~7 s with writer_count=8)
- [x] `uv run pytest tests/unit/files/test_service_retry_with_fake.py` — 2 passed (~2 s)
- [x] `uv run pytest tests/unit -m "not slow"` — 1106 passed, 5 skipped
- [x] `uv run pre-commit run --files tests/integration/files/test_toctou.py tests/unit/files/test_service_retry_with_fake.py` — all hooks pass (incl. unit-smoke + mypy)

## Refs

Resolves #267. Related: #266, #228, #154.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>