### PR TITLE
refactor(templates): move Template ORM into app/templates/models.py (Resolves #255)

### DIFF
--- a/app/servers/models.py
+++ b/app/servers/models.py
@@ -1,8 +1,4 @@
-import json
-from typing import Any, Dict, List
-
 from sqlalchemy import (
-    JSON,
     BigInteger,
     Boolean,
     Column,
@@ -33,7 +29,6 @@ __all__ = [
     "ServerConfiguration",
     "ServerStatus",
     "ServerType",
-    "Template",
 ]
 
 
@@ -119,43 +114,9 @@ class ServerConfiguration(Base):
     __table_args__ = (UniqueConstraint("server_id", "configuration_key"),)
 
 
-class Template(Base):
-    __tablename__ = "templates"
-
-    id = Column(Integer, primary_key=True, index=True)
-    name = Column(String(100), nullable=False)
-    description = Column(Text)
-    minecraft_version = Column(String(20), nullable=False)
-    server_type: Column[ServerType] = Column(Enum(ServerType), nullable=False)
-    configuration = Column(JSON, nullable=False)  # server.properties and other settings
-    default_groups = Column(JSON)  # Default group attachments
-    created_by = Column(Integer, ForeignKey("users.id"), nullable=False)
-    is_public = Column(Boolean, default=False)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
-    )
-
-    # Relationships
-    creator = relationship("User", back_populates="templates")
-    servers = relationship("Server", back_populates="template")
-
-    def get_configuration(self) -> Dict[str, Any]:
-        """Get configuration as Python dict"""
-        if isinstance(self.configuration, str):
-            return json.loads(self.configuration)
-        return self.configuration or {}
-
-    def set_configuration(self, config: Dict[str, Any]) -> None:
-        """Set configuration from Python dict"""
-        self.configuration = config
-
-    def get_default_groups(self) -> Dict[str, List[int]]:
-        """Get default groups as Python dict"""
-        if isinstance(self.default_groups, str):
-            return json.loads(self.default_groups)
-        return self.default_groups or {"op_groups": [], "whitelist_groups": []}
-
-    def set_default_groups(self, groups: Dict[str, List[int]]) -> None:
-        """Set default groups from Python dict"""
-        self.default_groups = groups
+# NOTE: The `Template` ORM class was relocated to `app.templates.models`
+# in Issue #255. The `Server.template` relationship above uses a
+# string-based class reference, which SQLAlchemy resolves at
+# mapper-configuration time; `app/templates/__init__.py` eagerly imports
+# `app.templates.models` so the class is registered before
+# `Base.metadata.create_all()` runs.

--- a/app/templates/__init__.py
+++ b/app/templates/__init__.py
@@ -1,0 +1,10 @@
+"""Templates domain package.
+
+Eagerly imports `app.templates.models` so the `Template` SQLAlchemy
+class is registered with `Base.metadata` before
+`Base.metadata.create_all()` runs in `app.main` startup. This also
+ensures `Server.template = relationship("Template", ...)` in
+`app.servers.models` resolves at mapper-configuration time.
+"""
+
+from . import models  # noqa: F401

--- a/app/templates/adapters/repository.py
+++ b/app/templates/adapters/repository.py
@@ -5,15 +5,11 @@ is the only layer that knows about the SQLAlchemy ORM and the
 `Template` columns; it converts ORM rows to/from `TemplateEntity` so
 the application layer never sees ORM types.
 
-The `Template` ORM class currently lives at
-`app.servers.models.Template` for historical reasons (no Alembic;
-relocating the owning module needs careful import-ordering with the
-`Server.template` back-population). The model is functionally a
-templates-domain table; the import direction here
-(`templates.adapters` → `servers.models`) is an artefact of file
-placement, not a cross-domain Port bypass per `docs/ARCHITECTURE.md`
-§4.3. Follow-up: see the issue linked from the #225 PR description for
-the planned `app/templates/models.py` relocation.
+The `Template` ORM class lives at `app.templates.models.Template`
+(relocated in Issue #255). `Server` is still imported from
+`app.servers.models` because templates-side queries need to filter on
+the servers FK; that direction is allowed per
+`docs/ARCHITECTURE.md` §4.3.
 
 Per the UnitOfWork pattern, repository methods **do not commit**. They
 stage changes on the session and rely on the surrounding
@@ -25,7 +21,7 @@ from typing import Dict, Optional
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
-from app.servers.models import Server, ServerType, Template
+from app.servers.models import Server, ServerType
 from app.templates.domain.entities import (
     CreateTemplateCommand,
     TemplateEntity,
@@ -33,6 +29,7 @@ from app.templates.domain.entities import (
     TemplateListSpec,
     UpdateTemplateCommand,
 )
+from app.templates.models import Template
 
 
 def _template_to_entity(row: Template) -> TemplateEntity:

--- a/app/templates/models.py
+++ b/app/templates/models.py
@@ -1,0 +1,86 @@
+"""SQLAlchemy ORM models for the templates domain.
+
+The `Template` ORM was originally co-located with the servers domain in
+`app/servers/models.py`. Moving it here (Issue #255) restores the
+domain-aligned layout introduced by the hexagonal refactor in #225.
+
+Note on mapper configuration:
+    `app.servers.models.Server` declares
+    `template = relationship("Template", back_populates="servers")`
+    using a string-based class reference. SQLAlchemy resolves that
+    reference at mapper-configuration time, so this module must be
+    imported *before* the first mapper-config trigger
+    (i.e. before `Base.metadata.create_all()` in `app.main`).
+
+    `app/templates/__init__.py` eagerly imports this module
+    (`from . import models  # noqa: F401`) so any code that imports the
+    `app.templates` package — including `from app.templates.router
+    import router` in `app.main` — guarantees the class is registered
+    in time. The pre-existing chain `templates.router → application →
+    adapters.repository` also imports this module, providing belt-
+    and-braces coverage.
+"""
+
+import json
+from typing import Any, Dict, List
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+from app.servers.domain.value_objects import ServerType
+
+__all__ = ["Template"]
+
+
+class Template(Base):
+    __tablename__ = "templates"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False)
+    description = Column(Text)
+    minecraft_version = Column(String(20), nullable=False)
+    server_type: Column[ServerType] = Column(Enum(ServerType), nullable=False)
+    configuration = Column(JSON, nullable=False)  # server.properties and other settings
+    default_groups = Column(JSON)  # Default group attachments
+    created_by = Column(Integer, ForeignKey("users.id"), nullable=False)
+    is_public = Column(Boolean, default=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    # Relationships
+    creator = relationship("User", back_populates="templates")
+    servers = relationship("Server", back_populates="template")
+
+    def get_configuration(self) -> Dict[str, Any]:
+        """Get configuration as Python dict"""
+        if isinstance(self.configuration, str):
+            return json.loads(self.configuration)
+        return self.configuration or {}
+
+    def set_configuration(self, config: Dict[str, Any]) -> None:
+        """Set configuration from Python dict"""
+        self.configuration = config
+
+    def get_default_groups(self) -> Dict[str, List[int]]:
+        """Get default groups as Python dict"""
+        if isinstance(self.default_groups, str):
+            return json.loads(self.default_groups)
+        return self.default_groups or {"op_groups": [], "whitelist_groups": []}
+
+    def set_default_groups(self, groups: Dict[str, List[int]]) -> None:
+        """Set default groups from Python dict"""
+        self.default_groups = groups

--- a/tests/integration/templates/test_template_repository.py
+++ b/tests/integration/templates/test_template_repository.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional
 
 import pytest
 
-from app.servers.models import Server, ServerStatus, ServerType, Template
+from app.servers.models import Server, ServerStatus, ServerType
 from app.templates.adapters.repository import SqlAlchemyTemplateRepository
 from app.templates.adapters.uow import SqlAlchemyTemplatesUnitOfWork
 from app.templates.domain.entities import (
@@ -19,6 +19,7 @@ from app.templates.domain.entities import (
     TemplateListSpec,
     UpdateTemplateCommand,
 )
+from app.templates.models import Template
 from app.users.models import User
 
 

--- a/tests/unit/servers/test_models.py
+++ b/tests/unit/servers/test_models.py
@@ -8,7 +8,8 @@ from datetime import datetime
 
 import pytest
 
-from app.servers.models import ServerStatus, ServerType, Template
+from app.servers.models import ServerStatus, ServerType
+from app.templates.models import Template
 
 
 class TestTemplate:


### PR DESCRIPTION
## Summary

Relocate the `Template` SQLAlchemy ORM class from `app/servers/models.py` to a new `app/templates/models.py`, ending the templates-table co-location with the servers domain (Issue #255, follow-up to #225).

- `app/templates/models.py` now defines `Template` (incl. `get_configuration`, `set_configuration`, `get_default_groups`, `set_default_groups`).
- `app/servers/models.py` keeps the `Server.template` relationship declaration but no longer defines the class.
- Three callsites updated to import from `app.templates.models`:
  - `app/templates/adapters/repository.py`
  - `tests/integration/templates/test_template_repository.py`
  - `tests/unit/servers/test_models.py`
- `__tablename__` unchanged (`templates`) - no Alembic migration required, no row-level impact.

## Architecture rationale

Per `docs/ARCHITECTURE.md` §4.3, the templates table belongs to the templates domain. The class living under `app.servers.models` was an artefact of the hexagonal refactor in #225 deferring the relocation. The templates adapter still imports `Server` for the cross-domain `count_active_dependent_servers` query, which is an allowed direction (templates -> servers).

## Mapper-config order rationale

`Server.template = relationship("Template", back_populates="servers")` uses a string-based class reference, resolved by SQLAlchemy at mapper-configuration time. To guarantee the class is registered with `Base.metadata` before `Base.metadata.create_all()` runs in `app.main` startup, `app/templates/__init__.py` now eagerly imports the models module:

```python
from . import models  # noqa: F401
```

Any code that imports the `app.templates` package - including `from app.templates.router import router` in `app.main` - triggers this load. The pre-existing chain `templates.router -> application.service -> adapters.repository -> templates.models` provides belt-and-braces coverage.

## Test plan

- [x] `rg -n 'from app.servers.models import .*Template' app/ tests/` -> 0 hits
- [x] `uv run ruff check` on touched files: clean
- [x] `uv run pytest tests/unit -m "not slow"`: pass
- [x] `uv run pytest tests/integration -m "not slow"`: pass
- [x] `just test` (full suite incl. slow): 1718 passed, 10 skipped
- [x] `uv run pre-commit run --files <touched>`: pass

Resolves #255

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

[Generated with Claude Code](https://claude.com/claude-code)