### PR TITLE
refactor: make _notify_status_change async-aware to restore bool result + ordering (Resolves #280)

### DIFF
--- a/app/servers/application/database_integration.py
+++ b/app/servers/application/database_integration.py
@@ -5,14 +5,26 @@ rewritten on top of `ServersUnitOfWork` / `ServerRepository` (R-15).
 
 The legacy implementation talked to SQLAlchemy directly via
 `SessionLocal()` + `session.query(Server)` and registered a *sync*
-callback with `MinecraftServerManager`. That contract still holds
-on the daemon side — subprocess SIGCHLD reapers and threadpool callbacks
-cannot `await` — so this module owns the sync→async bridge:
+callback with `MinecraftServerManager`. After Issue #280 the
+`MinecraftServerManager._notify_status_change` callsites are all
+async-aware and await the registered callback directly, so the
+canonical contract is now async:
 
-* `update_server_status_sync(server_id, status)` is the public
-  cross-thread entry point. It captures the running event loop in
-  `initialize()` and dispatches each call via
-  `asyncio.run_coroutine_threadsafe` to that loop.
+* `_update_server_status_async(server_id, status)` is the async impl
+  registered with the manager via `set_status_update_callback`. The
+  manager `await`s it from each of its ``async def`` callsites,
+  restoring the bool result that the PR #279 fire-and-forget bridge
+  dropped and preserving ordering of consecutive status changes
+  within each task.
+* `update_server_status_sync(server_id, status)` is preserved as a
+  cross-thread façade: it captures the running event loop in
+  `initialize()` and dispatches via `asyncio.run_coroutine_threadsafe`
+  for daemon callers that still cannot `await` (subprocess SIGCHLD
+  reapers, threadpool callbacks). The same-loop branch keeps its
+  fire-and-forget semantics for the same reason — calling
+  `future.result()` on the loop you're already running on would
+  deadlock — but the manager no longer takes that branch since it now
+  awaits the async method directly.
 * The async impl runs under `ServersUnitOfWork`. Repository
   `update_status` owns its own transaction (see D-5 in the #228 plan)
   so `commit()` is a no-op for that path — the UoW context is still
@@ -42,8 +54,11 @@ from app.servers.models import ServerStatus
 logger = logging.getLogger(__name__)
 
 
-# A sync `(server_id, status) -> bool` callback contract is what
-# `MinecraftServerManager.set_status_update_callback` accepts.
+# `MinecraftServerManager.set_status_update_callback` accepts either a
+# sync `(server_id, status) -> bool` or an async
+# `(server_id, status) -> Awaitable[bool]` callable. Since #280 we
+# register the async impl so each manager callsite awaits a real
+# bool result.
 StatusUpdateCallback = Callable[[int, ServerStatus], bool]
 UowFactory = Callable[[], ServersUnitOfWork]
 
@@ -67,10 +82,17 @@ class DatabaseIntegrationService:
         """Capture the running event loop and register the status callback.
 
         Must be called from inside the loop that will own the bridge.
+
+        Since #280 the registered callback is the *async* impl: each
+        `MinecraftServerManager._notify_status_change` callsite awaits
+        it directly, so the bool result (and ordering of consecutive
+        status changes within a task) propagate back to the manager.
+        Cross-thread callers can still use `update_server_status_sync`
+        explicitly when they need the bridge.
         """
         self._loop = asyncio.get_running_loop()
         minecraft_server_manager.set_status_update_callback(
-            self.update_server_status_sync
+            self._update_server_status_async
         )
         logger.info("Database integration initialized")
 

--- a/app/servers/application/minecraft_server.py
+++ b/app/servers/application/minecraft_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import json
 import logging
 import os
@@ -11,7 +12,17 @@ import threading
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple
+from typing import (
+    Any,
+    AsyncGenerator,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import psutil
 
@@ -54,8 +65,17 @@ class MinecraftServerManager:
         self.processes: Dict[int, ServerProcess] = {}
         self.base_directory = Path("servers")
         self.base_directory.mkdir(exist_ok=True)
-        # Callback for database status updates
-        self._status_update_callback: Optional[Callable[[int, ServerStatus], None]] = None
+        # Callback for database status updates. The callback may be either a
+        # plain sync function (legacy / test fixtures) or an async function
+        # returning ``bool``; `_notify_status_change` awaits the awaitable
+        # form so callers see the bool result and ordering is preserved
+        # across consecutive status changes (Issue #280).
+        self._status_update_callback: Optional[
+            Callable[
+                [int, ServerStatus],
+                Union[Awaitable[Optional[bool]], Optional[bool]],
+            ]
+        ] = None
         # Configurable log queue size to prevent memory leaks
         self.log_queue_size = log_queue_size or settings.SERVER_LOG_QUEUE_SIZE
         self.java_check_timeout = settings.JAVA_CHECK_TIMEOUT
@@ -66,8 +86,20 @@ class MinecraftServerManager:
         # ``ServerRepository`` passed explicitly by the caller — no
         # framework-typed factories remain on this class.
 
-    def set_status_update_callback(self, callback: Callable[[int, ServerStatus], None]):
-        """Set callback function to update database when server status changes"""
+    def set_status_update_callback(
+        self,
+        callback: Callable[
+            [int, ServerStatus],
+            Union[Awaitable[Optional[bool]], Optional[bool]],
+        ],
+    ) -> None:
+        """Set callback function to update database when server status changes.
+
+        The callback may be sync or async. Sync callbacks are invoked
+        directly; async (coroutine) callbacks are awaited inside
+        `_notify_status_change`, so consecutive status changes from the same
+        async caller are ordered (Issue #280).
+        """
         self._status_update_callback = callback
 
     def _get_pid_file_path(self, server_id: int, server_dir: Path) -> Path:
@@ -346,7 +378,7 @@ class MinecraftServerManager:
                     f"Daemon server {server_id} (PID: {server_process.pid}) is already stopped"
                 )
                 await self._cleanup_server_process(server_id)
-                self._notify_status_change(server_id, ServerStatus.stopped)
+                await self._notify_status_change(server_id, ServerStatus.stopped)
                 return True
 
             # Start with graceful SIGTERM (even for non-force stops)
@@ -365,7 +397,7 @@ class MinecraftServerManager:
                     if not await self._is_process_running(server_process.pid):
                         logger.info(f"Daemon server {server_id} stopped with SIGTERM")
                         await self._cleanup_server_process(server_id)
-                        self._notify_status_change(server_id, ServerStatus.stopped)
+                        await self._notify_status_change(server_id, ServerStatus.stopped)
                         return True
 
                 # If SIGTERM doesn't work, use SIGKILL
@@ -380,7 +412,7 @@ class MinecraftServerManager:
                     if not await self._is_process_running(server_process.pid):
                         logger.info(f"Daemon server {server_id} stopped with SIGKILL")
                         await self._cleanup_server_process(server_id)
-                        self._notify_status_change(server_id, ServerStatus.stopped)
+                        await self._notify_status_change(server_id, ServerStatus.stopped)
                         return True
 
                 logger.error(
@@ -392,7 +424,7 @@ class MinecraftServerManager:
                 # Process already dead
                 logger.info(f"Daemon server {server_id} process already terminated")
                 await self._cleanup_server_process(server_id)
-                self._notify_status_change(server_id, ServerStatus.stopped)
+                await self._notify_status_change(server_id, ServerStatus.stopped)
                 return True
             except PermissionError:
                 logger.error(
@@ -583,7 +615,7 @@ class MinecraftServerManager:
                 if not await self._is_process_running(pid):
                     logger.info(f"Restored server {server_id} process {pid} has stopped")
                     server_process.status = ServerStatus.stopped
-                    self._notify_status_change(server_id, ServerStatus.stopped)
+                    await self._notify_status_change(server_id, ServerStatus.stopped)
 
                     # Clean up
                     await self._cleanup_server_process(server_id)
@@ -598,7 +630,7 @@ class MinecraftServerManager:
         except Exception as e:
             logger.error(f"Error monitoring restored server {server_id}: {e}")
             server_process.status = ServerStatus.error
-            self._notify_status_change(server_id, ServerStatus.error)
+            await self._notify_status_change(server_id, ServerStatus.error)
             await self._cleanup_server_process(server_id)
 
     async def discover_and_restore_processes(self) -> Dict[int, bool]:
@@ -648,7 +680,7 @@ class MinecraftServerManager:
                     if success:
                         logger.info(f"Successfully restored server {server_id}")
                         # Notify database of running status
-                        self._notify_status_change(server_id, ServerStatus.running)
+                        await self._notify_status_change(server_id, ServerStatus.running)
                     else:
                         logger.info(f"Failed to restore server {server_id}")
 
@@ -663,15 +695,38 @@ class MinecraftServerManager:
             logger.error(f"Error during process discovery: {e}")
             return restoration_results
 
-    def _notify_status_change(self, server_id: int, status: ServerStatus):
-        """Notify about status changes to update database"""
-        if self._status_update_callback:
-            try:
-                self._status_update_callback(server_id, status)
-            except Exception as e:
-                logger.error(
-                    f"Failed to update database status for server {server_id}: {e}"
-                )
+    async def _notify_status_change(self, server_id: int, status: ServerStatus) -> bool:
+        """Notify about status changes to update the database.
+
+        Returns ``True`` if the registered callback reported success (or
+        returned ``None``/no value, treated as success for backward
+        compatibility with sync recorders that don't return anything).
+        Returns ``False`` if no callback is registered, the callback raised
+        an exception, or the callback explicitly returned ``False``.
+
+        Issue #280: this used to be a sync method that swallowed the bool
+        result, leaving daemons unable to react to DB update failures and
+        racing consecutive status changes. It is now awaited at every
+        callsite (each of which already runs inside an ``async def``), so
+        the bool propagates to callers and ordering is preserved within
+        each task.
+        """
+        callback = self._status_update_callback
+        if callback is None:
+            return False
+        try:
+            result = callback(server_id, status)
+            if inspect.isawaitable(result):
+                result = await result
+        except Exception as e:
+            logger.error(f"Failed to update database status for server {server_id}: {e}")
+            return False
+        # Sync recorders / test fixtures often return ``None``; treat that
+        # as success so we don't regress legacy test expectations. Only an
+        # explicit ``False`` is treated as failure.
+        if result is None:
+            return True
+        return bool(result)
 
     async def _diagnose_log_issues(self, server_id: int, server_dir: Path) -> str:
         """Diagnose potential log file issues for debugging"""
@@ -747,7 +802,7 @@ class MinecraftServerManager:
                         f"Daemon server {server_id} process {pid} died during startup"
                     )
                     server_process.status = ServerStatus.error
-                    self._notify_status_change(server_id, ServerStatus.error)
+                    await self._notify_status_change(server_id, ServerStatus.error)
                     # Schedule cleanup without awaiting to avoid self-await issue
                     asyncio.create_task(self._cleanup_server_process(server_id))
                     return
@@ -834,7 +889,7 @@ class MinecraftServerManager:
                                     f"Daemon server {server_id} startup completed (detected pattern '{detected_pattern}' after {elapsed_seconds:.1f}s)"
                                 )
                                 server_process.status = ServerStatus.running
-                                self._notify_status_change(
+                                await self._notify_status_change(
                                     server_id, ServerStatus.running
                                 )
                                 startup_detected = True
@@ -903,13 +958,13 @@ class MinecraftServerManager:
                         f"but process is running - assuming started. Diagnostics: {diagnostic_info}"
                     )
                     server_process.status = ServerStatus.running
-                    self._notify_status_change(server_id, ServerStatus.running)
+                    await self._notify_status_change(server_id, ServerStatus.running)
                 else:
                     logger.error(
                         f"Daemon server {server_id} process {pid} died during startup (timeout)"
                     )
                     server_process.status = ServerStatus.error
-                    self._notify_status_change(server_id, ServerStatus.error)
+                    await self._notify_status_change(server_id, ServerStatus.error)
                     # Schedule cleanup without awaiting to avoid self-await issue
                     asyncio.create_task(self._cleanup_server_process(server_id))
                     return
@@ -919,7 +974,7 @@ class MinecraftServerManager:
                 if not await self._is_process_running(pid):
                     logger.info(f"Daemon server {server_id} process {pid} has stopped")
                     server_process.status = ServerStatus.stopped
-                    self._notify_status_change(server_id, ServerStatus.stopped)
+                    await self._notify_status_change(server_id, ServerStatus.stopped)
                     # Schedule cleanup without awaiting to avoid self-await issue
                     asyncio.create_task(self._cleanup_server_process(server_id))
                     break
@@ -935,7 +990,7 @@ class MinecraftServerManager:
                 f"Error monitoring daemon server {server_id}: {e}", exc_info=True
             )
             server_process.status = ServerStatus.error
-            self._notify_status_change(server_id, ServerStatus.error)
+            await self._notify_status_change(server_id, ServerStatus.error)
             # Schedule cleanup without awaiting to avoid self-await issue
             asyncio.create_task(self._cleanup_server_process(server_id))
 
@@ -1617,7 +1672,7 @@ class MinecraftServerManager:
                 )
 
             # Notify database of status change
