### PR TITLE
fix: mount visibility_router + correct get_current_active_user import (Resolves #288)

### DIFF
--- a/app/core/visibility_router.py
+++ b/app/core/visibility_router.py
@@ -14,7 +14,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
-from app.auth.dependencies import get_current_active_user
+from app.auth.dependencies import get_current_user
 from app.core.database import get_db
 from app.core.visibility import ResourceType, VisibilityType
 from app.core.visibility.api.dependencies import (
@@ -88,7 +88,7 @@ def _check_resource_ownership_or_admin(
 async def get_resource_visibility(
     resource_type: ResourceType,
     resource_id: int,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
     visibility_service: VisibilityService = Depends(get_visibility_service),
 ):
@@ -144,7 +144,7 @@ async def update_resource_visibility(
     resource_type: ResourceType,
     resource_id: int,
     request: VisibilityUpdateRequest,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
     visibility_service: VisibilityService = Depends(get_visibility_service),
 ):
@@ -224,7 +224,7 @@ async def grant_user_access(
     resource_type: ResourceType,
     resource_id: int,
     request: UserAccessGrantRequest,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
     visibility_service: VisibilityService = Depends(get_visibility_service),
 ):
@@ -296,7 +296,7 @@ async def revoke_user_access(
     resource_type: ResourceType,
     resource_id: int,
     user_id: int,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
     visibility_service: VisibilityService = Depends(get_visibility_service),
 ):
@@ -352,7 +352,7 @@ async def revoke_user_access(
     description="Get status of Phase 1 → Phase 2 visibility migration (admin only)",
 )
 async def get_migration_status(
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_user),
     migration_service: VisibilityMigrationService = Depends(
         get_visibility_migration_service
     ),
@@ -382,7 +382,7 @@ async def get_migration_status(
     description="Execute Phase 1 → Phase 2 visibility migration (admin only)",
 )
 async def execute_migration(
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_user),
     migration_service: VisibilityMigrationService = Depends(
         get_visibility_migration_service
     ),

--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ from app.core.database import Base, engine
 from app.core.error_handlers import register_exception_handlers
 
 # Import visibility models for Phase 2 resource access control
+from app.core.visibility_router import router as visibility_router
 from app.files.router import router as files_router
 from app.groups.router import router as groups_router
 from app.middleware.audit_middleware import AuditMiddleware
@@ -487,4 +488,5 @@ app.include_router(templates_router, prefix="/api/v1/templates", tags=["template
 app.include_router(files_router, prefix="/api/v1/files", tags=["files"])
 app.include_router(versions_router, prefix="/api/v1/versions", tags=["versions"])
 app.include_router(websockets_router, prefix="/api/v1/ws", tags=["websockets"])
+app.include_router(visibility_router, prefix="/api/v1", tags=["visibility"])
 app.include_router(audit_router, tags=["audit"])

--- a/tests/integration/api/test_visibility_router.py
+++ b/tests/integration/api/test_visibility_router.py
@@ -1,0 +1,48 @@
+"""Smoke tests for the visibility router mounted under /api/v1/visibility.
+
+These tests pin the wire contract introduced by Issue #288, namely that
+the router from `app.core.visibility_router` is mounted on the FastAPI
+application and the import of `get_current_user` resolves at runtime.
+They intentionally stay at the HTTP-edge to keep the suite fast — the
+service-layer behaviour is covered exhaustively by
+`tests/unit/core/visibility` and `tests/integration/core/visibility`.
+"""
+
+from fastapi import status
+
+
+def _auth_headers(client, username: str, password: str) -> dict:
+    response = client.post(
+        "/api/v1/auth/token",
+        data={"username": username, "password": password},
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+class TestVisibilityRouterMounted:
+    def test_unauthenticated_request_returns_401(self, client):
+        """Without a bearer token the mounted router returns 401.
+
+        Pre-Issue #288 the route was not registered at all, so the same
+        request would have returned 404. The 401 below proves the router
+        is now wired into the app and the `get_current_user` dependency
+        import resolves at runtime.
+        """
+        response = client.get("/api/v1/visibility/server/1")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_authenticated_request_reaches_handler(self, client, test_user):
+        """An authenticated request reaches the handler body.
+
+        We hit a server resource that does not exist for this user; the
+        handler runs ownership checks and surfaces a 404 from
+        `_check_resource_ownership_or_admin`. Reaching that branch
+        confirms (a) the route is registered, (b) the bearer token is
+        accepted by `get_current_user`, and (c) the DI graph for
+        `VisibilityService` resolves successfully.
+        """
+        headers = _auth_headers(client, "testuser", "testpassword")
+        response = client.get("/api/v1/visibility/server/9999", headers=headers)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json()["detail"] == "Server not found"


### PR DESCRIPTION
## Summary

- `app/core/visibility_router.py` imported `get_current_active_user` from `app/auth/dependencies` — a symbol that has not existed since the refresh-token refactor (only `get_current_user` + `get_current_user_ws` are exported). Mounting the router would have failed with `ImportError`, which is why the router was never wired up.
- `app/main.py` never called `app.include_router(visibility_router, ...)`, so all six endpoints (GET/PUT a resource's visibility, grant/revoke specific-user access, get migration status, execute migration) returned 404 in production despite the file existing.
- Both issues are pre-existing and were called out by PR #286 (#228 PR 2f).

## Bug detail

`get_current_user` already enforces `is_active` (raises HTTP 400 "Inactive user" if the user is deactivated), so swapping `get_current_active_user → get_current_user` is semantically equivalent to the legacy active-user guard — no behaviour change beyond the import now resolving.

Mount prefix: the router declares `prefix="/visibility"` at construction; mounting it on the app with `prefix="/api/v1"` results in `/api/v1/visibility/*`, matching the other domain routers (`/api/v1/servers`, `/api/v1/groups`, etc.).

## Changes

- `app/core/visibility_router.py`: replace the broken import and all six `Depends(get_current_active_user)` usages with `get_current_user`.
- `app/main.py`: import `visibility_router` and `include_router` it under `/api/v1` next to the other domain routers.
- `tests/integration/api/test_visibility_router.py`: new smoke test that pins the wiring — an unauthenticated request now returns 401 (was 404 pre-fix), and an authenticated request reaches the handler body (404 from the ownership branch), proving both the route registration and the DI graph resolve under TestClient.

## Test plan

- [x] `uv run ruff check app/core/visibility_router.py app/main.py tests/integration/api/test_visibility_router.py`
- [x] `uv run ruff format` (no changes needed)
- [x] `uv run pytest tests/integration/api/test_visibility_router.py -v` → 2 passed
- [x] `uv run pytest tests/unit -m "not slow"` → 1107 passed, 5 skipped
- [x] `uv run pytest tests/integration -m "not slow"` → 429 passed, 5 skipped
- [x] `uv run pre-commit run --files <touched>` → all hooks pass (incl. pytest unit smoke + mypy relaxed)

## Followup (out of scope)

While writing the smoke test I noticed `/visibility/migration/status` is shadowed by the earlier-registered `/visibility/{resource_type}/{resource_id}` route (FastAPI matches by definition order, so `migration` is parsed as a `resource_type` enum and returns 422). This pre-existing route-ordering bug should be fixed in a follow-up PR — outside the scope of #288, which is purely about wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>