### PR TITLE
feat: periodic cleanup of .pending/ and .failed/ in backups_directory (Resolves #284)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,13 @@ DATABASE_MAX_RETRIES=3
 DATABASE_RETRY_BACKOFF=0.1
 DATABASE_BATCH_SIZE=100
 
+# Backup directory housekeeping (Issue #284)
+# Periodic sweep of stale artifacts left in `backups/.pending/` and
+# `backups/.failed/` by interrupted atomic-rename operations.
+BACKUPS_PENDING_RETENTION_HOURS=24
+BACKUPS_FAILED_RETENTION_DAYS=30
+BACKUPS_CLEANUP_INTERVAL_SECONDS=3600
+
 # CORS configuration
 CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,https://127.0.0.1:3000
 

--- a/app/backups/api/dependencies.py
+++ b/app/backups/api/dependencies.py
@@ -91,7 +91,9 @@ def make_backup_service(
     )
 
 
-def make_backup_scheduler() -> BackupSchedulerService:
+def make_backup_scheduler(
+    backups_directory: Path = Path("backups"),
+) -> BackupSchedulerService:
     """Build the lifespan-scoped `BackupSchedulerService`.
 
     Both `uow_factory` and `server_read_factory` open per-call sessions
@@ -99,10 +101,15 @@ def make_backup_scheduler() -> BackupSchedulerService:
     The server-read factory is intentionally a callable rather than a
     pre-bound instance to avoid leaking a long-lived session into a
     background worker.
+
+    `backups_directory` is forwarded to the periodic `.pending/` /
+    `.failed/` housekeeping sweep (Issue #284). Retention windows and
+    sweep cadence are read from `app.core.config.settings`.
     """
     return BackupSchedulerService(
         uow_factory=lambda: SqlAlchemyBackupsUnitOfWork.from_session_factory(
             SessionLocal
         ),
         server_read_factory=lambda: SqlAlchemyServerReadPort(SessionLocal()),
+        backups_directory=backups_directory,
     )

--- a/app/backups/application/scheduler.py
+++ b/app/backups/application/scheduler.py
@@ -13,7 +13,9 @@ SELECT.
 
 import asyncio
 import logging
+import time
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
 from app.backups.domain.entities import (
@@ -56,13 +58,40 @@ class BackupSchedulerService:
         uow_factory: Callable[[], BackupsUnitOfWork],
         server_read_factory: ServerReadPortFactory,
         clock: Callable[[], datetime] = _utcnow,
+        backups_directory: Path = Path("backups"),
+        pending_retention_hours: Optional[int] = None,
+        failed_retention_days: Optional[int] = None,
+        cleanup_interval_seconds: Optional[int] = None,
     ):
         self._uow_factory = uow_factory
         self._server_read_factory = server_read_factory
         self._clock = clock
         self._running = False
         self._task: Optional[asyncio.Task] = None
+        self._cleanup_task: Optional[asyncio.Task] = None
         self._schedule_cache: Dict[int, BackupScheduleEntity] = {}
+
+        # Sweep configuration for `.pending/` and `.failed/` (Issue #284).
+        # Defaults come from `app.core.config.settings` but each value can
+        # be overridden by the constructor for tests / wiring flexibility.
+        from app.core.config import settings as _settings
+
+        self._backups_directory: Path = Path(backups_directory)
+        self._pending_retention_hours: int = (
+            pending_retention_hours
+            if pending_retention_hours is not None
+            else _settings.BACKUPS_PENDING_RETENTION_HOURS
+        )
+        self._failed_retention_days: int = (
+            failed_retention_days
+            if failed_retention_days is not None
+            else _settings.BACKUPS_FAILED_RETENTION_DAYS
+        )
+        self._cleanup_interval_seconds: int = (
+            cleanup_interval_seconds
+            if cleanup_interval_seconds is not None
+            else _settings.BACKUPS_CLEANUP_INTERVAL_SECONDS
+        )
 
     # ===================
     # Schedule CRUD
@@ -305,18 +334,29 @@ class BackupSchedulerService:
         except Exception as e:
             logger.error(f"Failed to load schedules from database during startup: {e}")
         self._task = asyncio.create_task(self._scheduler_loop())
+        # One-shot sweep at startup picks up any artifacts left by a
+        # previous crashed process before the periodic loop's first
+        # tick (Issue #284). Failures here are non-fatal — they're
+        # logged and the periodic loop will retry.
+        try:
+            self.sweep_stale_pending_and_failed()
+        except Exception as e:
+            logger.warning(f"Startup sweep of .pending/.failed failed: {e}")
+        self._cleanup_task = asyncio.create_task(self._cleanup_loop())
 
     async def stop_scheduler(self) -> None:
         if not self._running:
             return
         self._running = False
-        if self._task:
-            self._task.cancel()
-            try:
-                await self._task
-            except asyncio.CancelledError:
-                pass
-            self._task = None
+        for task_attr in ("_task", "_cleanup_task"):
+            task: Optional[asyncio.Task] = getattr(self, task_attr)
+            if task:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                setattr(self, task_attr, None)
         self._schedule_cache.clear()
 
     async def _scheduler_loop(self) -> None:
@@ -335,6 +375,113 @@ class BackupSchedulerService:
             except Exception as e:
                 logger.error(f"Unexpected error in backup scheduler loop: {e}")
                 await asyncio.sleep(60)
+
+    async def _cleanup_loop(self) -> None:
+        """Periodic sweep of `.pending/` and `.failed/` artifacts (Issue #284).
+
+        Runs `sweep_stale_pending_and_failed()` every
+        `cleanup_interval_seconds` (default 1h). Each sweep is
+        idempotent (mtime-based, query-then-skip), so a missed tick
+        will catch up on the next run. Exceptions are logged and the
+        loop continues — never block the scheduler on housekeeping.
+        """
+        while self._running:
+            try:
+                await asyncio.sleep(self._cleanup_interval_seconds)
+            except asyncio.CancelledError:
+                logger.info("Backup cleanup loop cancelled")
+                break
+            if not self._running:
+                break
+            try:
+                self.sweep_stale_pending_and_failed()
+            except Exception as e:
+                logger.warning(f"Periodic sweep of .pending/.failed failed: {e}")
+
+    # ===================
+    # `.pending/` / `.failed/` housekeeping (Issue #284)
+    # ===================
+
+    def sweep_stale_pending_and_failed(self) -> Dict[str, int]:
+        """Delete stale `*.tar.gz` files from `.pending/` and `.failed/`.
+
+        Retention defaults (env-tunable via
+        `BACKUPS_PENDING_RETENTION_HOURS` /
+        `BACKUPS_FAILED_RETENTION_DAYS`):
+
+        - `.pending/*.tar.gz`: 24h (atomic-rename interrupted between
+          tar-write and `os.replace` — orphan temp file with no DB row).
+        - `.failed/*.tar.gz`: 30d (post-commit `os.replace` failure
+          recovery files; operator should review before auto-deletion,
+          but the retention window is long enough to catch human
+          attention via monitoring).
+
+        Idempotent: only files whose `mtime` is older than the
+        retention cutoff are unlinked. Per-file failures (permission
+        denied, etc.) are logged at WARNING and the sweep continues.
+        Returns `{"pending_deleted": int, "failed_deleted": int}` for
+        callers (tests / metrics).
+        """
+        result = {"pending_deleted": 0, "failed_deleted": 0}
+        result["pending_deleted"] = self._sweep_directory(
+            self._backups_directory / ".pending",
+            max_age_seconds=self._pending_retention_hours * 3600,
+            kind="pending",
+        )
+        result["failed_deleted"] = self._sweep_directory(
+            self._backups_directory / ".failed",
+            max_age_seconds=self._failed_retention_days * 86400,
+            kind="failed",
+        )
+        return result
+
+    def _sweep_directory(
+        self, directory: Path, *, max_age_seconds: int, kind: str
+    ) -> int:
+        """Unlink `*.tar.gz` files older than `max_age_seconds` in `directory`.
+
+        Returns the number of files actually deleted. Missing
+        directories are a no-op (the directory is lazily created by
+        the atomic-rename failure path, so absence simply means no
+        artifacts have accumulated yet).
+        """
+        if not directory.exists():
+            return 0
+        try:
+            entries = list(directory.glob("*.tar.gz"))
+        except OSError as e:
+            logger.warning(f"Failed to enumerate {kind} sweep directory {directory}: {e}")
+            return 0
+
+        deleted = 0
+        now = time.time()
+        cutoff = now - max_age_seconds
+        for path in entries:
+            try:
+                mtime = path.stat().st_mtime
+            except OSError as e:
+                logger.warning(f"Failed to stat {kind} artifact {path}: {e}")
+                continue
+            if mtime >= cutoff:
+                # Within retention window — skip (query-then-skip
+                # idempotency).
+                continue
+            try:
+                path.unlink()
+                deleted += 1
+                age_hours = (now - mtime) / 3600
+                logger.info(
+                    "Swept stale %s backup artifact %s (age=%.1fh)",
+                    kind,
+                    path,
+                    age_hours,
+                )
+            except OSError as e:
+                # Per-file failure (permission, ENOENT race, …): warn
+                # and continue — do not let one bad file block the
+                # rest of the sweep.
+                logger.warning(f"Failed to unlink stale {kind} artifact {path}: {e}")
+        return deleted
 
     # ===================
     # Properties
@@ -407,6 +554,11 @@ class _SchedulerProxy:
 
     def clear_cache(self) -> None:
         backup_scheduler_instance.get().clear_cache()
+
+    # ---- Housekeeping ----
+
+    def sweep_stale_pending_and_failed(self) -> Any:
+        return backup_scheduler_instance.get().sweep_stale_pending_and_failed()
 
     # ---- Properties ----
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -33,6 +33,14 @@ class Settings(BaseSettings):
     DATABASE_RETRY_BACKOFF: float = 0.1
     DATABASE_BATCH_SIZE: int = 100
 
+    # Backup directory housekeeping (Issue #284)
+    # Periodic sweep of `backups_directory/.pending/` and `.failed/`
+    # artifacts left behind by atomic-rename failure paths (#228 PR 2e).
+    BACKUPS_PENDING_RETENTION_HOURS: int = 24
+    BACKUPS_FAILED_RETENTION_DAYS: int = 30
+    # Interval (seconds) between sweep runs in the scheduler loop.
+    BACKUPS_CLEANUP_INTERVAL_SECONDS: int = 3600
+
     # CORS configuration
     CORS_ORIGINS: str = (
         "http://localhost:3000,http://127.0.0.1:3000,https://127.0.0.1:3000"
@@ -104,6 +112,36 @@ class Settings(BaseSettings):
         """Validate DATABASE_BATCH_SIZE is within reasonable limits"""
         if v < 10 or v > 1000:
             raise ValueError("DATABASE_BATCH_SIZE must be between 10 and 1000")
+        return v
+
+    @field_validator("BACKUPS_PENDING_RETENTION_HOURS")
+    @classmethod
+    def validate_pending_retention(cls, v: int) -> int:
+        """Validate BACKUPS_PENDING_RETENTION_HOURS is within sane bounds."""
+        if v < 1 or v > 24 * 365:
+            raise ValueError(
+                "BACKUPS_PENDING_RETENTION_HOURS must be between 1 and 8760 hours"
+            )
+        return v
+
+    @field_validator("BACKUPS_FAILED_RETENTION_DAYS")
+    @classmethod
+    def validate_failed_retention(cls, v: int) -> int:
+        """Validate BACKUPS_FAILED_RETENTION_DAYS is within sane bounds."""
+        if v < 1 or v > 3650:
+            raise ValueError(
+                "BACKUPS_FAILED_RETENTION_DAYS must be between 1 and 3650 days"
+            )
+        return v
+
+    @field_validator("BACKUPS_CLEANUP_INTERVAL_SECONDS")
+    @classmethod
+    def validate_cleanup_interval(cls, v: int) -> int:
+        """Validate BACKUPS_CLEANUP_INTERVAL_SECONDS is within sane bounds."""
+        if v < 60 or v > 86400:
+            raise ValueError(
+                "BACKUPS_CLEANUP_INTERVAL_SECONDS must be between 60 and 86400 seconds"
+            )
         return v
 
     @property

--- a/tests/unit/backups/test_scheduler_sweep.py
+++ b/tests/unit/backups/test_scheduler_sweep.py
@@ -1,0 +1,212 @@
+"""Unit tests for `BackupSchedulerService.sweep_stale_pending_and_failed`.
+
+Covers the Issue #284 housekeeping job that deletes stale artifacts
+left behind by atomic-rename failure paths in `BackupService` (#228
+PR 2e). Test strategy: create real files in a `tmp_path`-backed
+`backups_directory`, manipulate their mtime to simulate age, run the
+sweep, assert idempotency + retention boundaries + failure tolerance.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from app.backups.application.scheduler import BackupSchedulerService
+from tests.unit.backups.fakes import FakeBackupsUnitOfWork, FakeServerReadPort
+
+FROZEN_NOW = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_scheduler(
+    backups_directory: Path,
+    *,
+    pending_retention_hours: int = 24,
+    failed_retention_days: int = 30,
+    cleanup_interval_seconds: int = 3600,
+) -> BackupSchedulerService:
+    return BackupSchedulerService(
+        uow_factory=lambda: FakeBackupsUnitOfWork(),
+        server_read_factory=lambda: FakeServerReadPort(),
+        clock=lambda: FROZEN_NOW,
+        backups_directory=backups_directory,
+        pending_retention_hours=pending_retention_hours,
+        failed_retention_days=failed_retention_days,
+        cleanup_interval_seconds=cleanup_interval_seconds,
+    )
+
+
+def _write_with_age(path: Path, *, age_seconds: float) -> None:
+    """Create `path` with content and set its mtime to `now - age_seconds`."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x")
+    mtime = path.stat().st_mtime - age_seconds
+    os.utime(path, (mtime, mtime))
+
+
+class TestSweepPending:
+    def test_no_pending_dir_is_noop(self, tmp_path):
+        scheduler = _make_scheduler(tmp_path)
+        result = scheduler.sweep_stale_pending_and_failed()
+        assert result == {"pending_deleted": 0, "failed_deleted": 0}
+
+    def test_deletes_pending_older_than_retention(self, tmp_path):
+        scheduler = _make_scheduler(tmp_path, pending_retention_hours=24)
+        stale = tmp_path / ".pending" / ".pending-stale.tar.gz"
+        _write_with_age(stale, age_seconds=25 * 3600)
+
+        result = scheduler.sweep_stale_pending_and_failed()
+        assert result["pending_deleted"] == 1
+        assert not stale.exists()
+
+    def test_skips_pending_within_retention(self, tmp_path):
+        scheduler = _make_scheduler(tmp_path, pending_retention_hours=24)
+        fresh = tmp_path / ".pending" / ".pending-fresh.tar.gz"
+        _write_with_age(fresh, age_seconds=1 * 3600)
+
+        result = scheduler.sweep_stale_pending_and_failed()
+        assert result["pending_deleted"] == 0
+        assert fresh.exists()
+
+    def test_ignores_non_tar_gz_files(self, tmp_path):
+        scheduler = _make_scheduler(tmp_path, pending_retention_hours=24)
+        weird = tmp_path / ".pending" / "stray.log"
+        _write_with_age(weird, age_seconds=30 * 24 * 3600)
+
+        result = scheduler.sweep_stale_pending_and_failed()
+        assert result["pending_deleted"] == 0
+        assert weird.exists()
+
+    def test_idempotent_second_run_is_noop(self, tmp_path):
+        scheduler = _make_scheduler(tmp_path, pending_retention_hours=24)
+        stale = tmp_path / ".pending" / ".pending-stale.tar.gz"
+        _write_with_age(stale, age_seconds=25 * 3600)
+        scheduler.sweep_stale_pending_and_failed()
+        # Second run with no remaining stale files.
+        result = scheduler.sweep_stale_pending_and_failed()
+        assert result == {"pending_deleted": 0, "failed_deleted": 0}
+
+
+class TestSweepFailed:
+    def test_deletes_failed_older_than_retention(self, tmp_path):
+        scheduler = _make_scheduler(tmp_path, failed_retention_days=30)
+        stale = tmp_path / ".failed" / "lost-uuid.tar.gz"
+        _write_with_age(stale, age_seconds=31 * 24 * 3600)
+
+        result = scheduler.sweep_stale_pending_and_failed()
+        assert result["failed_deleted"] == 1
+        assert not stale.exists()
+
+    def test_skips_failed_within_retention(self, tmp_path):
+        scheduler = _make_scheduler(tmp_path, failed_retention_days=30)
+        fresh = tmp_path / ".failed" / "recent.tar.gz"
+        _write_with_age(fresh, age_seconds=10 * 24 * 3600)
+
+        result = scheduler.sweep_stale_pending_and_failed()
+        assert result["failed_deleted"] == 0
+        assert fresh.exists()
+
+
+class TestSweepRobustness:
+    def test_mixed_pending_and_failed(self, tmp_path):
+        scheduler = _make_scheduler(
+            tmp_path, pending_retention_hours=24, failed_retention_days=30
+        )
+        # stale pending + fresh pending
+        _write_with_age(tmp_path / ".pending" / "a.tar.gz", age_seconds=48 * 3600)
+        _write_with_age(tmp_path / ".pending" / "b.tar.gz", age_seconds=2 * 3600)
+        # stale failed + fresh failed
+        _write_with_age(tmp_path / ".failed" / "c.tar.gz", age_seconds=40 * 24 * 3600)
+        _write_with_age(tmp_path / ".failed" / "d.tar.gz", age_seconds=5 * 24 * 3600)
+
+        result = scheduler.sweep_stale_pending_and_failed()
+        assert result == {"pending_deleted": 1, "failed_deleted": 1}
+        assert (tmp_path / ".pending" / "b.tar.gz").exists()
+        assert (tmp_path / ".failed" / "d.tar.gz").exists()
+
+    def test_per_file_failure_does_not_abort_sweep(self, tmp_path, monkeypatch):
+        """If `unlink` fails for one file, others should still be processed."""
+        scheduler = _make_scheduler(tmp_path, pending_retention_hours=24)
+        first = tmp_path / ".pending" / "a.tar.gz"
+        second = tmp_path / ".pending" / "b.tar.gz"
+        _write_with_age(first, age_seconds=48 * 3600)
+        _write_with_age(second, age_seconds=48 * 3600)
+
+        real_unlink = Path.unlink
+
+        def _flaky_unlink(self, *args, **kwargs):
+            if self.name == "a.tar.gz":
+                raise PermissionError("denied")
+            return real_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", _flaky_unlink)
+        result = scheduler.sweep_stale_pending_and_failed()
+        # one succeeded, one failed — the sweep continues.
+        assert result["pending_deleted"] == 1
+        assert first.exists()  # unlink failed
+        assert not second.exists()  # unlink succeeded
+
+    def test_retention_uses_settings_defaults(self, tmp_path, monkeypatch):
+        """When constructor args are omitted, settings supply defaults."""
+        from app.core import config as config_module
+
+        monkeypatch.setattr(config_module.settings, "BACKUPS_PENDING_RETENTION_HOURS", 1)
+        monkeypatch.setattr(config_module.settings, "BACKUPS_FAILED_RETENTION_DAYS", 1)
+        scheduler = BackupSchedulerService(
+            uow_factory=lambda: FakeBackupsUnitOfWork(),
+            server_read_factory=lambda: FakeServerReadPort(),
+            clock=lambda: FROZEN_NOW,
+            backups_directory=tmp_path,
+        )
+        _write_with_age(tmp_path / ".pending" / "a.tar.gz", age_seconds=2 * 3600)
+        _write_with_age(tmp_path / ".failed" / "b.tar.gz", age_seconds=2 * 24 * 3600)
+        result = scheduler.sweep_stale_pending_and_failed()
+        assert result == {"pending_deleted": 1, "failed_deleted": 1}
+
+
+class TestConfigValidators:
+    """Issue #284 env-var validators in `Settings`."""
+
+    def test_pending_retention_validator_rejects_zero(self):
+        from app.core.config import Settings
+
+        with pytest.raises(ValueError, match="BACKUPS_PENDING_RETENTION_HOURS"):
+            Settings(
+                SECRET_KEY="a" * 32,
+                DATABASE_URL="sqlite:///./x.db",
+                BACKUPS_PENDING_RETENTION_HOURS=0,
+            )
+
+    def test_failed_retention_validator_rejects_too_large(self):
+        from app.core.config import Settings
+
+        with pytest.raises(ValueError, match="BACKUPS_FAILED_RETENTION_DAYS"):
+            Settings(
+                SECRET_KEY="a" * 32,
+                DATABASE_URL="sqlite:///./x.db",
+                BACKUPS_FAILED_RETENTION_DAYS=100000,
+            )
+
+    def test_cleanup_interval_validator_rejects_too_small(self):
+        from app.core.config import Settings
+
+        with pytest.raises(ValueError, match="BACKUPS_CLEANUP_INTERVAL_SECONDS"):
+            Settings(
+                SECRET_KEY="a" * 32,
+                DATABASE_URL="sqlite:///./x.db",
+                BACKUPS_CLEANUP_INTERVAL_SECONDS=5,
+            )
+
+    def test_validators_accept_defaults(self):
+        from app.core.config import Settings
+
+        s = Settings(
+            SECRET_KEY="a" * 32,
+            DATABASE_URL="sqlite:///./x.db",
+        )
+        assert s.BACKUPS_PENDING_RETENTION_HOURS == 24
+        assert s.BACKUPS_FAILED_RETENTION_DAYS == 30
+        assert s.BACKUPS_CLEANUP_INTERVAL_SECONDS == 3600


### PR DESCRIPTION
## Summary

PR #283 (#228 PR 2e) introduced the atomic-rename pattern for `BackupService`, creating two operational directories under `backups_directory/`:

- `.pending/` — temp `*.tar.gz` files written before `os.replace()` to the canonical name. A tar-write interrupted by OOM kill / process SIGKILL / power loss leaves an orphan here (no DB row points at it).
- `.failed/` — post-commit recovery files. When `os.replace()` raises `EXDEV` / `ENOSPC` / `EACCES` / `EROFS` after the DB row already references `final_path`, the temp file is moved here so an operator can recover it. The user-data preservation contract forbids unlinking these eagerly.

Both leak paths are tightly bounded by the B-1 / B-2 fixes, but neither is zero. This PR adds a periodic housekeeping sweep so artifacts cannot accumulate indefinitely.

## What changed

- **`BackupSchedulerService`** gains a `_cleanup_loop` task started alongside `_scheduler_loop`. A one-shot sweep also runs at startup, catching any artifacts left by the previous process before the first periodic tick.
- **`sweep_stale_pending_and_failed()`** enumerates `*.tar.gz` files in each directory, compares `mtime` against the retention cutoff, and unlinks only those older than the cutoff. Properties:
  - **Idempotent**: query-then-skip — repeated runs are no-ops once nothing is stale.
  - **Failure-tolerant**: per-file `OSError` (permission, ENOENT race) is logged at WARNING and the sweep continues.
  - **No-op on missing dirs**: the directories are lazily created by the atomic-rename failure path, so absence is normal.
  - **Glob-scoped to `*.tar.gz`**: never touches anything outside the expected artifact pattern.
- **Three new `Settings` fields** with bounds validators:
  | name | default | validator range |
  |---|---|---|
  | `BACKUPS_PENDING_RETENTION_HOURS` | 24 | 1 – 8760 |
  | `BACKUPS_FAILED_RETENTION_DAYS` | 30 | 1 – 3650 |
  | `BACKUPS_CLEANUP_INTERVAL_SECONDS` | 3600 | 60 – 86400 |
- **`make_backup_scheduler()`** now accepts `backups_directory`; the legacy `_SchedulerProxy` exposes `sweep_stale_pending_and_failed` for parity.
- **`.env.example`** documents the new variables.

## Idempotency

Each sweep run only acts on files whose `mtime` is older than the cutoff. A missed tick is harmless — the next run catches up. Two consecutive runs with no new artifacts produce zero deletions (covered by `test_idempotent_second_run_is_noop`).

## Test plan

- [x] `pytest tests/unit/backups/test_scheduler_sweep.py` — 14 cases, all pass (no-op, retention boundary, mixed sweep, idempotency, per-file failure, settings defaults, validator rejects).
- [x] `pytest tests/unit -m "not slow"` — 1122 passed, 5 skipped (pre-existing).
- [x] `pytest tests/integration -m "not slow"` — 432 passed, 5 skipped (pre-existing).
- [x] `ruff check` + `ruff format` clean on all touched files.
- [x] `pre-commit run --files <touched>` — all hooks pass (ruff, ruff-format, pytest unit smoke, mypy relaxed).

## Out of scope (per issue note)

- Metrics export for `.failed/` count (issue marks this as recommended-not-required; can be added in a follow-up).

Resolves #284

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>