-            self._notify_status_change(server.id, ServerStatus.starting)
+            await self._notify_status_change(server.id, ServerStatus.starting)
 
             logger.info(
                 f"Successfully started daemon server {server.id} with PID {daemon_pid}"
@@ -1644,7 +1699,7 @@ class MinecraftServerManager:
             server_process.status = ServerStatus.stopping
 
             # Notify database of status change
-            self._notify_status_change(server_id, ServerStatus.stopping)
+            await self._notify_status_change(server_id, ServerStatus.stopping)
 
             # Handle daemon processes (no process object)
             if server_process.process is None:
@@ -1656,7 +1711,7 @@ class MinecraftServerManager:
                 logger.info(f"Server {server_id} process already terminated")
                 # Clean up immediately if process is already dead
                 await self._cleanup_server_process(server_id)
-                self._notify_status_change(server_id, ServerStatus.stopped)
+                await self._notify_status_change(server_id, ServerStatus.stopped)
                 return True
 
             if not force:
@@ -1709,7 +1764,7 @@ class MinecraftServerManager:
             await self._cleanup_server_process(server_id)
 
             # Notify database of final stopped status
-            self._notify_status_change(server_id, ServerStatus.stopped)
+            await self._notify_status_change(server_id, ServerStatus.stopped)
 
             logger.info(f"Successfully stopped server {server_id}")
             return True
@@ -1719,7 +1774,7 @@ class MinecraftServerManager:
             # Ensure cleanup even if there was an error
             try:
                 await self._cleanup_server_process(server_id)
-                self._notify_status_change(server_id, ServerStatus.stopped)
+                await self._notify_status_change(server_id, ServerStatus.stopped)
             except Exception as cleanup_error:
                 logger.error(f"Failed to cleanup server {server_id}: {cleanup_error}")
             return False
@@ -1951,7 +2006,9 @@ class MinecraftServerManager:
                 )
 
                 server_process.status = ServerStatus.error
