### PR TITLE
refactor: lift FastAPI deps out of servers authorization + drop dead decorators (Resolves #273, Resolves #292)

### DIFF
--- a/app/backups/domain/exceptions.py
+++ b/app/backups/domain/exceptions.py
@@ -23,3 +23,20 @@ class BackupScheduleNotFoundError(BackupError):
 
 class BackupScheduleAlreadyExistsError(BackupError):
     """Raised when a schedule for the given server already exists."""
+
+
+# Aliases for the framework-agnostic authorization-service raise sites
+# introduced in #273. ``BackupDomainError`` is the umbrella base used by
+# the global exception handlers; the two concrete subclasses pair with
+# the legacy HTTP-404 raises that previously lived inside
+# ``AuthorizationService.check_backup_access``.
+class BackupDomainError(BackupError):
+    """Base for domain errors surfaced by the backups application layer."""
+
+
+class BackupNotFoundError(BackupDomainError):
+    """Raised when a requested backup does not exist (HTTP 404)."""
+
+
+class BackupParentServerMissingError(BackupDomainError):
+    """Raised when a backup's parent server cannot be resolved (HTTP 404)."""

--- a/app/backups/router.py
+++ b/app/backups/router.py
@@ -31,6 +31,10 @@ from app.backups.api._mappers import (
 )
 from app.backups.api.dependencies import get_backup_service
 from app.backups.application.service import BackupService
+from app.backups.domain.exceptions import (
+    BackupNotFoundError,
+    BackupParentServerMissingError,
+)
 from app.backups.schemas import (
     BackupCreateRequest,
     BackupListResponse,
@@ -52,6 +56,7 @@ from app.core.exceptions import (
 )
 from app.servers.api.dependencies import get_authorization_service
 from app.servers.application.authorization import AuthorizationService
+from app.servers.domain.exceptions import ServerAccessError, ServerNotFoundError
 from app.servers.models import BackupStatus, BackupType
 from app.templates.api.dependencies import get_template_service
 from app.templates.application.service import TemplateService
@@ -125,7 +130,16 @@ async def create_backup(
 
         return backup_entity_to_response(entity)
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except (ServerNotFoundException, BackupNotFoundException):
         raise
@@ -181,7 +195,16 @@ async def upload_backup(
             original_filename=file.filename,
         )
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except (ServerNotFoundException, BackupNotFoundException):
         raise
@@ -223,7 +246,16 @@ async def list_server_backups(
             size=page_result.size,
         )
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -261,7 +293,16 @@ async def list_all_backups(
             size=page_result.size,
         )
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -286,7 +327,16 @@ async def get_global_backup_statistics(
         stats = await backup_service.get_backup_statistics()
         return backup_statistics_to_response(stats)
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -307,7 +357,16 @@ async def get_backup(
         backup = await auth.check_backup_access(backup_id, current_user)
         return backup_entity_to_response(backup)
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -344,7 +403,16 @@ async def restore_backup(
             details={"target_server_id": target_server_id},
         )
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except (BackupNotFoundException, ServerNotFoundException):
         raise
@@ -427,7 +495,16 @@ async def restore_backup_and_create_template(
             },
         )
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except (BackupNotFoundException, ServerNotFoundException):
         raise
@@ -475,7 +552,16 @@ async def download_backup(
             headers={"Content-Disposition": f'attachment; filename="{backup_filename}"'},
         )
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -500,9 +586,9 @@ async def delete_backup(
         # `backup.server.owner_id` (ORM relationship). With the domain
         # entity that relationship is denormalised away, so we fetch
         # the parent server explicitly and pass it as the third arg.
-        parent = await auth.check_server_access(
-            backup.server_id, current_user, log_access=False
-        )
+        # ``check_server_access`` no longer emits an audit log on its
+        # own (#273), so no ``log_access`` opt-out is required.
+        parent = await auth.check_server_access(backup.server_id, current_user)
         if not AuthorizationService.can_delete_backup(backup, current_user, parent):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -515,7 +601,16 @@ async def delete_backup(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Backup not found"
             )
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -540,7 +635,16 @@ async def get_server_backup_statistics(
         stats = await backup_service.get_backup_statistics(server_id=server_id)
         return backup_statistics_to_response(stats)
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -592,7 +696,16 @@ async def create_scheduled_backups(
             },
         )
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(

--- a/app/backups/scheduler_router.py
+++ b/app/backups/scheduler_router.py
@@ -20,6 +20,8 @@ from app.backups.api._mappers import (
 from app.backups.api.dependencies import get_backup_scheduler_service
 from app.backups.application.scheduler import BackupSchedulerService
 from app.backups.domain.exceptions import (
+    BackupNotFoundError,
+    BackupParentServerMissingError,
     BackupScheduleAlreadyExistsError,
     BackupScheduleNotFoundError,
 )
@@ -33,6 +35,7 @@ from app.backups.schemas import (
 from app.core.database import get_db
 from app.servers.api.dependencies import get_authorization_service
 from app.servers.application.authorization import AuthorizationService
+from app.servers.domain.exceptions import ServerAccessError, ServerNotFoundError
 from app.users.domain.value_objects import Role
 from app.users.models import User
 
@@ -71,7 +74,16 @@ async def create_backup_schedule(
     except BackupScheduleNotFoundError as e:
         # server-not-found case (raised from the create path)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -103,7 +115,16 @@ async def get_backup_schedule(
             )
         return backup_schedule_entity_to_response(entity)
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -140,7 +161,16 @@ async def update_backup_schedule(
 
     except BackupScheduleNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -173,7 +203,16 @@ async def delete_backup_schedule(
                 detail=f"No backup schedule found for server {server_id}",
             )
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -202,7 +241,16 @@ async def get_backup_schedule_logs(
         logs = await scheduler.list_logs_for_server(server_id, page=page, size=size)
         return [backup_schedule_log_entity_to_response(log) for log in logs]
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -232,7 +280,16 @@ async def get_scheduler_status(
 
         return scheduler_status_to_response(scheduler, all_schedules, enabled_schedules)
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -261,7 +318,16 @@ async def list_all_backup_schedules(
         schedules = await scheduler.list_schedules(enabled_only=enabled_only)
         return [backup_schedule_entity_to_response(s) for s in schedules]
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(

--- a/app/core/error_handlers.py
+++ b/app/core/error_handlers.py
@@ -1,0 +1,55 @@
+"""Global FastAPI exception handlers for domain exceptions.
+
+Centralises the mapping from framework-agnostic domain exceptions
+(raised by application-layer services) to HTTP responses. Introduced
+under #273 so the ``AuthorizationService`` and other application
+modules can ``raise`` plain Python exceptions without importing
+``fastapi.HTTPException``.
+
+The router-level ``try / except HTTPException: raise`` ladders are
+extended to re-raise these domain types before the catch-all
+``except Exception`` block so this handler is reached.
+"""
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from app.backups.domain.exceptions import (
+    BackupNotFoundError,
+    BackupParentServerMissingError,
+)
+from app.servers.domain.exceptions import ServerAccessError, ServerNotFoundError
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Register domain-exception → HTTP-response handlers on ``app``."""
+
+    @app.exception_handler(ServerNotFoundError)
+    async def _server_not_found(request: Request, exc: ServerNotFoundError):
+        return JSONResponse(
+            status_code=404,
+            content={"detail": str(exc) or "Server not found"},
+        )
+
+    @app.exception_handler(ServerAccessError)
+    async def _server_access_denied(request: Request, exc: ServerAccessError):
+        return JSONResponse(
+            status_code=403,
+            content={"detail": str(exc) or "Access denied"},
+        )
+
+    @app.exception_handler(BackupNotFoundError)
+    async def _backup_not_found(request: Request, exc: BackupNotFoundError):
+        return JSONResponse(
+            status_code=404,
+            content={"detail": str(exc) or "Backup not found"},
+        )
+
+    @app.exception_handler(BackupParentServerMissingError)
+    async def _backup_parent_missing(
+        request: Request, exc: BackupParentServerMissingError
+    ):
+        return JSONResponse(
+            status_code=404,
+            content={"detail": str(exc) or "Server not found for backup"},
+        )

--- a/app/files/router.py
+++ b/app/files/router.py
@@ -5,6 +5,10 @@ from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
 from app.auth.dependencies import get_current_user
+from app.backups.domain.exceptions import (
+    BackupNotFoundError,
+    BackupParentServerMissingError,
+)
 from app.core.database import get_db
 from app.files.api.dependencies import get_file_history_service
 from app.files.application.management import file_management_service
@@ -33,6 +37,7 @@ from app.files.schemas import (
 )
 from app.servers.api.dependencies import get_authorization_service
 from app.servers.application.authorization import AuthorizationService
+from app.servers.domain.exceptions import ServerAccessError, ServerNotFoundError
 from app.types import FileType
 from app.users.domain.value_objects import Role
 from app.users.models import User
@@ -457,6 +462,16 @@ async def list_server_files(
             current_path=path,
             total_files=len(file_responses),
         )
+    except (
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
+        raise
     except Exception as e:
         logger.error(f"Error listing files for server {server_id}: {str(e)}")
 

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from app.backups.router import router as backups_router
 from app.backups.scheduler_router import router as scheduler_router
 from app.core.config import settings
 from app.core.database import Base, engine
+from app.core.error_handlers import register_exception_handlers
 
 # Import visibility models for Phase 2 resource access control
 from app.files.router import router as files_router
@@ -328,6 +329,10 @@ app = FastAPI(
     version=__version__,
     lifespan=lifespan,
 )
+
+# Map framework-agnostic domain exceptions (raised by application-layer
+# services such as ``AuthorizationService``) to HTTP responses.
+register_exception_handlers(app)
 
 
 @app.get("/health", tags=["health"])

--- a/app/servers/application/authorization.py
+++ b/app/servers/application/authorization.py
@@ -1,42 +1,61 @@
-"""Authorization service — relocated from `app.services.authorization_service`.
+"""Authorization service — framework-agnostic application-layer policy.
 
-Migrated under #228 (PR 2b/?):
+Originally relocated from ``app.services.authorization_service`` under
+#228 (PR 2b). Refactored under #273 + #292 to:
 
-- ``check_server_access`` / ``check_backup_access`` are now ``async def``
-  and resolve resources through sibling Repository Ports
-  (``ServerRepository``, ``BackupRepository``) instead of bare
-  ``db.query`` calls. They return the domain entities
-  (``ServerEntity`` / ``BackupEntity``); the routers that still need
-  the SQLAlchemy ``Server`` row (notably the start/restart paths,
+- Remove every FastAPI import (``HTTPException``, ``Request``,
+  ``status``) so the application layer no longer leaks framework
+  concerns through its public signatures. Resource-resolution failures
+  now raise plain Python domain exceptions
+  (``ServerNotFoundError``, ``BackupNotFoundError``,
+  ``BackupParentServerMissingError``); a global FastAPI exception
+  handler registered in ``app.core.error_handlers`` maps them back to
+  the HTTP responses the API contract requires.
+- Drop the inline ``AuditService.log_permission_check`` calls. Audit
+  logging is a router-side concern (it needs the ``Request`` object)
+  and the two production callsites — both in
+  ``app.servers.routers.control`` — re-emit the success event after the
+  access check returns.
+- Delete the ``require_role`` / ``require_admin_or_operator``
+  decorators (#292). They were preserved only for legacy tests that
+  were retired in #290; production code never bound them.
+
+Method semantics:
+
+- ``check_server_access`` / ``check_backup_access`` remain ``async``
+  and resolve aggregates through sibling Repository Ports
+  (``ServerRepository``, ``BackupRepository``). They return the domain
+  entities (``ServerEntity`` / ``BackupEntity``); routers that still
+  need the SQLAlchemy ``Server`` row (notably the start/restart paths,
   which hand the object to ``minecraft_server_manager.start_server``
   for mutation by ``simplified_sync_service``) refetch the ORM row
   separately as a transitional pattern until #149 finishes.
-- ``AuthorizationService`` is now instance-based: the constructor
-  receives the three sibling Repositories so callers wire it via
-  FastAPI ``Depends(get_authorization_service)`` rather than calling a
+- ``AuthorizationService`` is instance-based: the constructor receives
+  the three sibling Repositories so callers wire it via FastAPI
+  ``Depends(get_authorization_service)`` rather than calling a
   module-level singleton.
 - Boolean helpers (``is_admin``, ``can_*``) remain ``@staticmethod``
   because they read only fields of ``User`` and do not touch the
   database.
-- ``can_delete_backup`` now accepts the parent ``ServerEntity`` (its
-  one previous caller used to pass an ORM ``Backup`` and reach through
+- ``can_delete_backup`` accepts the parent ``ServerEntity`` (its one
+  previous caller used to pass an ORM ``Backup`` and reach through
   ``backup.server.owner_id``; that path is no longer available off the
   domain entity, so the caller passes the server explicitly).
 
 The legacy module path ``app.services.authorization_service`` continues
 to re-export ``AuthorizationService`` for tests that have not yet been
-relocated; the module-level ``authorization_service`` singleton has
-been removed because every router now goes through DI.
+relocated; the module-level ``authorization_service`` singleton was
+removed under #228 because every router now goes through DI.
 """
 
-from functools import wraps
-from typing import Optional
-
-from fastapi import HTTPException, Request, status
-
 from app.backups.domain.entities import BackupEntity
+from app.backups.domain.exceptions import (
+    BackupNotFoundError,
+    BackupParentServerMissingError,
+)
 from app.backups.domain.ports import BackupRepository
 from app.servers.domain.entities import ServerEntity
+from app.servers.domain.exceptions import ServerNotFoundError
 from app.servers.domain.ports import ServerRepository
 from app.servers.models import Backup, Server
 from app.templates.domain.ports import TemplateRepository
@@ -71,82 +90,50 @@ class AuthorizationService:
         self,
         server_id: int,
         user: User,
-        request: Optional[Request] = None,
-        log_access: bool = True,
     ) -> ServerEntity:
         """Verify ``user`` may access the server identified by ``server_id``.
 
-        Returns the ``ServerEntity`` on success. Raises ``HTTPException``
-        with status 404 if the server is missing. All authenticated users
-        may access every server today (Phase 1 model from the legacy
-        implementation); the audit-log event is preserved for parity.
+        Returns the ``ServerEntity`` on success. Raises
+        ``ServerNotFoundError`` (mapped to HTTP 404 by the global
+        exception handler) when the server is missing. All
+        authenticated users may access every server today (Phase 1
+        policy from the legacy implementation).
 
         ``include_deleted=True`` matches the legacy ``db.query(Server)``
-        which returned soft-deleted rows — the backup-restore paths rely
-        on that behaviour.
+        which returned soft-deleted rows — the backup-restore paths
+        rely on that behaviour.
+
+        Audit logging is intentionally **not** performed here. Callers
+        that need to emit a ``permission_check`` audit event must do
+        so after this method returns (the only two such callsites live
+        in ``app.servers.routers.control``).
         """
         server = await self._server_repo.get(server_id, include_deleted=True)
         if server is None:
-            if log_access and request:
-                from app.audit.service import AuditService
-
-                AuditService.log_permission_check(
-                    request=request,
-                    resource_type="server",
-                    resource_id=server_id,
-                    permission="access",
-                    granted=False,
-                    user_id=user.id,
-                    details={"reason": "server_not_found"},
-                )
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="Server not found"
-            )
+            raise ServerNotFoundError("Server not found")
 
         # Phase 1: every authenticated user may access every server.
-        if log_access and request:
-            from app.audit.service import AuditService
-
-            AuditService.log_permission_check(
-                request=request,
-                resource_type="server",
-                resource_id=server_id,
-                permission="access",
-                granted=True,
-                user_id=user.id,
-                details={
-                    "server_name": server.name,
-                    "owner_id": server.owner_id,
-                    "user_role": user.role.value,
-                },
-            )
-
         return server
 
     async def check_backup_access(
         self,
         backup_id: int,
         user: User,
-        request: Optional[Request] = None,
     ) -> BackupEntity:
         """Verify ``user`` may access the backup identified by ``backup_id``.
 
         Returns the ``BackupEntity`` on success. Mirrors the legacy
-        behaviour: 404 on missing backup, 404 on missing parent server,
+        behaviour: ``BackupNotFoundError`` on missing backup,
+        ``BackupParentServerMissingError`` on missing parent server,
         otherwise allowed (Phase 1).
         """
         backup = await self._backup_repo.get(backup_id)
         if backup is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="Backup not found"
-            )
+            raise BackupNotFoundError("Backup not found")
 
         server = await self._server_repo.get(backup.server_id, include_deleted=True)
         if server is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Server not found for backup",
-            )
+            raise BackupParentServerMissingError("Server not found for backup")
 
         return backup
 
@@ -230,68 +217,6 @@ class AuthorizationService:
         raise ValueError(
             "can_delete_backup requires the parent server when called with a BackupEntity"
         )
-
-    @staticmethod
-    def require_role(required_role: Role):
-        """Decorator preserved for parity with the legacy class.
-
-        Production code does not use this decorator — the only callers
-        are tests under ``tests/unit/services/test_authorization_service``.
-        """
-
-        def decorator(func):
-            @wraps(func)
-            async def wrapper(*args, **kwargs):
-                current_user = kwargs.get("current_user")
-                if not current_user:
-                    for arg in args:
-                        if isinstance(arg, User):
-                            current_user = arg
-                            break
-                if not current_user:
-                    raise HTTPException(
-                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                        detail="Current user not found in request",
-                    )
-                if current_user.role != required_role and current_user.role != Role.admin:
-                    raise HTTPException(
-                        status_code=status.HTTP_403_FORBIDDEN,
-                        detail=f"Requires {required_role.value} role or higher",
-                    )
-                return await func(*args, **kwargs)
-
-            return wrapper
-
-        return decorator
-
-    @staticmethod
-    def require_admin_or_operator():
-        """Decorator preserved for parity with the legacy class (test-only)."""
-
-        def decorator(func):
-            @wraps(func)
-            async def wrapper(*args, **kwargs):
-                current_user = kwargs.get("current_user")
-                if not current_user:
-                    for arg in args:
-                        if isinstance(arg, User):
-                            current_user = arg
-                            break
-                if not current_user:
-                    raise HTTPException(
-                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                        detail="Current user not found in request",
-                    )
-                if current_user.role == Role.user:
-                    raise HTTPException(
-                        status_code=status.HTTP_403_FORBIDDEN,
-                        detail="Only operators and admins can perform this action",
-                    )
-                return await func(*args, **kwargs)
-
-            return wrapper
-
-        return decorator
 
     @staticmethod
     def filter_servers_for_user(user: User, servers, db=None) -> list:

--- a/app/servers/routers/control.py
+++ b/app/servers/routers/control.py
@@ -13,11 +13,16 @@ from sqlalchemy.orm import Session
 
 from app.audit.service import AuditService
 from app.auth.dependencies import get_current_user
+from app.backups.domain.exceptions import (
+    BackupNotFoundError,
+    BackupParentServerMissingError,
+)
 from app.core.config import settings
 from app.core.database import get_db
 from app.servers.api.dependencies import get_authorization_service
 from app.servers.application.authorization import AuthorizationService
 from app.servers.application.minecraft_server import minecraft_server_manager
+from app.servers.domain.exceptions import ServerAccessError, ServerNotFoundError
 from app.servers.models import Server, ServerStatus
 from app.servers.schemas import (
     ServerCommandRequest,
@@ -47,7 +52,25 @@ async def start_server(
     """
     try:
         # Check ownership/admin access
-        await auth.check_server_access(server_id, current_user, request)
+        server_entity = await auth.check_server_access(server_id, current_user)
+
+        # Re-emit the permission-check audit event that previously lived
+        # inside ``AuthorizationService.check_server_access``; the
+        # application-layer service is now framework-agnostic (#273) and
+        # cannot reach the FastAPI ``Request``.
+        AuditService.log_permission_check(
+            request=request,
+            resource_type="server",
+            resource_id=server_id,
+            permission="access",
+            granted=True,
+            user_id=current_user.id,
+            details={
+                "server_name": server_entity.name,
+                "owner_id": server_entity.owner_id,
+                "user_role": current_user.role.value,
+            },
+        )
 
         # Re-fetch the ORM `Server` row because
         # `minecraft_server_manager.start_server` and
@@ -225,7 +248,16 @@ async def start_server(
             process_info=minecraft_server_manager.get_server_info(server_id),
         )
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         # Log unexpected error
@@ -287,7 +319,16 @@ async def stop_server(
                     detail="Failed to stop server",
                 )
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         logger.error(f"Unexpected error stopping server {server_id}: {e}")
@@ -352,7 +393,16 @@ async def restart_server(
 
         return {"message": "Server restart initiated"}
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -391,7 +441,16 @@ async def get_server_status(
             server_id=server_id, status=server_status, process_info=process_info
         )
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -417,7 +476,24 @@ async def send_server_command(
     """
     try:
         # Check ownership/admin access
-        server = await auth.check_server_access(server_id, current_user, http_request)
+        server = await auth.check_server_access(server_id, current_user)
+
+        # Re-emit the permission-check audit event that previously lived
+        # inside ``AuthorizationService.check_server_access``; the
+        # application-layer service is now framework-agnostic (#273).
+        AuditService.log_permission_check(
+            request=http_request,
+            resource_type="server",
+            resource_id=server_id,
+            permission="access",
+            granted=True,
+            user_id=current_user.id,
+            details={
+                "server_name": server.name,
+                "owner_id": server.owner_id,
+                "user_role": current_user.role.value,
+            },
+        )
 
         # Check if server is running
         server_status = minecraft_server_manager.get_server_status(server_id)
@@ -481,7 +557,16 @@ async def send_server_command(
 
         return {"message": f"Command '{command_request.command}' sent to server"}
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         # Log unexpected error during command execution
@@ -520,7 +605,16 @@ async def get_server_logs(
 
         return ServerLogsResponse(server_id=server_id, logs=logs, total_lines=len(logs))
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(

--- a/app/servers/routers/import_export.py
+++ b/app/servers/routers/import_export.py
@@ -20,6 +20,10 @@ from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
 from app.auth.dependencies import get_current_user
+from app.backups.domain.exceptions import (
+    BackupNotFoundError,
+    BackupParentServerMissingError,
+)
 from app.core.database import get_db
 from app.servers.api.dependencies import (
     get_authorization_service,
@@ -33,6 +37,7 @@ from app.servers.application.service import (
 from app.servers.application.service import (
     _server_service_legacy as server_service,  # legacy module-level alias for old unit tests
 )
+from app.servers.domain.exceptions import ServerAccessError, ServerNotFoundError
 from app.servers.domain.ports import ServerRepository
 from app.servers.models import ServerStatus, ServerType
 from app.servers.schemas import (
@@ -148,7 +153,16 @@ async def export_server(
             },
         )
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         logger.error(f"Failed to export server {server_id}: {str(e)}")
@@ -316,7 +330,16 @@ async def import_server(
 
             return server
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         logger.error(f"Failed to import server: {str(e)}")

--- a/app/servers/routers/management.py
+++ b/app/servers/routers/management.py
@@ -11,6 +11,10 @@ from fastapi import (
 from sqlalchemy.orm import Session
 
 from app.auth.dependencies import get_current_user
+from app.backups.domain.exceptions import (
+    BackupNotFoundError,
+    BackupParentServerMissingError,
+)
 from app.core.database import get_db
 from app.core.exceptions import ConflictException
 from app.servers.api.dependencies import (
@@ -25,6 +29,7 @@ from app.servers.application.service import (
 from app.servers.application.service import (
     _server_service_legacy as server_service,  # legacy module-level alias (still referenced by older unit tests)
 )
+from app.servers.domain.exceptions import ServerAccessError, ServerNotFoundError
 from app.servers.models import ServerStatus
 from app.servers.schemas import (
     ServerCreateRequest,
@@ -146,7 +151,16 @@ async def get_server(
 
         return server
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -191,7 +205,16 @@ async def update_server(
 
         return server
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -233,7 +256,16 @@ async def delete_server(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Server not found"
             )
 
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(

--- a/app/templates/router.py
+++ b/app/templates/router.py
@@ -4,9 +4,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app.auth.dependencies import get_current_user
+from app.backups.domain.exceptions import (
+    BackupNotFoundError,
+    BackupParentServerMissingError,
+)
 from app.core.database import get_db
 from app.servers.api.dependencies import get_authorization_service
 from app.servers.application.authorization import AuthorizationService
+from app.servers.domain.exceptions import ServerAccessError, ServerNotFoundError
 from app.servers.models import ServerType
 from app.templates.api.dependencies import get_template_service
 from app.templates.application.service import (
@@ -85,7 +90,16 @@ async def create_template_from_server(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except TemplateError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -136,7 +150,16 @@ async def create_custom_template(
 
     except TemplateError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -245,7 +268,16 @@ async def get_template(
 
     except TemplateAccessError as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -290,7 +322,16 @@ async def update_template(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
     except TemplateError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -327,7 +368,16 @@ async def delete_template(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
     except TemplateError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(
@@ -393,7 +443,16 @@ async def clone_template(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
     except TemplateError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
-    except HTTPException:
+    except (
+        HTTPException,
+        ServerNotFoundError,
+        ServerAccessError,
+        BackupNotFoundError,
+        BackupParentServerMissingError,
+    ):
+        # Re-raise domain exceptions so the global handlers in
+        # ``app.core.error_handlers`` can map them to HTTP responses
+        # without being swallowed by the catch-all below (#273).
         raise
     except Exception as e:
         raise HTTPException(


### PR DESCRIPTION
## Summary

- Remove every FastAPI import (`HTTPException`, `Request`, `status`) from `app/servers/application/authorization.py` so the application-layer authorization service is framework-agnostic (#273).
- Drop the test-only `require_role` / `require_admin_or_operator` decorators that were preserved only for legacy tests retired in #290 (#292).
- Move audit logging out of `AuthorizationService` into the two production callsites in `app/servers/routers/control.py` (only places that pass the FastAPI `Request`).

## Architecture rationale

`AuthorizationService` is part of the application layer and should not depend on FastAPI. The legacy `HTTPException` raises and inline `AuditService.log_permission_check` calls forced both concerns up through the layer boundary. Lifting them out:

- Lets the same service be reused from non-HTTP entry points (background tasks, CLI, future event handlers) without dragging FastAPI in.
- Concentrates HTTP-mapping in one place (`app/core/error_handlers.py`) instead of scattering it across every raise site.
- Makes the audit-logging responsibility explicit at the router — the only layer that owns the `Request` lifecycle.

## Changes

### Application layer (framework-agnostic now)
- `app/servers/application/authorization.py`: remove `HTTPException` / `Request` / `status` / `wraps` / `AuditService` imports; trim `check_server_access` / `check_backup_access` signatures (no more `request: Optional[Request]` / `log_access: bool`); raise `ServerNotFoundError` / `BackupNotFoundError` / `BackupParentServerMissingError` instead of `HTTPException`; delete `require_role` and `require_admin_or_operator`.

### New domain exceptions + global handler
- `app/backups/domain/exceptions.py`: add `BackupDomainError`, `BackupNotFoundError`, `BackupParentServerMissingError`.
- `app/core/error_handlers.py` (new): `register_exception_handlers(app)` maps the four domain types to HTTP 403/404 with appropriate messages.
- `app/main.py`: wire the handlers immediately after `FastAPI(...)` construction.

### Router updates
- `app/servers/routers/control.py`: drop the `request` / `http_request` positional arg to `check_server_access` at the two callsites that passed it; re-emit the `permission_check` audit event after the call so `server_name`, `owner_id`, and `user_role` are preserved.
- `app/backups/router.py`, `app/backups/scheduler_router.py`, `app/files/router.py`, `app/servers/routers/import_export.py`, `app/servers/routers/management.py`, `app/templates/router.py`: extend each `except HTTPException: raise` ladder to also re-raise the four new domain types so they reach the global handler instead of being swallowed by `except Exception` and surfaced as 500. Drop the now-removed `log_access=False` opt-out from `delete_backup`'s parent-server lookup.

## Test plan

- [x] `uv run ruff check app/` — clean
- [x] `uv run ruff format app/` — no changes
- [x] `rg 'from fastapi|HTTPException|Request' app/servers/application/authorization.py` — only docstring hits
- [x] `rg 'require_role|require_admin_or_operator' app/ tests/` — only docstring hit
- [x] `uv run pytest tests/unit -m "not slow"` → **1106 passed**
- [x] `uv run pytest tests/integration -m "not slow"` → **427 passed**
- [x] `just test` (full suite) → **1718 passed**
- [x] `uv run pre-commit run --files <touched>` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)