### PR TITLE
refactor(backups): move Backup ORM into app/backups/models.py (Resolves #263)

### DIFF
--- a/app/backups/__init__.py
+++ b/app/backups/__init__.py
@@ -1,5 +1,12 @@
 """Backups domain package.
 
+Eagerly imports `app.backups.models` so the `Backup`, `BackupSchedule`,
+and `BackupScheduleLog` SQLAlchemy classes are registered with
+`Base.metadata` before `Base.metadata.create_all()` runs in `app.main`
+startup. This also ensures `Server.backups` / `Server.backup_schedule`
+relationships in `app.servers.models` resolve at mapper-configuration
+time.
+
 Re-exports the lifespan-scoped `backup_scheduler_instance` holder so
 that the FastAPI app startup (`app.main._initialize_backup_scheduler`)
 and the module-level `_SchedulerProxy` (in
@@ -17,6 +24,10 @@ test double; production calls `make_backup_scheduler()` in
 """
 
 from typing import TYPE_CHECKING, Optional
+
+from . import (
+    models,  # noqa: F401  # eager import so ORM classes register before create_all
+)
 
 if TYPE_CHECKING:
     from app.backups.application.scheduler import BackupSchedulerService

--- a/app/backups/adapters/repository.py
+++ b/app/backups/adapters/repository.py
@@ -37,9 +37,8 @@ from app.backups.domain.entities import (
     UpdateBackupFileCommand,
     UpdateBackupScheduleCommand,
 )
-from app.backups.models import BackupSchedule, BackupScheduleLog
+from app.backups.models import Backup, BackupSchedule, BackupScheduleLog, BackupStatus
 from app.core.datetime_utils import utcnow
-from app.servers.models import Backup, BackupStatus
 
 
 def _backup_to_entity(row: Backup) -> BackupEntity:

--- a/app/backups/application/file_service.py
+++ b/app/backups/application/file_service.py
@@ -15,9 +15,10 @@ import tarfile
 from datetime import datetime
 from pathlib import Path
 
+from app.backups.models import Backup, BackupType
 from app.core.exceptions import FileOperationException, handle_file_error
 from app.core.security import SecurityError, TarExtractor
-from app.servers.models import Backup, BackupType, Server
+from app.servers.models import Server
 
 logger = logging.getLogger(__name__)
 

--- a/app/backups/application/service.py
+++ b/app/backups/application/service.py
@@ -26,6 +26,12 @@ from app.backups.domain.entities import (
     UpdateBackupFileCommand,
 )
 from app.backups.domain.ports import BackupsUnitOfWork
+
+# `BackupStatus` / `BackupType` are runtime-required (used as values, not
+# just type annotations). The `Server` ORM class is only referenced from
+# type annotations, so it stays under TYPE_CHECKING to keep the
+# application layer free of cross-domain ORM imports at runtime.
+from app.backups.models import BackupStatus, BackupType
 from app.core.exceptions import (
     BackupNotFoundException,
     DatabaseOperationException,
@@ -41,14 +47,6 @@ from app.core.security import SecurityError, TarExtractor
 # Port in a follow-up (#154-9).
 from app.servers.application.minecraft_server import minecraft_server_manager
 from app.servers.domain.ports import ServerReadPort
-
-# `BackupStatus` / `BackupType` are runtime-required (used as values, not
-# just type annotations) — we accept the cross-domain enum import as a
-# documented deviation (see `docs/ARCHITECTURE.md` adoption notes). The
-# `Server` ORM class is only referenced from type annotations, so it
-# stays under TYPE_CHECKING to keep the application layer free of ORM
-# imports at runtime.
-from app.servers.models import BackupStatus, BackupType
 
 if TYPE_CHECKING:
     from fastapi import UploadFile

--- a/app/backups/domain/__init__.py
+++ b/app/backups/domain/__init__.py
@@ -5,10 +5,11 @@ Contains pure domain entities (`entities.py`), Port (Protocol) definitions
 framework, database driver, or HTTP client.
 
 `BackupType` / `BackupStatus` value objects live at
-`app.servers.domain.value_objects` (re-exported from `app.servers.models`
-for the SQLAlchemy column declaration). The `Backup` ORM class itself
-still lives at `app.servers.models.Backup`; adapters import it from
-that module.
+`app.servers.domain.value_objects` so that adjacent domain modules can
+reference them without transitively loading SQLAlchemy. The `Backup`
+ORM class lives at `app.backups.models.Backup` (relocated from
+`app.servers.models` in Issue #263); adapters import it from that
+module.
 
 See `docs/ARCHITECTURE.md` §4.1.
 """

--- a/app/backups/models.py
+++ b/app/backups/models.py
@@ -1,7 +1,31 @@
+"""SQLAlchemy ORM models for the backups domain.
+
+The `Backup` ORM was originally co-located with the servers domain in
+`app/servers/models.py`. Moving it here (Issue #263) restores the
+domain-aligned layout introduced by the hexagonal refactor in #225 and
+consolidates all backup tables (`Backup`, `BackupSchedule`,
+`BackupScheduleLog`) under one module. This mirrors the `Template` ORM
+relocation in PR #303 (Issue #255).
+
+Note on mapper configuration:
+    `app.servers.models.Server` declares
+    `backups = relationship("Backup", back_populates="server", ...)`
+    using a string-based class reference. SQLAlchemy resolves that
+    reference at mapper-configuration time, so this module must be
+    imported *before* the first mapper-config trigger
+    (i.e. before `Base.metadata.create_all()` in `app.main`).
+
+    `app/backups/__init__.py` eagerly imports this module
+    (`from . import models  # noqa: F401`) so any code that imports the
+    `app.backups` package — including `from app.backups.router import
+    router` in `app.main` — guarantees the class is registered in time.
+"""
+
 from enum import Enum as PyEnum
 
 from sqlalchemy import (
     JSON,
+    BigInteger,
     Boolean,
     CheckConstraint,
     Column,
@@ -10,11 +34,42 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     String,
+    Text,
 )
 from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
 
 from app.core.database import Base
 from app.core.datetime_utils import utcnow
+from app.servers.domain.value_objects import BackupStatus, BackupType
+
+__all__ = [
+    "Backup",
+    "BackupSchedule",
+    "BackupScheduleLog",
+    "BackupStatus",
+    "BackupType",
+    "ScheduleAction",
+]
+
+
+class Backup(Base):
+    __tablename__ = "backups"
+
+    id = Column(Integer, primary_key=True, index=True)
+    server_id = Column(Integer, ForeignKey("servers.id"), nullable=False)
+    name = Column(String(100), nullable=False)
+    description = Column(Text)
+    file_path = Column(String(500), nullable=False)
+    file_size = Column(BigInteger, nullable=False)  # bytes
+    backup_type: Column[BackupType] = Column(Enum(BackupType), default=BackupType.manual)
+    status: Column[BackupStatus] = Column(
+        Enum(BackupStatus), default=BackupStatus.creating
+    )
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    # Relationships
+    server = relationship("Server", back_populates="backups")
 
 
 class ScheduleAction(str, PyEnum):

--- a/app/backups/router.py
+++ b/app/backups/router.py
@@ -35,6 +35,7 @@ from app.backups.domain.exceptions import (
     BackupNotFoundError,
     BackupParentServerMissingError,
 )
+from app.backups.models import BackupStatus, BackupType
 from app.backups.schemas import (
     BackupCreateRequest,
     BackupListResponse,
@@ -57,7 +58,6 @@ from app.core.exceptions import (
 from app.servers.api.dependencies import get_authorization_service
 from app.servers.application.authorization import AuthorizationService
 from app.servers.domain.exceptions import ServerAccessError, ServerNotFoundError
-from app.servers.models import BackupStatus, BackupType
 from app.templates.api.dependencies import get_template_service
 from app.templates.application.service import TemplateService
 from app.users.domain.value_objects import Role

--- a/app/backups/schemas.py
+++ b/app/backups/schemas.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from app.servers.models import BackupStatus, BackupType
+from app.backups.models import BackupStatus, BackupType
 
 
 class BackupCreateRequest(BaseModel):

--- a/app/servers/application/authorization.py
+++ b/app/servers/application/authorization.py
@@ -54,10 +54,11 @@ from app.backups.domain.exceptions import (
     BackupParentServerMissingError,
 )
 from app.backups.domain.ports import BackupRepository
+from app.backups.models import Backup
 from app.servers.domain.entities import ServerEntity
 from app.servers.domain.exceptions import ServerNotFoundError
 from app.servers.domain.ports import ServerRepository
-from app.servers.models import Backup, Server
+from app.servers.models import Server
 from app.templates.domain.ports import TemplateRepository
 from app.users.domain.value_objects import Role
 from app.users.models import User

--- a/app/servers/models.py
+++ b/app/servers/models.py
@@ -1,5 +1,4 @@
 from sqlalchemy import (
-    BigInteger,
     Boolean,
     Column,
     DateTime,
@@ -15,16 +14,11 @@ from sqlalchemy.sql import func
 
 from app.core.database import Base
 from app.servers.domain.value_objects import (
-    BackupStatus,
-    BackupType,
     ServerStatus,
     ServerType,
 )
 
 __all__ = [
-    "Backup",
-    "BackupStatus",
-    "BackupType",
     "Server",
     "ServerConfiguration",
     "ServerStatus",
@@ -78,25 +72,6 @@ class Server(Base):
     )
 
 
-class Backup(Base):
-    __tablename__ = "backups"
-
-    id = Column(Integer, primary_key=True, index=True)
-    server_id = Column(Integer, ForeignKey("servers.id"), nullable=False)
-    name = Column(String(100), nullable=False)
-    description = Column(Text)
-    file_path = Column(String(500), nullable=False)
-    file_size = Column(BigInteger, nullable=False)  # bytes
-    backup_type: Column[BackupType] = Column(Enum(BackupType), default=BackupType.manual)
-    status: Column[BackupStatus] = Column(
-        Enum(BackupStatus), default=BackupStatus.creating
-    )
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-
-    # Relationships
-    server = relationship("Server", back_populates="backups")
-
-
 class ServerConfiguration(Base):
     __tablename__ = "server_configurations"
 
@@ -115,8 +90,11 @@ class ServerConfiguration(Base):
 
 
 # NOTE: The `Template` ORM class was relocated to `app.templates.models`
-# in Issue #255. The `Server.template` relationship above uses a
-# string-based class reference, which SQLAlchemy resolves at
-# mapper-configuration time; `app/templates/__init__.py` eagerly imports
-# `app.templates.models` so the class is registered before
-# `Base.metadata.create_all()` runs.
+# in Issue #255, and the `Backup` ORM class (with `BackupType` and
+# `BackupStatus` re-exports) was relocated to `app.backups.models` in
+# Issue #263. The `Server.template` / `Server.backups` /
+# `Server.backup_schedule` relationships above use string-based class
+# references, which SQLAlchemy resolves at mapper-configuration time;
+# `app/templates/__init__.py` and `app/backups/__init__.py` eagerly
+# import their respective `models` modules so the classes are registered
+# before `Base.metadata.create_all()` runs.

--- a/tests/integration/api/test_backup_router_comprehensive.py
+++ b/tests/integration/api/test_backup_router_comprehensive.py
@@ -20,13 +20,14 @@ from app.backups.domain.entities import (
     BackupListPage,
     BackupStatistics,
 )
+from app.backups.models import Backup, BackupStatus, BackupType
 from app.core.exceptions import (
     BackupNotFoundException,
     FileOperationException,
     ServerNotFoundException,
 )
 from app.main import app
-from app.servers.models import Backup, BackupStatus, BackupType, Server, ServerType
+from app.servers.models import Server, ServerType
 from app.users.domain.value_objects import Role
 from app.users.models import User
 

--- a/tests/integration/backups/test_backup_repository.py
+++ b/tests/integration/backups/test_backup_repository.py
@@ -15,7 +15,8 @@ from app.backups.domain.entities import (
     CreateBackupCommand,
     UpdateBackupFileCommand,
 )
-from app.servers.models import Backup, BackupStatus, BackupType, Server, ServerType
+from app.backups.models import Backup, BackupStatus, BackupType
+from app.servers.models import Server, ServerType
 
 
 @pytest.fixture

--- a/tests/integration/backups/test_backups_uow.py
+++ b/tests/integration/backups/test_backups_uow.py
@@ -15,8 +15,14 @@ from app.backups.domain.entities import (
     CreateBackupCommand,
     CreateBackupScheduleCommand,
 )
-from app.backups.models import BackupSchedule, BackupScheduleLog, ScheduleAction
-from app.servers.models import Backup, BackupType, Server, ServerType
+from app.backups.models import (
+    Backup,
+    BackupSchedule,
+    BackupScheduleLog,
+    BackupType,
+    ScheduleAction,
+)
+from app.servers.models import Server, ServerType
 
 
 def _seed_server(db, owner_id: int, *, name: str = "u", port: int = 25700) -> Server:

--- a/tests/integration/backups/test_orphan_prevention.py
+++ b/tests/integration/backups/test_orphan_prevention.py
@@ -28,8 +28,9 @@ from fastapi import UploadFile
 from app.backups.adapters.uow import SqlAlchemyBackupsUnitOfWork
 from app.backups.application import service as backup_service_module
 from app.backups.application.service import BackupService
+from app.backups.models import Backup
 from app.servers.adapters.read_port import SqlAlchemyServerReadPort
-from app.servers.models import Backup, Server, ServerType
+from app.servers.models import Server, ServerType
 
 
 @pytest.fixture

--- a/tests/unit/backups/fakes.py
+++ b/tests/unit/backups/fakes.py
@@ -29,9 +29,9 @@ from app.backups.domain.entities import (
     UpdateBackupFileCommand,
     UpdateBackupScheduleCommand,
 )
-from app.backups.models import ScheduleAction
+from app.backups.models import BackupStatus, BackupType, ScheduleAction
 from app.servers.domain.entities import ServerEntity
-from app.servers.models import BackupStatus, BackupType, ServerType
+from app.servers.models import ServerType
 
 
 def _utcnow() -> datetime:

--- a/tests/unit/backups/test_service_with_fake.py
+++ b/tests/unit/backups/test_service_with_fake.py
@@ -10,12 +10,12 @@ from pathlib import Path
 import pytest
 
 from app.backups.application.service import BackupService
+from app.backups.models import BackupStatus, BackupType
 from app.core.exceptions import (
     BackupNotFoundException,
     ServerNotFoundException,
     ServerStateException,
 )
-from app.servers.models import BackupStatus, BackupType
 from tests.unit.backups.fakes import (
     FakeBackupsUnitOfWork,
     FakeServerReadPort,


### PR DESCRIPTION
## Summary

Relocate the `Backup` SQLAlchemy ORM class from `app/servers/models.py` to `app/backups/models.py`, consolidating all backup tables (`Backup`, `BackupSchedule`, `BackupScheduleLog`) under one module. Sibling follow-up to PR #303 (Template ORM relocation, Issue #255); same mechanical pattern.

- `app/backups/models.py` now defines `Backup` alongside the existing `BackupSchedule` / `BackupScheduleLog` / `ScheduleAction`, and re-exports `BackupType` / `BackupStatus` (imported from the canonical domain-pure `app.servers.domain.value_objects`).
- `app/servers/models.py` drops the `Backup` class plus the `BackupStatus` / `BackupType` re-exports. The `Server.backups` / `Server.backup_schedule` relationships use string-based class references and are unchanged.
- `__tablename__ = "backups"` unchanged — no Alembic migration required, no row-level impact.
- `app/backups/domain/__init__.py` deviation note updated to reflect the new ORM home.

## Mapper-config order rationale

`Server.backups = relationship("Backup", back_populates="server", ...)` uses a string-based class reference, resolved by SQLAlchemy at mapper-configuration time. To guarantee the class is registered with `Base.metadata` before `Base.metadata.create_all()` runs in `app.main` startup, `app/backups/__init__.py` now eagerly imports the models module:

```python
from . import models  # noqa: F401
```

Any code that imports the `app.backups` package — including `from app.backups.router import router` in `app.main` — triggers this load. Several pre-existing chains (router → application.service → adapters.repository → backups.models, etc.) also import the module, providing belt-and-braces coverage.

## Callsite updates (16 files)

**Production (8):**
- `app/backups/__init__.py` (eager import)
- `app/backups/adapters/repository.py`
- `app/backups/application/file_service.py`
- `app/backups/application/service.py`
- `app/backups/domain/__init__.py`
- `app/backups/router.py`
- `app/backups/schemas.py`
- `app/servers/application/authorization.py`

**Tests (6):**
- `tests/integration/api/test_backup_router_comprehensive.py`
- `tests/integration/backups/test_backup_repository.py`
- `tests/integration/backups/test_backups_uow.py`
- `tests/integration/backups/test_orphan_prevention.py`
- `tests/unit/backups/fakes.py`
- `tests/unit/backups/test_service_with_fake.py`

**ORM (2):**
- `app/backups/models.py` (add `Backup` + re-exports)
- `app/servers/models.py` (remove `Backup` + re-exports)

## Test plan

- [x] `rg -n 'from app.servers.models import .*(Backup|BackupType|BackupStatus)\b' app/ tests/` → 0 hits
- [x] `uv run ruff check` on touched files: clean
- [x] `uv run pytest tests/unit -m "not slow"`: pass
- [x] `uv run pytest tests/integration -m "not slow"`: pass (1533 passed, 10 skipped combined)
- [x] `just test` (full suite incl. slow): 1718 passed, 10 skipped
- [x] `uv run pre-commit run --files <touched>`: pass (all hooks)

Resolves #263

[Generated with Claude Code](https://claude.com/claude-code)