### PR TITLE
refactor: wrap update_server / delete_server in ServersUnitOfWork (Resolves #278)

### DIFF
--- a/app/servers/application/service.py
+++ b/app/servers/application/service.py
@@ -72,6 +72,7 @@ from app.servers.application.server_properties_generator import (
 from app.servers.domain.entities import (
     CreateServerCommand,
     ServerListSpec,
+    UpdateServerCommand,
 )
 from app.servers.domain.ports import ServerRepository, ServersUnitOfWork
 from app.servers.models import (
@@ -732,7 +733,16 @@ class ServerService:
                     f"{request.server_properties['server-port']}"
                 )
 
-        updated_server = self.database_service.update_server_record(server, request, db)
+        # Persist via UoW + repo when DI wired; legacy path otherwise
+        # (parity with `create_server`). The legacy fallback preserves
+        # the existing unit-test contract that constructs `ServerService()`
+        # without DI and mocks `database_service.update_server_record`.
+        if self._uow is not None:
+            updated_server = await self._update_via_uow(server_id, request)
+        else:
+            updated_server = self.database_service.update_server_record(
+                server, request, db
+            )
 
         await self._sync_server_properties_after_update(
             updated_server, request.server_properties
@@ -740,9 +750,66 @@ class ServerService:
 
         return ServerResponse.model_validate(updated_server)
 
+    async def _update_via_uow(
+        self, server_id: int, request: ServerUpdateRequest
+    ) -> Server:
+        """Persist a server update through the injected UoW.
+
+        Mirrors `_create_via_uow`: stages the write through the
+        repository, commits, and then refetches the ORM row from the
+        UoW's session so the downstream
+        `_sync_server_properties_after_update` helper (which reads
+        `server.directory_path`, `server.id`, `server.port`,
+        `server.max_players` from an ORM row) continues to work without
+        change.
+        """
+        assert self._uow is not None
+        command = UpdateServerCommand(
+            name=request.name,
+            description=request.description,
+            port=request.port,
+            max_memory=request.max_memory,
+            max_players=request.max_players,
+        )
+        async with self._uow as uow:
+            entity = await uow.servers.update(server_id, command)
+            if entity is None:
+                # validate_server_exists() already guarded above; if the
+                # row vanished between validation and update, surface a
+                # clear error rather than letting None propagate.
+                raise RuntimeError(
+                    f"Server {server_id} vanished between validation and update"
+                )
+            await uow.commit()
+            # See `_create_via_uow` for the rationale on refetching the
+            # ORM row from the UoW's session — the downstream
+            # `_sync_server_properties_after_update` helper still wants
+            # an ORM-row shaped object and will be migrated separately
+            # under #149.
+            db = getattr(uow, "_db", None)
+            if db is None:
+                raise RuntimeError(
+                    "ServersUnitOfWork did not expose a session for ORM refetch"
+                )
+            row = db.get(Server, server_id)
+            if row is None:
+                raise RuntimeError(f"Updated server {server_id} could not be re-read")
+            return row
+
     async def delete_server(self, server_id: int, db: Session) -> bool:
         server = self.validation_service.validate_server_exists(server_id, db)
-        self.database_service.soft_delete_server(server, db)
+        # Persist via UoW + repo when DI wired; legacy path otherwise
+        # (parity with `create_server` / `update_server`).
+        if self._uow is not None:
+            async with self._uow as uow:
+                deleted = await uow.servers.soft_delete(server_id)
+                if not deleted:
+                    raise RuntimeError(
+                        f"Server {server_id} vanished between validation and delete"
+                    )
+                await uow.commit()
+        else:
+            self.database_service.soft_delete_server(server, db)
         return True
 
     # ===================

--- a/tests/unit/servers/test_service.py
+++ b/tests/unit/servers/test_service.py
@@ -305,6 +305,125 @@ class TestServerService:
             mock_server, mock_db
         )
 
+    @pytest.mark.asyncio
+    async def test_update_server_uses_uow_when_wired(self, mock_db):
+        """`update_server` routes through the UoW when DI is wired (#278)."""
+        # Build a ServerService with an injected UoW; the legacy
+        # database_service.update_server_record path must NOT be reached.
+        fake_uow = Mock()
+        service = ServerService(uow=fake_uow)
+        mock_existing = Mock()
+        mock_existing.port = 25565
+        service.validation_service.validate_server_exists = Mock(
+            return_value=mock_existing
+        )
+        # Stub _update_via_uow so we don't need a full SqlAlchemy UoW.
+        mock_updated = Mock()
+        mock_updated.directory_path = "/tmp/server"
+        mock_updated.id = 1
+        mock_updated.port = 25565
+        mock_updated.max_players = 20
+        service._update_via_uow = AsyncMock(return_value=mock_updated)
+        # And stub the property-sync helper so we don't touch the FS.
+        service._sync_server_properties_after_update = AsyncMock()
+        # Make sure the legacy DB path is NOT called.
+        service.database_service.update_server_record = Mock(
+            side_effect=AssertionError("legacy path must not be used with UoW")
+        )
+
+        request = Mock(spec=ServerUpdateRequest)
+        request.name = "renamed"
+        request.max_memory = None
+        request.max_players = None
+        request.port = None
+        request.server_properties = None
+        request.description = None
+
+        with patch("app.servers.application.service.ServerSecurityValidator"):
+            with patch("app.servers.application.service.ServerResponse") as mock_resp:
+                mock_resp.model_validate.return_value = "uow_response"
+                await service.update_server(1, request, mock_db)
+
+        service._update_via_uow.assert_awaited_once_with(1, request)
+        service._sync_server_properties_after_update.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_server_uses_uow_when_wired(self, mock_db):
+        """`delete_server` routes through the UoW when DI is wired (#278)."""
+
+        class _FakeServersRepo:
+            def __init__(self) -> None:
+                self.soft_delete_called_with: list[int] = []
+
+            async def soft_delete(self, server_id: int) -> bool:
+                self.soft_delete_called_with.append(server_id)
+                return True
+
+        class _FakeUoW:
+            def __init__(self) -> None:
+                self.servers = _FakeServersRepo()
+                self.commits = 0
+                self.entered = 0
+
+            async def __aenter__(self):
+                self.entered += 1
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            async def commit(self):
+                self.commits += 1
+
+            async def rollback(self):
+                pass
+
+        uow = _FakeUoW()
+        service = ServerService(uow=uow)
+        mock_server = Mock()
+        service.validation_service.validate_server_exists = Mock(return_value=mock_server)
+        # Legacy path must NOT be used.
+        service.database_service.soft_delete_server = Mock(
+            side_effect=AssertionError("legacy path must not be used with UoW")
+        )
+
+        result = await service.delete_server(42, mock_db)
+
+        assert result is True
+        assert uow.servers.soft_delete_called_with == [42]
+        assert uow.commits == 1
+        assert uow.entered == 1
+
+    @pytest.mark.asyncio
+    async def test_delete_server_uow_missing_row_raises(self, mock_db):
+        """If the row vanishes between validation and UoW delete, raise."""
+
+        class _FakeServersRepo:
+            async def soft_delete(self, server_id: int) -> bool:
+                return False
+
+        class _FakeUoW:
+            def __init__(self) -> None:
+                self.servers = _FakeServersRepo()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            async def commit(self):
+                pass
+
+            async def rollback(self):
+                pass
+
+        service = ServerService(uow=_FakeUoW())
+        service.validation_service.validate_server_exists = Mock(return_value=Mock())
+
+        with pytest.raises(RuntimeError, match="vanished between validation and delete"):
+            await service.delete_server(99, mock_db)
+
 
 class TestServerValidationServiceExtended:
     """Additional tests for ServerValidationService methods"""


### PR DESCRIPTION
## Summary

PR #275 (#228 PR 2c) wrapped `ServerService.create_server` in `async with self._uow:` but left `update_server` / `delete_server` on the legacy `database_service.update_server_record(...)` / `soft_delete_server(...)` ORM-direct path. This PR brings the two remaining CRUD verbs into symmetry with `create_server` and extends the atomic transaction boundary to the multi-step write flows.

## Symmetry with create_server

| Verb | Before (#275) | After (this PR) |
|---|---|---|
| `create_server` | `async with self._uow:` -> `uow.servers.add(...)` | (unchanged) |
| `update_server` | `database_service.update_server_record(...)` (ORM-direct) | `async with self._uow:` -> `uow.servers.update(...)` |
| `delete_server` | `database_service.soft_delete_server(...)` (ORM-direct) | `async with self._uow:` -> `uow.servers.soft_delete(...)` |

Both new flows commit through the UoW so a future addition of a second repo write (e.g. cascade group detach, backup audit) becomes atomic without further refactor.

## Changes

- `ServerService.update_server`: new `_update_via_uow` helper stages the write through `uow.servers.update(...)`, validates the row didn't vanish between `validate_server_exists` and the UoW write, commits, and refetches the ORM row for the downstream `_sync_server_properties_after_update` helper (parity with `_create_via_uow`'s refetch -- both will migrate to entity-only access under #149).
- `ServerService.delete_server`: routes through `uow.servers.soft_delete(...)` inside `async with self._uow:`.
- Both verbs keep the legacy `if self._uow is None:` fallback so the pre-existing `ServerService()`-no-DI unit tests (which mock `database_service.update_server_record` / `soft_delete_server` directly) continue to pass.
- New unit tests:
  - `test_update_server_uses_uow_when_wired` -- asserts the UoW path is reached and the legacy path is NOT.
  - `test_delete_server_uses_uow_when_wired` -- asserts `uow.servers.soft_delete` is called and `uow.commit` runs exactly once.
  - `test_delete_server_uow_missing_row_raises` -- guards the vanished-between-validation-and-delete edge case.

## Legacy helper status

`ServerDatabaseService.update_server_record` and `soft_delete_server` (in `app/servers/application/service.py`) are **retained** as the legacy fallback path. Removing them requires rewriting `TestServerDatabaseService.test_soft_delete_server_success` and the `test_update_server_success` / `test_delete_server_success` fixtures in `tests/unit/servers/test_service.py`; that test-suite rewrite belongs to the #149 sweep, not this PR.

## Test plan

- [x] `uv run pytest tests/unit -m "not slow"` -> 1107 passed, 5 skipped
- [x] `uv run pytest tests/integration -m "not slow"` -> 427 passed, 5 skipped
- [x] `uv run pre-commit run --files app/servers/application/service.py tests/unit/servers/test_service.py` -> all hooks pass
- [x] `uv run ruff check app/servers/application/service.py` -> clean

## Refs

- Resolves #278
- Follow-up to #275 (#228 PR 2c)
- Parent: #228 / #154