### PR TITLE
feat: invoke VisibilityMigrationService at lifespan startup (Resolves #289)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -100,16 +100,19 @@ async def _initialize_services():
     # 1. Initialize database (critical - app cannot function without it)
     await _initialize_database()
 
-    # 2. Initialize database integration (important but not critical)
+    # 2. Backfill Phase 2 visibility rows for legacy resources (best-effort)
+    await _initialize_visibility_migration()
+
+    # 3. Initialize database integration (important but not critical)
     await _initialize_database_integration()
 
-    # 3. Initialize backup scheduler (optional - can be started later)
+    # 4. Initialize backup scheduler (optional - can be started later)
     await _initialize_backup_scheduler()
 
-    # 4. Initialize WebSocket service (optional - real-time features)
+    # 5. Initialize WebSocket service (optional - real-time features)
     await _initialize_websocket_service()
 
-    # 5. Initialize version update scheduler (optional - background updates)
+    # 6. Initialize version update scheduler (optional - background updates)
     await _initialize_version_update_scheduler()
 
 
@@ -134,6 +137,76 @@ async def _initialize_database():
         service_status.failed_services.append("database")
         # Database failure is critical - re-raise to prevent startup
         raise RuntimeError(f"Critical database initialization failed: {e}") from e
+
+
+async def _initialize_visibility_migration():
+    """Backfill Phase 2 visibility rows for legacy servers/groups.
+
+    Runs `VisibilityMigrationService.migrate_all_resources` at lifespan
+    startup so that resources created before the Phase 2 visibility
+    feature landed (or by a code path that forgot to assign a default
+    row) receive the canonical PUBLIC default. The underlying service is
+    idempotent: the cross-domain query (`list_missing_*`) returns the
+    empty set once every resource already has a visibility row, so
+    re-running on every boot is cheap when the system is steady-state
+    (see `app/core/visibility/application/migration.py`).
+
+    Failure handling: this is a best-effort backfill, not a critical
+    boot step. Any exception is logged at WARNING and startup continues;
+    operators can re-trigger manually through the
+    ``POST /api/v1/visibility/migration/execute`` admin endpoint
+    (mounted by #312).
+    """
+    try:
+        logger.info("Running visibility migration backfill...")
+        import time
+
+        from app.core.database import SessionLocal
+        from app.core.visibility.api.dependencies import (
+            make_visibility_migration_service,
+        )
+
+        db = SessionLocal()
+        try:
+            service = make_visibility_migration_service(db)
+            started = time.monotonic()
+            counts = await service.migrate_all_resources()
+            elapsed = time.monotonic() - started
+        finally:
+            db.close()
+
+        # Slow-startup guard: flag boots where the backfill noticeably
+        # delays startup so operators investigating long lifespans have
+        # a breadcrumb. Threshold mirrors the
+        # `PerformanceMonitoringMiddleware` slow-request default.
+        if elapsed >= 1.0:
+            logger.warning(
+                "Visibility migration backfill took %.2fs "
+                "(servers=%d, groups=%d, total=%d)",
+                elapsed,
+                counts.get("servers", 0),
+                counts.get("groups", 0),
+                counts.get("total", 0),
+            )
+        else:
+            logger.info(
+                "Visibility migration backfill completed in %.2fs "
+                "(servers=%d, groups=%d, total=%d)",
+                elapsed,
+                counts.get("servers", 0),
+                counts.get("groups", 0),
+                counts.get("total", 0),
+            )
+    except Exception as e:
+        logger.warning(
+            "Visibility migration backfill failed; startup continues. "
+            "Re-trigger manually via POST /api/v1/visibility/migration/execute. "
+            "error=%s",
+            e,
+        )
+        # Intentionally not added to `failed_services`: this is a
+        # best-effort backfill, not a tracked service. Health checks
+        # remain unaffected.
 
 
 async def _initialize_database_integration():

--- a/tests/integration/test_main_comprehensive.py
+++ b/tests/integration/test_main_comprehensive.py
@@ -311,6 +311,107 @@ class TestApplicationStartupShutdown:
             mock_logger.critical.assert_called()
 
     @pytest.mark.asyncio
+    async def test_initialize_visibility_migration_success(self):
+        """Backfill invokes the migration service and logs the result.
+
+        Verifies the lifespan hook constructs the service through the
+        documented factory, calls `migrate_all_resources`, and closes
+        the session it opened. Idempotency itself is exercised by the
+        domain-level tests in
+        ``tests/unit/core/visibility/test_service_with_fake.py``.
+        """
+        mock_service = AsyncMock()
+        mock_service.migrate_all_resources = AsyncMock(
+            return_value={"servers": 2, "groups": 1, "total": 3}
+        )
+        mock_db = MagicMock()
+
+        with (
+            patch("app.core.database.SessionLocal", return_value=mock_db),
+            patch(
+                "app.core.visibility.api.dependencies.make_visibility_migration_service",
+                return_value=mock_service,
+            ) as mock_factory,
+            patch("app.main.logger") as mock_logger,
+        ):
+            from app.main import _initialize_visibility_migration
+
+            await _initialize_visibility_migration()
+
+            mock_factory.assert_called_once_with(mock_db)
+            mock_service.migrate_all_resources.assert_awaited_once()
+            mock_db.close.assert_called_once()
+            mock_logger.info.assert_called()
+            # Best-effort hook must not signal failure
+            mock_logger.warning.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_initialize_visibility_migration_failure_swallowed(self):
+        """Migration failure logs a warning and lets startup continue.
+
+        Best-effort backfill: the lifespan must never abort because of a
+        migration error; operators re-trigger via the admin endpoint.
+        """
+        mock_service = AsyncMock()
+        mock_service.migrate_all_resources = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_db = MagicMock()
+
+        with (
+            patch("app.core.database.SessionLocal", return_value=mock_db),
+            patch(
+                "app.core.visibility.api.dependencies.make_visibility_migration_service",
+                return_value=mock_service,
+            ),
+            patch("app.main.service_status") as mock_status,
+            patch("app.main.logger") as mock_logger,
+        ):
+            mock_status.failed_services = []
+            from app.main import _initialize_visibility_migration
+
+            # Must not raise
+            await _initialize_visibility_migration()
+
+            mock_logger.warning.assert_called()
+            # Session must still be closed even when migration raises
+            mock_db.close.assert_called_once()
+            # Best-effort hook does not flag the system as degraded
+            assert "visibility_migration" not in mock_status.failed_services
+
+    @pytest.mark.asyncio
+    async def test_initialize_visibility_migration_slow_warning(self):
+        """Slow backfill (>=1s) emits a warning breadcrumb for operators."""
+        import asyncio
+
+        mock_db = MagicMock()
+
+        async def slow_migrate():
+            # Yield control so the wall-clock can advance under the
+            # patched ``time.monotonic`` below.
+            await asyncio.sleep(0)
+            return {"servers": 0, "groups": 0, "total": 0}
+
+        mock_service = AsyncMock()
+        mock_service.migrate_all_resources = AsyncMock(side_effect=slow_migrate)
+
+        # Fake a >=1s elapsed window via deterministic monotonic clock
+        clock = iter([0.0, 1.5])
+        with (
+            patch("app.core.database.SessionLocal", return_value=mock_db),
+            patch(
+                "app.core.visibility.api.dependencies.make_visibility_migration_service",
+                return_value=mock_service,
+            ),
+            patch("time.monotonic", side_effect=lambda: next(clock)),
+            patch("app.main.logger") as mock_logger,
+        ):
+            from app.main import _initialize_visibility_migration
+
+            await _initialize_visibility_migration()
+
+            mock_logger.warning.assert_called()
+            mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_initialize_database_integration_success(self):
         """Test successful database integration initialization.
 
@@ -422,7 +523,9 @@ class TestApplicationStartupShutdown:
                 "app.servers.application.minecraft_server.minecraft_server_manager"
             ) as mock_mc_manager,
             patch("app.backups.backup_scheduler_instance") as mock_holder,
-            patch("app.websockets.application.service.websocket_service") as mock_ws_service,
+            patch(
+                "app.websockets.application.service.websocket_service"
+            ) as mock_ws_service,
             patch("app.main.service_status") as mock_status,
             patch("app.main.logger") as mock_logger,
         ):


### PR DESCRIPTION
## Summary

- Wires `VisibilityMigrationService.migrate_all_resources` into `app/main.py` lifespan via a new `_initialize_visibility_migration` hook, ordered immediately after `_initialize_database` and before `_initialize_database_integration`.
- Backfills the Phase 2 `ResourceVisibility` PUBLIC default for legacy servers/groups on every boot, closing the pre-existing gap where the only trigger was the admin endpoint mounted by #312.
- Uses the existing `make_visibility_migration_service` factory; no new factory was required.

## Idempotent design

The underlying service already encodes a query-then-skip pattern: `list_missing_server_ids` / `list_missing_group_ids` (cross-domain LEFT-ANTI-JOINs in `app/core/visibility/adapters/repository.py`) return the empty set once every resource has a visibility row. At steady state the boot-time cost is therefore O(rows-without-row) = 0 — no writes, no commit, no log spam. Domain-level idempotency is covered by `tests/unit/core/visibility/test_service_with_fake.py::test_migrate_all_resources_is_idempotent`.

## Failure handling

- Best-effort: exceptions are logged at WARNING and startup continues. Re-trigger manually via `POST /api/v1/visibility/migration/execute`.
- Not added to `service_status.failed_services` — `/health` remains unaffected, in line with the "not critical" tier (database integration, scheduler, websocket).

## Observability

- Elapsed time logged at INFO; runs >=1s emit a WARNING breadcrumb (mirrors `PerformanceMonitoringMiddleware`'s slow-request threshold) so operators investigating long lifespans see large-environment backfill events.

## Test plan

- [x] Unit smoke (`tests/unit -m "not slow"`): 1108 passed, 5 skipped
- [x] Integration smoke (`tests/integration -m "not slow"`): 432 passed, 5 skipped
- [x] New tests (`tests/integration/test_main_comprehensive.py::*visibility_migration*`):
  - `test_initialize_visibility_migration_success` — factory called, `migrate_all_resources` awaited, session closed
  - `test_initialize_visibility_migration_failure_swallowed` — exception -> WARNING + session close + startup continues, no `failed_services` flag
  - `test_initialize_visibility_migration_slow_warning` — fake >=1s elapsed window emits the slow-startup WARNING
- [x] `uv run ruff check app/ tests/`
- [x] `uv run pre-commit run --files app/main.py tests/integration/test_main_comprehensive.py`

## Refs

Resolves #289. Builds on #286 (service path) and #312 (admin re-trigger endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)