### PR TITLE
refactor: fail-loud when ServerRepository is missing in _validate_port_availability (Resolves #281)

### DIFF
--- a/app/servers/application/minecraft_server.py
+++ b/app/servers/application/minecraft_server.py
@@ -1322,13 +1322,34 @@ class MinecraftServerManager:
         self,
         server: ServerEntity,
         server_repository: Optional[ServerRepository] = None,
+        *,
+        _for_test_default: bool = False,
     ) -> tuple[bool, str]:
         """Validate that the server's port is not already in use by another running server
 
         This method checks both:
         1. Database for servers using the same port and currently running/starting
         2. System-level port availability for external processes
+
+        Production callers MUST pass an explicit ``ServerRepository`` so the
+        database conflict check actually runs. Silently skipping the DB
+        check when production forgets to wire the repository would let a
+        port conflict slip past pre-flight validation (#281); we therefore
+        fail loud with ``RuntimeError`` in that case.
+
+        ``_for_test_default`` is a test-only escape hatch: it acknowledges
+        that the caller intentionally wants the socket-only probe (no DB
+        check) and suppresses the ``RuntimeError`` guard. Production code
+        MUST NOT set this flag.
         """
+        if server_repository is None and not _for_test_default:
+            raise RuntimeError(
+                "_validate_port_availability requires an explicit ServerRepository "
+                "in production code paths to perform the database port-conflict "
+                "check. Pass `server_repository=...`, or set "
+                "`_for_test_default=True` in test-only contexts that intentionally "
+                "exercise the socket-only probe."
+            )
         try:
             # First check database for servers using the same port through
             # the injected ``ServerRepository``. The Session-scoped factory

--- a/tests/unit/servers/application/test_minecraft_server.py
+++ b/tests/unit/servers/application/test_minecraft_server.py
@@ -145,7 +145,9 @@ class TestMinecraftServerManagerSimpleCoverage:
             mock_socket_class.return_value = mock_socket
             mock_socket.connect_ex.return_value = 1  # Port not in use
 
-            available, message = await manager._validate_port_availability(mock_server)
+            available, message = await manager._validate_port_availability(
+                mock_server, _for_test_default=True
+            )
 
             assert available is True
             assert "Port 25565 is available" in message
@@ -158,7 +160,9 @@ class TestMinecraftServerManagerSimpleCoverage:
             mock_socket_class.return_value = mock_socket
             mock_socket.connect_ex.return_value = 0  # Port in use
 
-            available, message = await manager._validate_port_availability(mock_server)
+            available, message = await manager._validate_port_availability(
+                mock_server, _for_test_default=True
+            )
 
             assert available is False
             assert "Port 25565 is already in use" in message
@@ -238,7 +242,9 @@ class TestMinecraftServerManagerSimpleCoverage:
     async def test_validate_port_availability_exception(self, manager, mock_server):
         """Test _validate_port_availability exception handling"""
         with patch("socket.socket", side_effect=Exception("Socket error")):
-            available, message = await manager._validate_port_availability(mock_server)
+            available, message = await manager._validate_port_availability(
+                mock_server, _for_test_default=True
+            )
 
             assert available is False
             assert "Port validation failed" in message

--- a/tests/unit/utils/test_port_validation.py
+++ b/tests/unit/utils/test_port_validation.py
@@ -54,9 +54,7 @@ class TestPortValidation:
         return _make_entity()
 
     @pytest.mark.asyncio
-    async def test_validate_port_availability_no_conflict(
-        self, manager, mock_server
-    ):
+    async def test_validate_port_availability_no_conflict(self, manager, mock_server):
         """Port available when repo returns no conflicts and socket is free."""
         repo = _make_repo(conflicts=[])
         with patch("socket.socket") as mock_socket:
@@ -81,18 +79,14 @@ class TestPortValidation:
         conflicting.status = ServerStatus.running
         repo = _make_repo(conflicts=[conflicting])
 
-        available, message = await manager._validate_port_availability(
-            mock_server, repo
-        )
+        available, message = await manager._validate_port_availability(mock_server, repo)
 
         assert available is False
         assert "already in use by running server 'existing-server'" in message
         assert "Stop the server to free up the port" in message
 
     @pytest.mark.asyncio
-    async def test_validate_port_availability_system_conflict(
-        self, manager, mock_server
-    ):
+    async def test_validate_port_availability_system_conflict(self, manager, mock_server):
         """No DB conflict but `connect_ex == 0` -> external port-in-use."""
         repo = _make_repo(conflicts=[])
         with patch("socket.socket") as mock_socket:
