### PR TITLE
refactor: replace Session-DI with ServerRepository Port in servers application layer (Resolves #285)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -139,20 +139,16 @@ async def _initialize_database_integration():
     """Initialize database integration - important but not critical"""
     try:
         logger.info("Initializing database integration service...")
-        from app.servers.api.dependencies import make_server_repository_from_session
         from app.servers.application.database_integration import (
             database_integration_instance,
             make_database_integration_service,
         )
-        from app.servers.application.minecraft_server import minecraft_server_manager
 
-        # Late-bind the server-repository factory on the manager
-        # singleton so the port-conflict check inside `start_server`
-        # can go through the Repository instead of `db_session.query`
-        # (R-17 / #228 PR 2d).
-        minecraft_server_manager.server_repository_factory = (
-            make_server_repository_from_session
-        )
+        # NB(#285): the late-bound ``server_repository_factory`` on
+        # ``minecraft_server_manager`` was removed once the
+        # ``_validate_port_availability`` path started consuming an
+        # explicit ``ServerRepository`` argument (#272). No factory
+        # wiring is required here anymore.
 
         # Build a fresh integration service inside the running loop so
         # `initialize()` captures the correct loop for its sync→async

--- a/app/servers/adapters/_legacy_helpers.py
+++ b/app/servers/adapters/_legacy_helpers.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, Optional
 from fastapi import HTTPException
 from fastapi import status as http_status
 from sqlalchemy import and_, func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.exceptions import (
@@ -31,19 +32,30 @@ from app.core.exceptions import (
     InvalidRequestException,
     ServerNotFoundException,
     handle_database_error,
+    handle_file_error,
 )
 from app.core.security import PathValidator, SecurityError
 from app.servers.application.minecraft_server import minecraft_server_manager
 from app.servers.models import Server, ServerStatus, ServerType
-from app.servers.schemas import ServerCreateRequest, ServerResponse
+from app.servers.schemas import (
+    ServerCreateRequest,
+    ServerResponse,
+    ServerUpdateRequest,
+)
 from app.users.domain.value_objects import Role
 from app.users.models import User
+from app.versions.adapters.repository import SqlAlchemyVersionRepository
+from app.versions.application.jar_cache_manager import jar_cache_manager
+from app.versions.application.version_manager import minecraft_version_manager
 
 logger = logging.getLogger(__name__)
 
 
 __all__ = [
+    "ServerDatabaseService",
+    "ServerJarService",
     "ServerValidationService",
+    "is_version_supported_db_legacy",
     "list_servers_legacy_db",
     "list_servers_for_user_legacy",
     "validate_server_operation_legacy",
@@ -52,6 +64,49 @@ __all__ = [
     "get_server_statistics_legacy",
     "update_server_status_legacy",
 ]
+
+
+async def is_version_supported_db_legacy(
+    db: Session, server_type: ServerType, version: str
+) -> bool:
+    """Legacy version-support lookup that talks to SQLAlchemy directly.
+
+    Moved here from ``app.servers.application.service`` in #285 so the
+    application layer no longer constructs ``SqlAlchemyVersionRepository``
+    by hand (ARCHITECTURE §4.2). Behaviour matches the original
+    ``ServerService._is_version_supported_db``: DB-first lookup, fall
+    back to the external version-manager API on miss / DB failure.
+    """
+    try:
+        repo = SqlAlchemyVersionRepository(db)
+        db_version = await repo.get_version_by_type_and_version(server_type, version)
+        if db_version is not None and db_version.is_active:
+            return True
+        try:
+            return minecraft_version_manager.is_version_supported(server_type, version)
+        except Exception as api_error:
+            logger.error(
+                f"External API validation failed for {server_type.value} "
+                f"{version}: {api_error}"
+            )
+            raise InvalidRequestException(
+                f"Unable to validate version {version} for {server_type.value}. "
+                "Version not found in database and external API is unavailable."
+            )
+    except InvalidRequestException:
+        raise
+    except Exception as db_error:
+        logger.error(
+            f"Database validation failed for {server_type.value} {version}: {db_error}"
+        )
+        try:
+            return minecraft_version_manager.is_version_supported(server_type, version)
+        except Exception as api_error:
+            logger.error(f"Both database and API validation failed: {api_error}")
+            raise InvalidRequestException(
+                f"Unable to validate version {version} for {server_type.value}. "
+                "Both database and external API are unavailable."
+            )
 
 
 class ServerValidationService:
@@ -344,3 +399,154 @@ def update_server_status_legacy(
     except Exception as e:
         logger.error(f"Failed to update server {server_id} status: {e}")
         return False
+
+
+# ---------------------------------------------------------------------------
+# Session-direct helpers (moved from app.servers.application.service in #285).
+#
+# These classes call SQLAlchemy methods on a ``Session`` at runtime
+# (``db.add``, ``db.query``, ``db.commit``...), so they belong in
+# adapters/ per ARCHITECTURE §4.2/§4.3. The application service module
+# re-exports them for backward compatibility with the legacy tests that
+# import them via ``app.servers.application.service``.
+# ---------------------------------------------------------------------------
+
+
+class ServerJarService:
+    """Service for handling server JAR downloads and management with caching.
+
+    Pre-existing legacy class that consumes a ``Session`` at runtime to
+    look up versions through the version repository. Kept here in
+    adapters/ rather than application/ to preserve the §4.2 invariant.
+    """
+
+    def __init__(self) -> None:
+        self.version_manager = minecraft_version_manager
+        self.cache_manager = jar_cache_manager
+
+    async def _is_version_supported_db(
+        self, db: Session, server_type: ServerType, version: str
+    ) -> bool:
+        try:
+            repo = SqlAlchemyVersionRepository(db)
+            db_version = await repo.get_version_by_type_and_version(server_type, version)
+            if db_version is not None and db_version.is_active:
+                return True
+            return False
+        except Exception:
+            return False
+
+    async def _get_download_url_db(
+        self, db: Session, server_type: ServerType, version: str
+    ) -> Optional[str]:
+        try:
+            repo = SqlAlchemyVersionRepository(db)
+            db_version = await repo.get_version_by_type_and_version(server_type, version)
+            if db_version and db_version.is_active and db_version.download_url:
+                return db_version.download_url
+            return None
+        except Exception:
+            return None
+
+    async def get_server_jar(
+        self,
+        server_type: ServerType,
+        minecraft_version: str,
+        server_dir: Path,
+        db: Session,
+    ) -> Path:
+        try:
+            if not await self._is_version_supported_db(
+                db, server_type, minecraft_version
+            ):
+                raise InvalidRequestException(
+                    f"Version {minecraft_version} is not supported for {server_type.value} "
+                    f"(minimum supported version: 1.8)"
+                )
+
+            download_url = await self._get_download_url_db(
+                db, server_type, minecraft_version
+            )
+
+            cached_jar_path = await self.cache_manager.get_or_download_jar(
+                server_type, minecraft_version, download_url
+            )
+
+            server_jar_path = await self.cache_manager.copy_jar_to_server(
+                cached_jar_path, server_dir
+            )
+
+            logger.info(
+                f"Prepared {server_type.value} {minecraft_version} JAR for server "
+                f"at {server_jar_path}"
+            )
+            return server_jar_path
+
+        except Exception as e:
+            handle_file_error("get server jar", str(server_dir), e)
+
+
+class ServerDatabaseService:
+    """Legacy DB-direct CRUD helper.
+
+    Preserved for backward compatibility with the existing unit tests
+    that inject a ``Mock(db)`` and exercise the SQLAlchemy path. The
+    canonical ``ServerService.create_server`` path uses the
+    ``ServerRepository`` Port instead.
+    """
+
+    def create_server_record(
+        self,
+        request: ServerCreateRequest,
+        owner: User,
+        directory_path: str,
+        db: Session,
+    ) -> Server:
+        try:
+            server = Server(
+                name=request.name,
+                description=request.description,
+                server_type=request.server_type,
+                minecraft_version=request.minecraft_version,
+                port=request.port,
+                max_memory=request.max_memory,
+                max_players=request.max_players,
+                directory_path=directory_path,
+                owner_id=owner.id,
+                status=ServerStatus.stopped,
+            )
+            db.add(server)
+            db.commit()
+            db.refresh(server)
+            logger.info(f"Created server record: {server.name} (ID: {server.id})")
+            return server
+        except IntegrityError as e:
+            db.rollback()
+            handle_database_error("create", "server", e)
+        except Exception as e:
+            db.rollback()
+            handle_database_error("create", "server", e)
+
+    def update_server_record(
+        self, server: Server, request: ServerUpdateRequest, db: Session
+    ) -> Server:
+        try:
+            for field_name, value in request.model_dump(exclude_unset=True).items():
+                setattr(server, field_name, value)
+            db.commit()
+            db.refresh(server)
+            logger.info(f"Updated server record: {server.name} (ID: {server.id})")
+            return server
+        except Exception as e:
+            db.rollback()
+            handle_database_error("update", "server", e)
+
+    def soft_delete_server(self, server: Server, db: Session) -> None:
+        try:
+            server.is_deleted = True
+            server.status = ServerStatus.stopped
+            db.commit()
+            logger.info(f"Soft deleted server: {server.name} (ID: {server.id})")
+        except Exception as e:
+            db.rollback()
+            handle_database_error("delete", "server", e)

--- a/app/servers/application/minecraft_server.py
+++ b/app/servers/application/minecraft_server.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple
 
 import psutil
-from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.servers.domain.entities import ServerEntity
@@ -51,7 +50,6 @@ class MinecraftServerManager:
     def __init__(
         self,
         log_queue_size: Optional[int] = None,
-        server_repository_factory: Optional[Callable[[Session], ServerRepository]] = None,
     ):
         self.processes: Dict[int, ServerProcess] = {}
         self.base_directory = Path("servers")
@@ -61,31 +59,16 @@ class MinecraftServerManager:
         # Configurable log queue size to prevent memory leaks
         self.log_queue_size = log_queue_size or settings.SERVER_LOG_QUEUE_SIZE
         self.java_check_timeout = settings.JAVA_CHECK_TIMEOUT
-        # Late-bound `ServerRepository` factory (#228 PR 2d). Wired in
-        # `app/main.py` lifespan after the singleton is constructed so
-        # constructor compatibility is preserved for legacy callers /
-        # tests that still instantiate `MinecraftServerManager()` with
-        # no arguments.
-        self._server_repository_factory: Optional[
-            Callable[[Session], ServerRepository]
-        ] = server_repository_factory
+        # NB(#285): the pre-#272 ``server_repository_factory`` indirection
+        # (``Callable[[Session], ServerRepository]``) was deleted as part
+        # of completing the ARCHITECTURE §4.2 cleanup. The port-conflict
+        # check inside ``_validate_port_availability`` now consumes a
+        # ``ServerRepository`` passed explicitly by the caller — no
+        # framework-typed factories remain on this class.
 
     def set_status_update_callback(self, callback: Callable[[int, ServerStatus], None]):
         """Set callback function to update database when server status changes"""
         self._status_update_callback = callback
-
-    @property
-    def server_repository_factory(
-        self,
-    ) -> Optional[Callable[[Session], ServerRepository]]:
-        """Late-bound `ServerRepository` factory (see `__init__`)."""
-        return self._server_repository_factory
-
-    @server_repository_factory.setter
-    def server_repository_factory(
-        self, factory: Optional[Callable[[Session], ServerRepository]]
-    ) -> None:
-        self._server_repository_factory = factory
 
     def _get_pid_file_path(self, server_id: int, server_dir: Path) -> Path:
         """Get path to PID file for server"""
@@ -1331,9 +1314,10 @@ class MinecraftServerManager:
         """
         try:
             # First check database for servers using the same port through
-            # the injected ``ServerRepository``. The Session-scoped factory
-            # on this manager is no longer consulted here (#272): callers
-            # pass the already-built repository in alongside the entity,
+            # the injected ``ServerRepository``. The legacy
+            # ``server_repository_factory`` indirection (which used to
+            # take a ``Session``) was removed in #285; callers now pass
+            # the already-built repository in alongside the entity,
             # mirroring the rest of the application layer.
             if server_repository is not None:
                 conflicts = await server_repository.list_by_port(

--- a/app/servers/application/service.py
+++ b/app/servers/application/service.py
@@ -43,23 +43,30 @@ import re
 import shlex
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Optional
-
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from app.core.exceptions import (
     ConflictException,
     InvalidRequestException,
-    handle_database_error,
     handle_file_error,
 )
 from app.core.security import PathValidator, SecurityError
 from app.groups.application.service import GroupService
+
+# `ServerJarService` / `ServerDatabaseService` originally lived in this
+# module but consume a `Session` at runtime, so they were moved to the
+# adapter layer in #285 (ARCHITECTURE §4.2 — application/ must not
+# depend on a framework). They are re-imported here purely so the
+# pre-existing public API
+# (`from app.servers.application.service import ServerJarService`)
+# keeps resolving for legacy callers and unit tests.
 from app.servers.adapters._legacy_helpers import (
+    ServerDatabaseService,
+    ServerJarService,
     ServerValidationService,
     get_server_statistics_legacy,
     get_server_with_access_check_legacy,
+    is_version_supported_db_legacy,
     list_servers_for_user_legacy,
     server_exists_legacy,
     update_server_status_legacy,
@@ -84,10 +91,16 @@ from app.servers.schemas import ServerCreateRequest, ServerResponse, ServerUpdat
 from app.templates.application.service import TemplateService
 from app.users.domain.value_objects import Role
 from app.users.models import User
-from app.versions.adapters.repository import SqlAlchemyVersionRepository
-from app.versions.application.jar_cache_manager import jar_cache_manager
 from app.versions.application.java_compatibility import java_compatibility_service
-from app.versions.application.version_manager import minecraft_version_manager
+
+# `Session` is used only as a type annotation on legacy passthrough
+# methods that forward the value to ``_legacy_helpers`` (which lives in
+# adapters/). With ``from __future__ import annotations`` enabled the
+# names are strings at runtime, so we keep the import under
+# ``TYPE_CHECKING`` to keep the application module framework-free at
+# runtime (ARCHITECTURE §4.2, #285).
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 
@@ -171,75 +184,6 @@ class ServerSecurityValidator:
 # ---------------------------------------------------------------------------
 # JAR + filesystem helpers
 # ---------------------------------------------------------------------------
-
-
-class ServerJarService:
-    """Service for handling server JAR downloads and management with caching."""
-
-    def __init__(self) -> None:
-        self.version_manager = minecraft_version_manager
-        self.cache_manager = jar_cache_manager
-
-    async def _is_version_supported_db(
-        self, db: Session, server_type: ServerType, version: str
-    ) -> bool:
-        try:
-            repo = SqlAlchemyVersionRepository(db)
-            db_version = await repo.get_version_by_type_and_version(server_type, version)
-            if db_version is not None and db_version.is_active:
-                return True
-            return False
-        except Exception:
-            return False
-
-    async def _get_download_url_db(
-        self, db: Session, server_type: ServerType, version: str
-    ) -> Optional[str]:
-        try:
-            repo = SqlAlchemyVersionRepository(db)
-            db_version = await repo.get_version_by_type_and_version(server_type, version)
-            if db_version and db_version.is_active and db_version.download_url:
-                return db_version.download_url
-            return None
-        except Exception:
-            return None
-
-    async def get_server_jar(
-        self,
-        server_type: ServerType,
-        minecraft_version: str,
-        server_dir: Path,
-        db: Session,
-    ) -> Path:
-        try:
-            if not await self._is_version_supported_db(
-                db, server_type, minecraft_version
-            ):
-                raise InvalidRequestException(
-                    f"Version {minecraft_version} is not supported for {server_type.value} "
-                    f"(minimum supported version: 1.8)"
-                )
-
-            download_url = await self._get_download_url_db(
-                db, server_type, minecraft_version
-            )
-
-            cached_jar_path = await self.cache_manager.get_or_download_jar(
-                server_type, minecraft_version, download_url
-            )
-
-            server_jar_path = await self.cache_manager.copy_jar_to_server(
-                cached_jar_path, server_dir
-            )
-
-            logger.info(
-                f"Prepared {server_type.value} {minecraft_version} JAR for server "
-                f"at {server_jar_path}"
-            )
-            return server_jar_path
-
-        except Exception as e:
-            handle_file_error("get server jar", str(server_dir), e)
 
 
 class ServerFileSystemService:
@@ -408,70 +352,10 @@ exec java -Xmx"${{MAX_MEMORY}}"M -Xms"${{MIN_MEMORY}}"M -jar "$JAR_FILE" nogui
             logger.warning(f"Failed to cleanup server directory {server_dir}: {e}")
 
 
-class ServerDatabaseService:
-    """Legacy DB-direct CRUD helper.
-
-    Preserved for backward compatibility with the existing unit tests
-    that inject a `Mock(db)` and exercise the SQLAlchemy path. The new
-    `ServerService.create_server` path uses the `ServerRepository`
-    instead.
-    """
-
-    def create_server_record(
-        self,
-        request: ServerCreateRequest,
-        owner: User,
-        directory_path: str,
-        db: Session,
-    ) -> Server:
-        try:
-            server = Server(
-                name=request.name,
-                description=request.description,
-                server_type=request.server_type,
-                minecraft_version=request.minecraft_version,
-                port=request.port,
-                max_memory=request.max_memory,
-                max_players=request.max_players,
-                directory_path=directory_path,
-                owner_id=owner.id,
-                status=ServerStatus.stopped,
-            )
-            db.add(server)
-            db.commit()
-            db.refresh(server)
-            logger.info(f"Created server record: {server.name} (ID: {server.id})")
-            return server
-        except IntegrityError as e:
-            db.rollback()
-            handle_database_error("create", "server", e)
-        except Exception as e:
-            db.rollback()
-            handle_database_error("create", "server", e)
-
-    def update_server_record(
-        self, server: Server, request: ServerUpdateRequest, db: Session
-    ) -> Server:
-        try:
-            for field_name, value in request.model_dump(exclude_unset=True).items():
-                setattr(server, field_name, value)
-            db.commit()
-            db.refresh(server)
-            logger.info(f"Updated server record: {server.name} (ID: {server.id})")
-            return server
-        except Exception as e:
-            db.rollback()
-            handle_database_error("update", "server", e)
-
-    def soft_delete_server(self, server: Server, db: Session) -> None:
-        try:
-            server.is_deleted = True
-            server.status = ServerStatus.stopped
-            db.commit()
-            logger.info(f"Soft deleted server: {server.name} (ID: {server.id})")
-        except Exception as e:
-            db.rollback()
-            handle_database_error("delete", "server", e)
+# `ServerJarService` and `ServerDatabaseService` (the SQLAlchemy-direct
+# legacy CRUD helpers) live in ``app.servers.adapters._legacy_helpers``
+# after #285. They are re-imported at the top of this module for
+# back-compat so legacy imports / unit tests continue to work.
 
 
 # ---------------------------------------------------------------------------
@@ -521,41 +405,14 @@ class ServerService:
     async def _is_version_supported_db(
         self, db: Session, server_type: ServerType, version: str
     ) -> bool:
-        try:
-            repo = SqlAlchemyVersionRepository(db)
-            db_version = await repo.get_version_by_type_and_version(server_type, version)
-            if db_version is not None and db_version.is_active:
-                return True
-            try:
-                return minecraft_version_manager.is_version_supported(
-                    server_type, version
-                )
-            except Exception as api_error:
-                logger.error(
-                    f"External API validation failed for {server_type.value} "
-                    f"{version}: {api_error}"
-                )
-                raise InvalidRequestException(
-                    f"Unable to validate version {version} for {server_type.value}. "
-                    "Version not found in database and external API is unavailable."
-                )
-        except InvalidRequestException:
-            raise
-        except Exception as db_error:
-            logger.error(
-                f"Database validation failed for {server_type.value} "
-                f"{version}: {db_error}"
-            )
-            try:
-                return minecraft_version_manager.is_version_supported(
-                    server_type, version
-                )
-            except Exception as api_error:
-                logger.error(f"Both database and API validation failed: {api_error}")
-                raise InvalidRequestException(
-                    f"Unable to validate version {version} for {server_type.value}. "
-                    "Both database and external API are unavailable."
-                )
+        """Thin passthrough to the SQLAlchemy-direct legacy helper.
+
+        The implementation was moved to
+        ``app.servers.adapters._legacy_helpers.is_version_supported_db_legacy``
+        in #285 so this module no longer constructs adapter classes
+        directly (ARCHITECTURE §4.2).
+        """
+        return await is_version_supported_db_legacy(db, server_type, version)
 
     # ===================
     # Server CRUD
@@ -816,6 +673,29 @@ class ServerService:
     # Server control
     # ===================
 
+    def _require_server_repo(self, db: Session) -> ServerRepository:
+        """Return the injected ``ServerRepository`` for control flows.
+
+        The canonical production path constructs ``ServerService``
+        through ``get_server_service`` (which wires
+        ``self._server_repo``). The legacy ``ServerService()`` shape
+        (no DI) does not exercise ``start_server`` / ``stop_server`` /
+        ``restart_server`` so we raise when the Port is not wired
+        rather than reach into ``adapters/`` from the application
+        layer (ARCHITECTURE §4.2). The ``db`` argument is accepted
+        purely so the calling methods can still expose a
+        ``db: Session`` annotation under TYPE_CHECKING for legacy
+        signature parity.
+        """
+        if self._server_repo is None:
+            raise RuntimeError(
+                "ServerService.start_server / restart_server require a "
+                "ServerRepository Port; construct the service via the "
+                "DI factory `get_server_service` instead of bare "
+                "`ServerService()`."
+            )
+        return self._server_repo
+
     async def start_server(self, server_id: int, db: Session) -> Dict[str, str]:
         # Existence check (kept on the legacy validator for the
         # not-found semantics it raises). The manager now accepts a
@@ -823,9 +703,7 @@ class ServerService:
         # we hand it the entity loaded through the Port instead of the
         # ORM row.
         server = self.validation_service.validate_server_exists(server_id, db)
-        from app.servers.api.dependencies import make_server_repository_from_session
-
-        server_repository = make_server_repository_from_session(db)
+        server_repository = self._require_server_repo(db)
         entity = await server_repository.get(server_id, include_deleted=False)
         if entity is None:
             raise RuntimeError(
@@ -875,9 +753,7 @@ class ServerService:
             )
 
         logger.info(f"Starting server {server.id} after confirmed stop")
-        from app.servers.api.dependencies import make_server_repository_from_session
-
-        server_repository = make_server_repository_from_session(db)
+        server_repository = self._require_server_repo(db)
         entity = await server_repository.get(server.id, include_deleted=False)
         if entity is None:
             raise RuntimeError(f"Server {server.id} vanished between stop and restart")

--- a/tests/unit/servers/test_service.py
+++ b/tests/unit/servers/test_service.py
@@ -499,7 +499,7 @@ class TestServerJarServiceExtended:
             jar_service.version_manager, "is_version_supported", return_value=False
         ):
             with patch(
-                "app.servers.application.service.handle_file_error"
+                "app.servers.adapters._legacy_helpers.handle_file_error"
             ) as mock_handle_error:
                 await jar_service.get_server_jar(
                     ServerType.vanilla, "1.7.10", Path("/tmp"), db
@@ -520,7 +520,7 @@ class TestServerJarServiceExtended:
                 side_effect=Exception("Download error"),
             ):
                 with patch(
-                    "app.servers.application.service.handle_file_error"
+                    "app.servers.adapters._legacy_helpers.handle_file_error"
                 ) as mock_handle_error:
                     await jar_service.get_server_jar(
                         ServerType.vanilla, "1.20.1", Path("/tmp"), db
@@ -583,7 +583,7 @@ class TestServerDatabaseService:
         server_dir = "/tmp/test-server"
         mock_db = Mock()
 
-        with patch("app.servers.application.service.Server") as mock_server_class:
+        with patch("app.servers.adapters._legacy_helpers.Server") as mock_server_class:
             mock_server = Mock()
             mock_server_class.return_value = mock_server
 


### PR DESCRIPTION
## Summary

Completes ARCHITECTURE §4.2 cleanup of `app/servers/application/` by eliminating all runtime `Session` / `sqlalchemy` imports from the servers application layer. After this PR, the only `Session` reference under `app/servers/application/` is a `TYPE_CHECKING`-only annotation used by legacy passthrough methods.

### Changes

- **`app/servers/application/minecraft_server.py`** — Removed the dead `Callable[[Session], ServerRepository]` factory (`server_repository_factory` constructor param, property + setter, attribute, and the matching `sqlalchemy.orm.Session` import). The factory had not been consumed internally since #272; the manager already receives an explicit `ServerRepository` from each `start_server` caller.
- **`app/main.py`** — Dropped the matching late-bind of `minecraft_server_manager.server_repository_factory` in the database-integration init path.
- **`app/servers/application/service.py`** —
  - Moved `ServerJarService` and `ServerDatabaseService` (both `Session`-direct legacy CRUD helpers) into `app/servers/adapters/_legacy_helpers.py`. The application module re-imports them so existing unit tests / legacy importers keep working.
  - Converted `ServerService._is_version_supported_db` to a thin passthrough into a new `is_version_supported_db_legacy(...)` helper in `_legacy_helpers.py`. The previous body constructed `SqlAlchemyVersionRepository` directly, which is an adapter type — application code can no longer do that.
  - Replaced the two in-method imports of `make_server_repository_from_session` (which pulled `app/servers/api/` into `application/`) with a small `_require_server_repo(db)` helper that returns the constructor-injected `ServerRepository` Port and raises a clear error when the service was built without DI.
  - Hoisted the `Session` import under `TYPE_CHECKING`. With `from __future__ import annotations` already in effect this means `service.py` has zero runtime `sqlalchemy` imports.
- **`app/servers/adapters/_legacy_helpers.py`** — Hosts the moved classes and the new `is_version_supported_db_legacy` helper.
- **`tests/unit/servers/test_service.py`** — Updated two `patch(...)` paths from `app.servers.application.service.handle_file_error` / `.Server` to the new `app.servers.adapters._legacy_helpers.*` locations.

### ARCHITECTURE §4.2 invariant achieved

```bash
$ grep -rn 'from sqlalchemy' app/servers/application/
app/servers/application/service.py:103:    from sqlalchemy.orm import Session   # ← inside `if TYPE_CHECKING:` only
```

Zero runtime `sqlalchemy` imports remain under `app/servers/application/`. The `simplified_sync.py` module was already `Session`-free post-#272.

### Out of scope / follow-up

- `app/servers/application/service.py` still has a runtime import from `app/servers/adapters/_legacy_helpers.py` (pre-existing since #291). That `application -> adapters` edge is a separate §4.2 concern tracked under #149.
- The legacy `ServerService.start_server` / `stop_server` / `restart_server` / `get_server_status` methods (unused in production after #272 — `app/servers/routers/control.py` calls `minecraft_server_manager` directly) are kept for back-compat. Their `db: Session` parameter is now a TYPE_CHECKING-only annotation; the live argument is no longer used inside the method body (the new `_require_server_repo` helper returns the injected Port).

## Test plan

- [x] `uv run pytest tests/unit -m "not slow"` — 1107 passed, 5 skipped.
- [x] `uv run pytest tests/integration -m "not slow"` — 427 passed, 5 skipped.
- [x] `just test` (full suite, incl. `slow`) — 1719 passed, 10 skipped in 2m11s.
- [x] `uv run ruff check app/` — clean.
- [x] `uv run ruff format --check` on touched files — clean.
- [x] `uv run pre-commit run --files <touched>` — all hooks pass.
- [x] Manual grep — no runtime `from sqlalchemy` import under `app/servers/application/`.

Resolves #285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)