### PR TITLE
refactor: expose broadcast_group_change to remove Demeter chain in GroupService (Resolves #262)

### DIFF
--- a/app/groups/application/file_syncer.py
+++ b/app/groups/application/file_syncer.py
@@ -85,6 +85,41 @@ class GroupFileSyncer:
             real_time_commands = real_time_server_commands
         self._real_time_commands = real_time_commands
 
+    async def broadcast_group_change(
+        self,
+        server_id: int,
+        server_path: Path,
+        group_type: GroupType,
+        change_type: str,
+        removed_players: Optional[List[Optional[Dict[str, Any]]]] = None,
+    ) -> bool:
+        """Forward a real-time group-change command to the running server.
+
+        Public wrapper around the injected `real_time_commands`
+        collaborator. Callers (e.g. `GroupService`) MUST go through this
+        method instead of reaching into the private
+        `_real_time_commands` attribute — exposing the collaborator
+        keeps the call graph shallow and respects the Law of Demeter
+        (see Issue #262).
+
+        Args mirror
+        `RealTimeServerCommands.handle_group_change_commands`:
+        `change_type` is one of "update", "attach", "detach",
+        "player_add", "player_remove"; `removed_players` carries the
+        deop-broadcast payload for op detach / player_remove.
+
+        Returns the collaborator's success flag; raises whatever the
+        collaborator raises so callers can apply their own best-effort
+        log-and-continue semantics.
+        """
+        return await self._real_time_commands.handle_group_change_commands(
+            server_id,
+            server_path,
+            group_type,
+            change_type,
+            removed_players=removed_players,
+        )
+
     async def update_server_files(self, server_id: int) -> None:
         """Regenerate ops.json + whitelist.json for one server.
 

--- a/app/groups/application/service.py
+++ b/app/groups/application/service.py
@@ -446,7 +446,7 @@ class GroupService:
 
         # Best-effort real-time commands
         try:
-            await self._file_syncer._real_time_commands.handle_group_change_commands(
+            await self._file_syncer.broadcast_group_change(
                 server_id, Path(server.directory_path), existing.type, "attach"
             )
         except Exception as cmd_error:
@@ -524,12 +524,12 @@ class GroupService:
             )
 
         try:
-            await self._file_syncer._real_time_commands.handle_group_change_commands(
+            await self._file_syncer.broadcast_group_change(
                 server_id,
                 Path(server.directory_path),
                 existing.type,
                 "detach",
-                removed_players,
+                removed_players=removed_players,
             )
         except Exception as cmd_error:
             logger.warning(
@@ -593,7 +593,7 @@ class GroupService:
             async with self._uow as uow:
                 attached = await uow.server_groups.list_server_dirs_for_group(group_id)
             for server_id, directory_path in attached:
-                await self._file_syncer._real_time_commands.handle_group_change_commands(
+                await self._file_syncer.broadcast_group_change(
                     server_id,
                     Path(directory_path),
                     group_type,


### PR DESCRIPTION
## Summary

`GroupService` was reaching into `GroupFileSyncer`'s private `_real_time_commands` collaborator at three callsites (`attach_group_to_server`, `detach_group_from_server`, `_broadcast_player_change`). That two-hop access is a Demeter smell flagged in PR #261 / Issue #262.

This PR adds a public seam `GroupFileSyncer.broadcast_group_change(...)` and routes all three callsites through it. Pure refactor — behaviour is unchanged.

## Why

- Removes private-attribute reach-through across module boundaries
- Keeps the call graph one hop deep, aligning with the Law of Demeter
- Future-proofs `GroupFileSyncer` against further internal restructuring (Issue #262)

## Changes

- `app/groups/application/file_syncer.py`: add `broadcast_group_change(server_id, server_path, group_type, change_type, removed_players=None)` — thin forwarder around `_real_time_commands.handle_group_change_commands`.
- `app/groups/application/service.py`: replace the three `self._file_syncer._real_time_commands.handle_group_change_commands(...)` calls with `self._file_syncer.broadcast_group_change(...)`.

Existing tests inject a fake via `GroupFileSyncer(real_time_commands=...)`, so the new forwarder still routes to the fake — no test update needed.

## Test plan

- [x] `rg -n '_file_syncer\._real_time_commands' app/` → 0 hits
- [x] `uv run pytest tests/unit/groups -m "not slow"` → 65 passed
- [x] `uv run pytest tests/unit -m "not slow"` → 1107 passed, 5 skipped
- [x] `uv run pytest tests/integration -m "not slow"` → 427 passed, 5 skipped
- [x] `uv run ruff check app/` clean, `ruff format --check` clean
- [x] `uv run pre-commit run --files app/groups/application/{service,file_syncer}.py` passes
- [x] pre-push hook (unit + integration smoke) passes

Resolves #262