@@ -109,18 +103,29 @@ class TestPortValidation:
 
     @pytest.mark.asyncio
     async def test_validate_port_availability_no_repo(self, manager, mock_server):
-        """No repository -> skip DB check, only socket probe runs."""
+        """No repository (test escape hatch) -> skip DB check, only socket probe runs."""
         with patch("socket.socket") as mock_socket:
             mock_sock_instance = Mock()
             mock_sock_instance.connect_ex.return_value = 1
             mock_socket.return_value = mock_sock_instance
 
             available, message = await manager._validate_port_availability(
-                mock_server, None
+                mock_server, None, _for_test_default=True
             )
 
         assert available is True
         assert "available" in message
+
+    @pytest.mark.asyncio
+    async def test_validate_port_availability_missing_repo_raises(
+        self, manager, mock_server
+    ):
+        """Production path with no repository -> fail loud (#281)."""
+        with pytest.raises(RuntimeError, match="requires an explicit ServerRepository"):
+            await manager._validate_port_availability(mock_server)
+
+        with pytest.raises(RuntimeError, match="requires an explicit ServerRepository"):
+            await manager._validate_port_availability(mock_server, None)
 
     @pytest.mark.asyncio
     async def test_validate_port_availability_socket_exception(
@@ -144,9 +149,7 @@ class TestPortValidation:
         repo = Mock()
         repo.list_by_port = AsyncMock(side_effect=Exception("Database error"))
 
-        available, message = await manager._validate_port_availability(
-            mock_server, repo
-        )
+        available, message = await manager._validate_port_availability(mock_server, repo)
 
         assert available is False
         assert "Port validation failed: Database error" in message
@@ -161,17 +164,13 @@ class TestPortValidation:
         conflicting.status = ServerStatus.starting
         repo = _make_repo(conflicts=[conflicting])
 
-        available, message = await manager._validate_port_availability(
-            mock_server, repo
-        )
+        available, message = await manager._validate_port_availability(mock_server, repo)
 
         assert available is False
         assert "already in use by starting server 'starting-server'" in message
 
     @pytest.mark.asyncio
-    async def test_validate_port_availability_self_exclusion(
-        self, manager, mock_server
-    ):
+    async def test_validate_port_availability_self_exclusion(self, manager, mock_server):
         """`exclude_id=server.id` keeps the server from conflicting with itself."""
         repo = _make_repo(conflicts=[])
         with patch("socket.socket") as mock_socket:


### PR DESCRIPTION
## Summary
- Make `_validate_port_availability` raise `RuntimeError` when called without an explicit `ServerRepository` in production paths, instead of silently skipping the DB port-conflict check.
- Expose a keyword-only `_for_test_default=True` escape hatch so unit tests that intentionally exercise only the socket probe still work.
- Update existing unit tests to opt into the escape hatch and add a regression test for the new fail-loud guard.

## Why
PR #285/#272 removed the `_server_repository_factory` indirection, but the `server_repository: Optional[ServerRepository] = None` default on `_validate_port_availability` still made the DB conflict check optional. If a future production caller forgets to thread the repository through, port conflicts would slip past pre-flight validation undetected (#281).

The production call site (`start_server` -> `_validate_port_availability`) already passes the repository explicitly, so the new guard is not dead code — it only fires when a caller regresses to the implicit-`None` path.

## Changes
- `app/servers/application/minecraft_server.py`: add `_for_test_default` keyword-only flag, raise `RuntimeError` when `server_repository is None and not _for_test_default`, and document the contract in the docstring.
- `tests/unit/utils/test_port_validation.py`: pass `_for_test_default=True` in the existing no-repo test; add `test_validate_port_availability_missing_repo_raises` to cover the new fail-loud guard for both `(server,)` and `(server, None)` invocations.
- `tests/unit/servers/application/test_minecraft_server.py`: pass `_for_test_default=True` in the three callers that intentionally hit the socket-only path.

## Test plan
- [x] `uv run ruff check` on touched files
- [x] `uv run pytest tests/unit/utils/test_port_validation.py -v` (9 passed)
- [x] `uv run pytest tests/unit -m "not slow"` (1108 passed, 5 skipped)
- [x] `uv run pytest tests/integration -m "not slow"` (427 passed, 5 skipped)
- [x] `just test` full suite (1720 passed, 10 skipped)
- [x] `uv run pre-commit run --files <touched>`

Resolves #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)