### PR TITLE
refactor: denormalize server_owner_id onto BackupEntity, restore can_delete_backup 2-arg (Resolves #274)

### DIFF
--- a/app/backups/adapters/repository.py
+++ b/app/backups/adapters/repository.py
@@ -44,10 +44,15 @@ from app.core.datetime_utils import utcnow
 def _backup_to_entity(row: Backup) -> BackupEntity:
     """Convert an ORM row to a `BackupEntity`.
 
-    Reads `row.server.name` / `row.server.minecraft_version` eagerly:
-    callers that need these fields must load the row with
-    `joinedload(Backup.server)` so the access does not trigger a
-    separate SELECT.
+    Reads `row.server.name` / `row.server.minecraft_version` /
+    `row.server.owner_id` eagerly: callers that need these fields must
+    load the row with `joinedload(Backup.server)` so the access does
+    not trigger a separate SELECT.
+
+    `server_owner_id` is denormalised under #274 so that
+    ``AuthorizationService.can_delete_backup`` can keep a two-argument
+    signature and the delete-backup router no longer needs a second
+    round-trip to fetch the parent server purely for its owner.
     """
     return BackupEntity(
         id=row.id,
@@ -63,6 +68,7 @@ def _backup_to_entity(row: Backup) -> BackupEntity:
         minecraft_version=row.server.minecraft_version
         if row.server is not None
         else None,
+        server_owner_id=row.server.owner_id if row.server is not None else None,
     )
 
 

--- a/app/backups/domain/entities.py
+++ b/app/backups/domain/entities.py
@@ -29,10 +29,17 @@ from app.servers.domain.value_objects import (
 class BackupEntity:
     """A persisted backup row.
 
-    `server_name` / `minecraft_version` are denormalised onto the entity
-    because the wire response (`BackupResponse`) needs both and the
-    adapter eager-loads `Backup.server` via `joinedload` to avoid a
-    per-row N+1.
+    `server_name` / `minecraft_version` / `server_owner_id` are
+    denormalised onto the entity because the wire response
+    (`BackupResponse`) needs the first two, and the authorization
+    layer needs `server_owner_id` to decide whether the caller may
+    delete the backup. The adapter eager-loads `Backup.server` via
+    `joinedload` to populate all three without a per-row N+1.
+
+    `server_owner_id` is `Optional[int]` only to mirror the defensive
+    handling already present for `server_name` / `minecraft_version`
+    when `row.server` is absent (the FK is `nullable=False`, so the
+    None branch is unreachable in production; see #274).
     """
 
     id: int
@@ -46,6 +53,7 @@ class BackupEntity:
     created_at: datetime
     server_name: Optional[str]
     minecraft_version: Optional[str]
+    server_owner_id: Optional[int]
 
 
 @dataclass(frozen=True)

--- a/app/backups/router.py
+++ b/app/backups/router.py
@@ -582,14 +582,10 @@ async def delete_backup(
     try:
         backup = await auth.check_backup_access(backup_id, current_user)
 
-        # The legacy `can_delete_backup(backup, user)` reached through
-        # `backup.server.owner_id` (ORM relationship). With the domain
-        # entity that relationship is denormalised away, so we fetch
-        # the parent server explicitly and pass it as the third arg.
-        # ``check_server_access`` no longer emits an audit log on its
-        # own (#273), so no ``log_access`` opt-out is required.
-        parent = await auth.check_server_access(backup.server_id, current_user)
-        if not AuthorizationService.can_delete_backup(backup, current_user, parent):
+        # `BackupEntity` carries `server_owner_id` denormalised by the
+        # repository (#274), so the ownership check no longer needs a
+        # second round-trip to fetch the parent server.
+        if not AuthorizationService.can_delete_backup(backup, current_user):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Only admins and server owners can delete backups",

--- a/app/servers/application/authorization.py
+++ b/app/servers/application/authorization.py
@@ -37,10 +37,13 @@ Method semantics:
 - Boolean helpers (``is_admin``, ``can_*``) remain ``@staticmethod``
   because they read only fields of ``User`` and do not touch the
   database.
-- ``can_delete_backup`` accepts the parent ``ServerEntity`` (its one
-  previous caller used to pass an ORM ``Backup`` and reach through
-  ``backup.server.owner_id``; that path is no longer available off the
-  domain entity, so the caller passes the server explicitly).
+- ``can_delete_backup`` is two-argument again (``backup``, ``user``).
+  The transitional three-argument form added in #228 PR 2b
+  (``server=None``) was removed under #274 once ``BackupEntity``
+  started carrying a denormalised ``server_owner_id`` populated by
+  the repository's ``joinedload(Backup.server)``. Legacy ORM
+  ``Backup`` rows still work because the static helper falls back to
+  ``backup.server.owner_id`` when the input is not a ``BackupEntity``.
 
 The legacy module path ``app.services.authorization_service`` continues
 to re-export ``AuthorizationService`` for tests that have not yet been
@@ -198,26 +201,28 @@ class AuthorizationService:
         return user.role == Role.admin or getattr(server, "owner_id", None) == user.id
 
     @staticmethod
-    def can_delete_backup(backup, user: User, server=None) -> bool:
+    def can_delete_backup(backup, user: User) -> bool:
         """Admin or owner of the backup's parent server may delete the backup.
 
-        Accepts either a legacy ORM ``Backup`` (whose ``backup.server``
-        relationship still resolves) or a domain ``BackupEntity`` plus
-        the parent ``ServerEntity`` passed explicitly via ``server``.
-        The two-argument legacy form is preserved for tests that pre-date
-        #228.
+        Accepts either a domain ``BackupEntity`` (reads the
+        ``server_owner_id`` field denormalised by the repository under
+        #274) or a legacy ORM ``Backup`` (reaches through the
+        ``backup.server`` relationship; preserved for tests that pre-date
+        #228).
         """
         if user.role == Role.admin:
             return True
-        if server is not None:
-            return getattr(server, "owner_id", None) == user.id
+        if isinstance(backup, BackupEntity):
+            return backup.server_owner_id == user.id
         # Legacy ORM path: ``backup.server`` is a relationship.
         if isinstance(backup, Backup):
             return backup.server.owner_id == user.id
-        # Domain entity without explicit server — caller bug.
-        raise ValueError(
-            "can_delete_backup requires the parent server when called with a BackupEntity"
-        )
+        # Defensive: anything else with a usable attribute.
+        owner_id = getattr(backup, "server_owner_id", None)
+        if owner_id is None:
+            server = getattr(backup, "server", None)
+            owner_id = getattr(server, "owner_id", None) if server is not None else None
+        return owner_id == user.id
 
     @staticmethod
     def filter_servers_for_user(user: User, servers, db=None) -> list:

--- a/tests/integration/api/test_backup_router_comprehensive.py
+++ b/tests/integration/api/test_backup_router_comprehensive.py
@@ -51,6 +51,7 @@ def make_entity(
     server_name=None,
     minecraft_version=None,
     created_at=None,
+    server_owner_id=None,
 ) -> BackupEntity:
     """Helper to build a domain entity for AsyncMock return values."""
     return BackupEntity(
@@ -65,6 +66,7 @@ def make_entity(
         created_at=created_at or datetime.now(),
         server_name=server_name,
         minecraft_version=minecraft_version,
+        server_owner_id=server_owner_id,
     )
 
 

--- a/tests/unit/backups/fakes.py
+++ b/tests/unit/backups/fakes.py
@@ -102,6 +102,7 @@ class FakeBackupRepository:
             created_at=_utcnow(),
             server_name=None,
             minecraft_version=None,
+            server_owner_id=None,
         )
         self._records[self._next_id] = entity
         self._next_id += 1
@@ -370,6 +371,7 @@ def make_backup_entity(
     created_at: Optional[datetime] = None,
     server_name: Optional[str] = None,
     minecraft_version: Optional[str] = None,
+    server_owner_id: Optional[int] = None,
 ) -> BackupEntity:
     return BackupEntity(
         id=id,
@@ -383,6 +385,7 @@ def make_backup_entity(
         created_at=created_at or _utcnow(),
         server_name=server_name,
         minecraft_version=minecraft_version,
+        server_owner_id=server_owner_id,
     )
 
 


### PR DESCRIPTION
## Summary

PR #269 (#228 PR 2b) added a transitional 3-arg form
`can_delete_backup(backup, user, server=None)` because the domain
`BackupEntity` did not carry the parent server's `owner_id`. The
`delete_backup` router had to issue a second `check_server_access`
round-trip purely to hand that server to the ownership check.

This PR denormalises `server_owner_id` onto `BackupEntity` (populated
from the already-eager-loaded `Backup.server` via the repository's
existing `joinedload`), so the authorization check collapses back to
its legacy 2-arg signature and the router drops the extra round-trip.

Resolves #274.

## Why

- The 3-arg form was a temporary bridge while the domain entity was
  in flux — see `app/servers/application/authorization.py` docstring
  (now updated).
- The extra `check_server_access` call in `delete_backup` was N+1 noise
  (the data was already in the entity, just not exposed).
- Keeps `can_delete_*` boolean helpers symmetric across the codebase
  (all other variants are 2-arg).

## Changes

- **`app/backups/domain/entities.py`** — add `server_owner_id:
  Optional[int]` to `BackupEntity`. Optional only to mirror the
  defensive `None` handling already used for `server_name` /
  `minecraft_version` (the FK is `nullable=False`, so the `None`
  branch is unreachable in production).
- **`app/backups/adapters/repository.py`** —
  `_backup_to_entity` populates `server_owner_id` from
  `row.server.owner_id`. No new query: `joinedload(Backup.server)`
  was already in place for `server_name` / `minecraft_version`.
- **`app/servers/application/authorization.py`** — drop the `server=None`
  third parameter from `can_delete_backup`. Read
  `BackupEntity.server_owner_id` directly. The legacy ORM `Backup`
  branch (`backup.server.owner_id`) is preserved for pre-#228 tests.
  Docstring updated.
- **`app/backups/router.py::delete_backup`** — drop the second
  `check_server_access` round-trip.
- **Tests** — `tests/unit/backups/fakes.py` and
  `tests/integration/api/test_backup_router_comprehensive.py` updated
  to populate the new field on the in-memory fake + helper.

## Callsite delta

- 3-arg callsites: 1 -> 0 (only `app/backups/router.py:592` referenced
  the third arg).
- `AuthorizationService.check_server_access` extra invocations in the
  delete-backup path: 1 -> 0.

## Test plan

- [x] `uv run ruff check app/ tests/` (touched files) — passed.
- [x] `uv run pytest tests/unit -m "not slow"` — 1106 passed.
- [x] `uv run pytest tests/integration -m "not slow"` — 427 passed.
- [x] `just test` (full suite) — 1718 passed, 10 skipped, ~2 min.
- [x] `uv run pre-commit run --files <touched>` — passed.
- [x] `rg 'can_delete_backup\([^)]*,[^)]*,'` — no 3-arg callsites remain.

## Notes

- Orphan-backup handling: `Backup.server_id` is `nullable=False`
  and `Server.owner_id` is `nullable=False`, so a missing
  `server_owner_id` is unreachable in normal data. The defensive
  `Optional[int]` is kept symmetric with `server_name` /
  `minecraft_version`, which already follow the same "tolerate
  `row.server is None`" pattern in `_backup_to_entity`.
- The 2-arg form still accepts a legacy ORM `Backup` row through the
  `isinstance(backup, Backup)` branch for the small number of pre-#228
  tests that have not been migrated.