-                self._notify_status_change(server_process.server_id, ServerStatus.error)
+                await self._notify_status_change(
+                    server_process.server_id, ServerStatus.error
+                )
 
                 # Clean up
                 await self._cleanup_server_process(server_process.server_id)
@@ -1963,7 +2020,9 @@ class MinecraftServerManager:
                     f"Server {server_process.server_id} process is stable after 5 seconds - marking as running"
                 )
                 server_process.status = ServerStatus.running
-                self._notify_status_change(server_process.server_id, ServerStatus.running)
+                await self._notify_status_change(
+                    server_process.server_id, ServerStatus.running
+                )
 
             # For detached processes, we can't reliably wait() so we check periodically
             while server_process.server_id in self.processes:
@@ -1979,7 +2038,7 @@ class MinecraftServerManager:
                         logger.info(
                             f"Server {server_process.server_id} process has ended"
                         )
-                        self._notify_status_change(
+                        await self._notify_status_change(
                             server_process.server_id, ServerStatus.stopped
                         )
                         break
@@ -1999,7 +2058,7 @@ class MinecraftServerManager:
             logger.error(f"Error monitoring server {server_process.server_id}: {e}")
             server_process.status = ServerStatus.error
             # Notify database of error status
-            self._notify_status_change(server_process.server_id, ServerStatus.error)
+            await self._notify_status_change(server_process.server_id, ServerStatus.error)
 
             # Clean up
             await self._cleanup_server_process(server_process.server_id)

--- a/tests/integration/test_daemon_lifecycle_comprehensive.py
+++ b/tests/integration/test_daemon_lifecycle_comprehensive.py
@@ -374,7 +374,8 @@ class TestDaemonLifecycleComprehensive:
         manager.set_status_update_callback(record_status)
 
         # Notify status change before cleanup
-        manager._notify_status_change(1, ServerStatus.stopped)
+        # Issue #280: `_notify_status_change` is now async.
+        await manager._notify_status_change(1, ServerStatus.stopped)
 
         # Execute cleanup
         await manager._cleanup_server_process(1)

--- a/tests/integration/test_database_integration_enhanced.py
+++ b/tests/integration/test_database_integration_enhanced.py
@@ -6,9 +6,12 @@ in-memory `FakeServersUnitOfWork` rather than mocking SQLAlchemy
 internals (`SessionLocal`, `with_transaction`, query chains) — the
 legacy assertion style is no longer applicable.
 
-The async path is the canonical one. `update_server_status_sync` and
-`sync_server_states` are sync façades that bridge through the loop the
-service captured in `initialize()`.
+The async path is the canonical one and — since Issue #280 — it is
+registered as the manager callback directly so every callsite awaits a
+real bool result. `update_server_status_sync` and `sync_server_states`
+remain available as sync façades for cross-thread callers that still
+cannot `await`; they bridge through the loop the service captured in
+`initialize()`.
 """
 
 import asyncio
@@ -49,8 +52,12 @@ class TestLifecycle:
             "app.servers.application.database_integration.minecraft_server_manager"
         ) as mock_mgr:
             service.initialize()
+            # Since #280 the manager awaits the async impl directly so we
+            # register `_update_server_status_async` rather than the sync
+            # façade — the bool result and ordering of consecutive status
+            # changes now propagate back to the manager callsite.
             mock_mgr.set_status_update_callback.assert_called_once_with(
-                service.update_server_status_sync
+                service._update_server_status_async
             )
         assert service._loop is not None  # captured running loop
 

--- a/tests/integration/test_minecraft_server_manager_integration.py
+++ b/tests/integration/test_minecraft_server_manager_integration.py
@@ -318,9 +318,7 @@ print("[12:35:01] [Server thread/INFO]: Server stopped")
     # ===== Port Validation Integration Tests =====
 
     @pytest.mark.asyncio
-    async def test_validate_port_availability_success(
-        self, manager, integration_server
-    ):
+    async def test_validate_port_availability_success(self, manager, integration_server):
         """Test port validation success path with real socket operations"""
         repo = self._wire_empty_repo_factory(manager)
         available, message = await manager._validate_port_availability(
@@ -387,9 +385,12 @@ print("[12:35:01] [Server thread/INFO]: Server stopped")
         manager.set_status_update_callback(callback)
 
         with patch("app.servers.application.minecraft_server.logger") as mock_logger:
-            # This should not raise exception even though callback fails
-            manager._notify_status_change(1, ServerStatus.running)
+            # This should not raise exception even though callback fails.
+            # Issue #280: `_notify_status_change` is now async and returns
+            # ``False`` when the callback raises.
+            result = await manager._notify_status_change(1, ServerStatus.running)
 
+            assert result is False
             callback.assert_called_once_with(1, ServerStatus.running)
             mock_logger.error.assert_called_once()
             assert "Failed to update database status for server 1" in str(

--- a/tests/integration/test_minecraft_server_monitoring.py
+++ b/tests/integration/test_minecraft_server_monitoring.py
@@ -179,8 +179,9 @@ sys.exit(0)
 
             # If status change didn't happen naturally, verify the logs were at least read
             if len(running_status_changes) == 0:
-                # Manually trigger status update to verify callback works
-                manager._notify_status_change(1, ServerStatus.running)
+                # Manually trigger status update to verify callback works.
+                # Issue #280: `_notify_status_change` is now async.
+                await manager._notify_status_change(1, ServerStatus.running)
                 running_status_changes = [
                     (sid, status)
                     for sid, status in status_changes

--- a/tests/integration/test_minecraft_server_simple.py
+++ b/tests/integration/test_minecraft_server_simple.py
@@ -226,8 +226,11 @@ class TestMinecraftServerManagerSimpleIntegration:
         manager.set_status_update_callback(callback)
 
         with patch("app.servers.application.minecraft_server.logger") as mock_logger:
-            manager._notify_status_change(1, ServerStatus.running)
+            # Issue #280: `_notify_status_change` is now async and returns
+            # ``False`` when the callback raises.
+            result = await manager._notify_status_change(1, ServerStatus.running)
 
+            assert result is False
             callback.assert_called_once_with(1, ServerStatus.running)
             mock_logger.error.assert_called_once()
             assert "Failed to update database status for server 1" in str(


### PR DESCRIPTION
## Summary

PR #279 (#228 PR 2d) converted the 22 `_notify_status_change` callsites in `MinecraftServerManager` to a sync entry point that fire-and-forget scheduled the DB update via `asyncio.ensure_future` when called on the same loop. That retrofit unblocked the migration to `ServersUnitOfWork` but dropped two properties the legacy sync-blocking callback had:

- the `bool` result of the DB update no longer reached the daemon callsite, so a failed status write was silent; and
- two consecutive status changes from the same task could land out of order because both were unawaited tasks racing on the loop.

This PR retrofits the rest of the way: `_notify_status_change` is now `async def ... -> bool` and every callsite `await`s it. All 22 sites already live inside `async def` methods, so this is a mechanical change at the manager. `DatabaseIntegrationService` now registers `_update_server_status_async` directly with the manager so the await yields a real bool from the repository write.

## Why

- Closes the regression introduced in PR #279
- Restores propagation of DB update failures to daemon callers (so they can react)
- Restores ordering of consecutive status changes within a task
- Follow-up to #228 / #149 / #155

## Changes

- `app/servers/application/minecraft_server.py`
  - `_notify_status_change` becomes `async def` returning `bool`. Sync callbacks (legacy / test recorders that return `None`) are still supported via `inspect.isawaitable` detection and treated as success unless they raise or return `False`.
  - `set_status_update_callback` signature widened to `Callable[..., Union[Awaitable[Optional[bool]], Optional[bool]]]` so async or sync callbacks both register cleanly.
  - All 22 callsites updated with `await` (mechanical).
- `app/servers/application/database_integration.py`
  - `initialize()` now registers `_update_server_status_async` (not `update_server_status_sync`). The same-loop fire-and-forget bridge inside `update_server_status_sync` is preserved for cross-thread callers but is no longer the manager-callback path.
  - Module docstring updated to reflect the new contract.
- Tests updated to `await manager._notify_status_change(...)` and to assert the new bool result; the integration-service registration test now expects `_update_server_status_async`.

## Threading bridge

No new `run_coroutine_threadsafe` calls were needed: every existing `_notify_status_change` callsite is already inside an `async def` method on the manager's own event loop, so awaiting the async impl directly is sufficient. The legacy `update_server_status_sync` cross-thread facade remains in place for `sync_server_states` / `batch_update_server_statuses` and any non-loop callers that may surface in the future (subprocess SIGCHLD reapers, threadpool callbacks).

## Test plan

- [x] `uv run ruff check` on touched files - clean
- [x] `uv run ruff format` - applied
- [x] `uv run pre-commit run --files <touched>` - passed (ruff, mypy, pytest unit smoke)
- [x] `uv run pytest tests/unit -m "not slow"` - all passed
- [x] `uv run pytest tests/integration -m "not slow"` - all passed
- [x] `just test` (full suite incl. slow) - 1725 passed, 10 skipped in 5m36s

Resolves #280

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>