### PR TITLE
test: restore coverage for authorization + visibility services (Resolves #293)

### DIFF
--- a/tests/unit/core/visibility/test_service_coverage.py
+++ b/tests/unit/core/visibility/test_service_coverage.py
@@ -1,0 +1,328 @@
+"""Coverage gap-filler for `VisibilityService`.
+
+`test_service_with_fake.py` already pins the access-check / mutation /
+filter happy paths. This module focuses on the branches the existing
+suite left uncovered after #271/#287 deletion:
+
+- `_check_visibility_access`: unknown visibility type fallthrough
+- `_check_role_based_access`: empty `role_restriction` (grant-all)
+- `get_resource_visibility_info`: present / absent + SPECIFIC_USERS
+  payload-shape lane
+- `migrate_existing_resources_to_public`: idempotent + zero-noise
+  lanes
+- `_validate_role_configuration`: every illegal combination
+  enumerated by the implementation
+
+All tests are fake-based and deterministic; no production code is
+modified.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.core.visibility.application.service import VisibilityService
+from app.core.visibility.models import ResourceType, VisibilityType
+from app.users.domain.value_objects import Role
+from tests.unit.core.visibility.fakes import (
+    FakeVisibilityRepository,
+    FakeVisibilityUnitOfWork,
+)
+
+
+def _user(user_id: int = 1, role: Role = Role.user) -> Any:
+    return SimpleNamespace(id=user_id, role=role)
+
+
+def _make_service(repo: FakeVisibilityRepository | None = None):
+    uow = FakeVisibilityUnitOfWork(repository=repo)
+    return VisibilityService(uow=uow), uow
+
+
+# ---------------------------------------------------------------------------
+# `_check_visibility_access` fallthrough — unknown visibility type
+# ---------------------------------------------------------------------------
+
+
+class TestCheckVisibilityAccessFallthrough:
+    @pytest.mark.asyncio
+    async def test_unknown_visibility_type_denies_access(self):
+        """Defensive branch: an entity stored with an unrecognised
+        `visibility_type` must not silently grant access."""
+        repo = FakeVisibilityRepository()
+        service, _ = _make_service(repo)
+        await service.set_resource_visibility(
+            ResourceType.SERVER, 1, VisibilityType.PUBLIC
+        )
+        # Bypass the public API to mutate visibility_type into a
+        # non-enum sentinel that exercises the fallthrough.
+        stored = await repo.get(ResourceType.SERVER, 1)
+        assert stored is not None
+        repo._rows[(ResourceType.SERVER, 1)] = replace(  # noqa: SLF001
+            stored,
+            visibility_type="UNKNOWN_LANE",  # type: ignore[arg-type]
+        )
+
+        granted = await service.check_resource_access(
+            _user(user_id=2, role=Role.user), ResourceType.SERVER, 1
+        )
+        assert granted is False
+
+
+# ---------------------------------------------------------------------------
+# `_check_role_based_access` — empty role_restriction grants everyone.
+# ---------------------------------------------------------------------------
+
+
+class TestRoleBasedFallback:
+    @pytest.mark.asyncio
+    async def test_role_based_without_restriction_allows_all_roles(self):
+        """ROLE_BASED with role_restriction=None logs a warning and
+        defaults to grant-all (legacy contract)."""
+        repo = FakeVisibilityRepository()
+        service, _ = _make_service(repo)
+        # `set_resource_visibility` permits ROLE_BASED+None and emits a
+        # warning; access checks below should accept every role.
+        await service.set_resource_visibility(
+            ResourceType.SERVER, 1, VisibilityType.ROLE_BASED, role_restriction=None
+        )
+        for role in (Role.user, Role.operator, Role.admin):
+            assert await service.check_resource_access(
+                _user(user_id=2, role=role), ResourceType.SERVER, 1
+            )
+
+
+# ---------------------------------------------------------------------------
+# `get_resource_visibility_info`
+# ---------------------------------------------------------------------------
+
+
+class TestGetResourceVisibilityInfo:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_row(self):
+        service, _ = _make_service()
+        assert await service.get_resource_visibility_info(ResourceType.SERVER, 1) is None
+
+    @pytest.mark.asyncio
+    async def test_returns_shape_for_role_based_visibility(self):
+        repo = FakeVisibilityRepository()
+        service, _ = _make_service(repo)
+        await service.set_resource_visibility(
+            ResourceType.SERVER,
+            1,
+            VisibilityType.ROLE_BASED,
+            role_restriction=Role.operator,
+        )
+        info = await service.get_resource_visibility_info(ResourceType.SERVER, 1)
+        assert info is not None
+        assert info["visibility_type"] == VisibilityType.ROLE_BASED.value
+        assert info["role_restriction"] == Role.operator.value
+        assert "created_at" in info
+        assert "updated_at" in info
+        # ROLE_BASED entries must NOT carry a `granted_users` payload.
+        assert "granted_users" not in info
+
+    @pytest.mark.asyncio
+    async def test_includes_granted_users_for_specific_users_type(self):
+        repo = FakeVisibilityRepository()
+        service, _ = _make_service(repo)
+        await service.set_resource_visibility(
+            ResourceType.SERVER, 1, VisibilityType.SPECIFIC_USERS
+        )
+        await service.grant_user_access(
+            ResourceType.SERVER, 1, user_id=42, granted_by_user_id=7
+        )
+        info = await service.get_resource_visibility_info(ResourceType.SERVER, 1)
+        assert info is not None
+        assert info["visibility_type"] == VisibilityType.SPECIFIC_USERS.value
+        # `role_restriction` is null for non-ROLE_BASED entries.
+        assert info["role_restriction"] is None
+        assert info["granted_users"] == [
+            {
+                "user_id": 42,
+                "granted_by_user_id": 7,
+                "granted_at": info["granted_users"][0]["granted_at"],
+            }
+        ]
+
+
+# ---------------------------------------------------------------------------
+# `migrate_existing_resources_to_public`
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateExistingResourcesToPublic:
+    @pytest.mark.asyncio
+    async def test_migrates_missing_resources_only(self):
+        repo = FakeVisibilityRepository()
+        service, uow = _make_service(repo)
+        # Resource 2 already has a visibility row; should NOT be touched.
+        await service.set_resource_visibility(
+            ResourceType.SERVER, 2, VisibilityType.PRIVATE
+        )
+        commit_before = uow.commit_count
+        migrated = await service.migrate_existing_resources_to_public(
+            ResourceType.SERVER, [1, 2, 3]
+        )
+        assert migrated == 2
+        # The migration emits a single commit when there is work to do.
+        assert uow.commit_count == commit_before + 1
+        # Resource 2's visibility was preserved (not overwritten).
+        existing = await repo.get(ResourceType.SERVER, 2)
+        assert existing is not None
+        assert existing.visibility_type == VisibilityType.PRIVATE
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_and_skips_commit_when_nothing_to_migrate(self):
+        repo = FakeVisibilityRepository()
+        service, uow = _make_service(repo)
+        # Every resource already configured.
+        await service.set_resource_visibility(
+            ResourceType.SERVER, 1, VisibilityType.PUBLIC
+        )
+        commit_before = uow.commit_count
+        migrated = await service.migrate_existing_resources_to_public(
+            ResourceType.SERVER, [1]
+        )
+        assert migrated == 0
+        # No-op migration must not emit a commit.
+        assert uow.commit_count == commit_before
+
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_zero(self):
+        service, uow = _make_service()
+        commit_before = uow.commit_count
+        assert (
+            await service.migrate_existing_resources_to_public(ResourceType.SERVER, [])
+            == 0
+        )
+        assert uow.commit_count == commit_before
+
+
+# ---------------------------------------------------------------------------
+# `_validate_role_configuration` — every illegal combination.
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRoleConfiguration:
+    @pytest.mark.asyncio
+    async def test_role_based_with_invalid_role_raises(self):
+        service, _ = _make_service()
+
+        # Pass a hashable duck-typed value that is NOT in the
+        # `role_hierarchy` dict — exercises the explicit validation
+        # path. (Real production never reaches this branch because
+        # FastAPI rejects the request at parse-time, but the legacy
+        # `ValueError` contract is asserted here for parity.)
+        class _BogusRole:
+            value = "ghost"
+
+            def __hash__(self) -> int:  # pragma: no cover (delegated)
+                return id(self)
+
+        bogus = _BogusRole()
+        with pytest.raises(ValueError, match="Invalid role restriction"):
+            await service.set_resource_visibility(
+                ResourceType.SERVER,
+                1,
+                VisibilityType.ROLE_BASED,
+                role_restriction=bogus,  # type: ignore[arg-type]
+            )
+
+    @pytest.mark.asyncio
+    async def test_role_based_with_valid_role_succeeds(self):
+        """Positive control: every real `Role` is accepted for ROLE_BASED."""
+        repo = FakeVisibilityRepository()
+        service, _ = _make_service(repo)
+        for role in (Role.user, Role.operator, Role.admin):
+            entity = await service.set_resource_visibility(
+                ResourceType.SERVER,
+                role.value.__hash__(),  # unique resource id per loop
+                VisibilityType.ROLE_BASED,
+                role_restriction=role,
+            )
+            assert entity.role_restriction == role
+
+    @pytest.mark.asyncio
+    async def test_private_rejects_role_restriction(self):
+        service, _ = _make_service()
+        with pytest.raises(
+            ValueError, match="PRIVATE visibility cannot have role restrictions"
+        ):
+            await service.set_resource_visibility(
+                ResourceType.SERVER,
+                1,
+                VisibilityType.PRIVATE,
+                role_restriction=Role.operator,
+            )
+
+    @pytest.mark.asyncio
+    async def test_public_rejects_role_restriction(self):
+        service, _ = _make_service()
+        with pytest.raises(
+            ValueError, match="PUBLIC visibility cannot have role restrictions"
+        ):
+            await service.set_resource_visibility(
+                ResourceType.SERVER,
+                1,
+                VisibilityType.PUBLIC,
+                role_restriction=Role.admin,
+            )
+
+    @pytest.mark.asyncio
+    async def test_specific_users_rejects_role_restriction(self):
+        service, _ = _make_service()
+        with pytest.raises(
+            ValueError,
+            match="SPECIFIC_USERS visibility cannot have role restrictions",
+        ):
+            await service.set_resource_visibility(
+                ResourceType.SERVER,
+                1,
+                VisibilityType.SPECIFIC_USERS,
+                role_restriction=Role.user,
+            )
+
+    @pytest.mark.asyncio
+    async def test_defensive_unknown_visibility_type_with_role_restriction(self):
+        """The final ``raise ValueError`` after the four explicit lanes
+        is unreachable in production (every `VisibilityType` enum value
+        has an explicit branch). Pin it anyway by passing a sentinel
+        that exposes the same `.value` duck-typing the message uses."""
+        service, _ = _make_service()
+
+        class _UnknownVisibility:
+            value = "unknown"
+
+        with pytest.raises(
+            ValueError,
+            match="role_restriction can only be used with ROLE_BASED visibility",
+        ):
+            await service.set_resource_visibility(
+                ResourceType.SERVER,
+                1,
+                _UnknownVisibility(),  # type: ignore[arg-type]
+                role_restriction=Role.user,
+            )
+
+    @pytest.mark.asyncio
+    async def test_no_role_restriction_passes_for_non_role_based(self):
+        """Sanity: every non-ROLE_BASED type without restriction is OK."""
+        repo = FakeVisibilityRepository()
+        service, _ = _make_service(repo)
+        for i, vtype in enumerate(
+            (
+                VisibilityType.PUBLIC,
+                VisibilityType.PRIVATE,
+                VisibilityType.SPECIFIC_USERS,
+            ),
+            start=1,
+        ):
+            entity = await service.set_resource_visibility(
+                ResourceType.SERVER, i, vtype, role_restriction=None
+            )
+            assert entity.visibility_type == vtype

--- a/tests/unit/servers/application/test_authorization_coverage.py
+++ b/tests/unit/servers/application/test_authorization_coverage.py
@@ -1,0 +1,336 @@
+"""Coverage for `app.servers.application.authorization.AuthorizationService`.
+
+PR #290 (#228 PR 3) removed the legacy
+`tests/unit/services/test_authorization_service*.py` files (they were
+``pytest.mark.skip``-only and contributed 0% coverage). This module
+re-pins the public surface of the post-#273/#292 application service
+through the existing fake Repositories so the error branches and the
+``@staticmethod`` boolean helpers regain coverage.
+
+Tests are fake-based and deterministic; no production code is touched.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from app.backups.domain.exceptions import (
+    BackupNotFoundError,
+    BackupParentServerMissingError,
+)
+from app.backups.models import Backup, BackupStatus, BackupType
+from app.servers.application.authorization import AuthorizationService
+from app.servers.domain.exceptions import ServerNotFoundError
+from app.servers.models import Server, ServerStatus, ServerType
+from app.users.domain.value_objects import Role
+from tests.unit.backups.fakes import FakeBackupRepository, make_backup_entity
+from tests.unit.servers.fakes import FakeServerRepository, make_server_entity
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _user(user_id: int = 1, role: Role = Role.user) -> Any:
+    """Duck-typed `User` — the service only reads `.id` and `.role`."""
+    return SimpleNamespace(id=user_id, role=role)
+
+
+def _make_service(
+    server_repo: FakeServerRepository | None = None,
+    backup_repo: FakeBackupRepository | None = None,
+) -> AuthorizationService:
+    return AuthorizationService(
+        server_repo=server_repo or FakeServerRepository(),
+        backup_repo=backup_repo or FakeBackupRepository(),
+        # `TemplateRepository` is wired for parity (#228) but not used by
+        # any path under test; a bare object is enough.
+        template_repo=object(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# check_server_access
+# ---------------------------------------------------------------------------
+
+
+class TestCheckServerAccess:
+    @pytest.mark.asyncio
+    async def test_returns_entity_when_present(self):
+        repo = FakeServerRepository()
+        entity = repo.seed(make_server_entity(id=10, owner_id=7))
+        svc = _make_service(server_repo=repo)
+        result = await svc.check_server_access(10, _user(user_id=99, role=Role.user))
+        assert result.id == entity.id
+
+    @pytest.mark.asyncio
+    async def test_includes_soft_deleted_rows(self):
+        """`include_deleted=True` is the documented behaviour (legacy parity).
+
+        The backup-restore path depends on soft-deleted servers staying
+        resolvable through this helper.
+        """
+        repo = FakeServerRepository()
+        repo.seed(make_server_entity(id=11, owner_id=1, is_deleted=True))
+        svc = _make_service(server_repo=repo)
+        result = await svc.check_server_access(11, _user(role=Role.admin))
+        assert result.id == 11
+        assert result.is_deleted is True
+
+    @pytest.mark.asyncio
+    async def test_raises_server_not_found_when_missing(self):
+        svc = _make_service()
+        with pytest.raises(ServerNotFoundError):
+            await svc.check_server_access(404, _user())
+
+
+# ---------------------------------------------------------------------------
+# check_backup_access
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBackupAccess:
+    @pytest.mark.asyncio
+    async def test_returns_entity_when_backup_and_server_present(self):
+        server_repo = FakeServerRepository()
+        server_repo.seed(make_server_entity(id=5, owner_id=2))
+        backup_repo = FakeBackupRepository()
+        # `FakeBackupRepository.add` allocates ids, but we need a
+        # specific id; insert directly.
+        entity = make_backup_entity(id=77, server_id=5, server_owner_id=2)
+        backup_repo._records[77] = entity  # noqa: SLF001 (test-only seed)
+        backup_repo._next_id = 78  # noqa: SLF001
+        svc = _make_service(server_repo=server_repo, backup_repo=backup_repo)
+        result = await svc.check_backup_access(77, _user(user_id=2))
+        assert result.id == 77
+
+    @pytest.mark.asyncio
+    async def test_raises_backup_not_found(self):
+        svc = _make_service()
+        with pytest.raises(BackupNotFoundError):
+            await svc.check_backup_access(999, _user())
+
+    @pytest.mark.asyncio
+    async def test_raises_parent_server_missing(self):
+        """Backup row resolves but the server fk is dangling."""
+        backup_repo = FakeBackupRepository()
+        backup_repo._records[1] = make_backup_entity(  # noqa: SLF001
+            id=1, server_id=42
+        )
+        backup_repo._next_id = 2  # noqa: SLF001
+        # ``server_repo`` is empty, so the parent lookup returns None.
+        svc = _make_service(backup_repo=backup_repo)
+        with pytest.raises(BackupParentServerMissingError):
+            await svc.check_backup_access(1, _user())
+
+
+# ---------------------------------------------------------------------------
+# Sync boolean helpers — every role lane must be pinned.
+# ---------------------------------------------------------------------------
+
+
+class TestPhase1BooleanHelpers:
+    """Phase 1 helpers all allow every authenticated role.
+
+    A parametrized table would obscure that the helpers diverge from
+    ``can_schedule_backups`` (admin-only) and ``is_admin`` /
+    ``is_operator_or_admin``; the helpers are listed explicitly so the
+    intent is readable.
+    """
+
+    @pytest.mark.parametrize("role", [Role.admin, Role.operator, Role.user])
+    def test_phase1_helpers_allow_every_role(self, role: Role):
+        u = _user(role=role)
+        assert AuthorizationService.can_create_server(u)
+        assert AuthorizationService.can_modify_files(u)
+        assert AuthorizationService.can_create_backup(u)
+        assert AuthorizationService.can_restore_backup(u)
+        assert AuthorizationService.can_create_group(u)
+        assert AuthorizationService.can_create_template(u)
+
+
+class TestRestrictedRoleHelpers:
+    def test_can_schedule_backups_admin_only(self):
+        assert AuthorizationService.can_schedule_backups(_user(role=Role.admin))
+        assert not AuthorizationService.can_schedule_backups(_user(role=Role.operator))
+        assert not AuthorizationService.can_schedule_backups(_user(role=Role.user))
+
+    def test_is_admin(self):
+        assert AuthorizationService.is_admin(_user(role=Role.admin))
+        assert not AuthorizationService.is_admin(_user(role=Role.operator))
+        assert not AuthorizationService.is_admin(_user(role=Role.user))
+
+    def test_is_operator_or_admin(self):
+        assert AuthorizationService.is_operator_or_admin(_user(role=Role.admin))
+        assert AuthorizationService.is_operator_or_admin(_user(role=Role.operator))
+        assert not AuthorizationService.is_operator_or_admin(_user(role=Role.user))
+
+
+# ---------------------------------------------------------------------------
+# can_delete_server — exercises every type-dispatch branch.
+# ---------------------------------------------------------------------------
+
+
+class TestCanDeleteServer:
+    def test_admin_can_delete_any_server_entity(self):
+        entity = make_server_entity(id=1, owner_id=42)
+        admin = _user(user_id=1, role=Role.admin)
+        assert AuthorizationService.can_delete_server(entity, admin)
+
+    def test_owner_can_delete_own_server_entity(self):
+        entity = make_server_entity(id=1, owner_id=7)
+        owner = _user(user_id=7, role=Role.user)
+        assert AuthorizationService.can_delete_server(entity, owner)
+
+    def test_non_owner_non_admin_cannot_delete_server_entity(self):
+        entity = make_server_entity(id=1, owner_id=7)
+        stranger = _user(user_id=8, role=Role.user)
+        assert not AuthorizationService.can_delete_server(entity, stranger)
+
+    def test_works_with_orm_server_via_mock_spec(self):
+        """Legacy code paths pass `Mock(spec=Server)` — the helper
+        treats ``Server`` instances the same as ``ServerEntity``."""
+        orm = Mock(spec=Server)
+        orm.owner_id = 5
+        # `isinstance(orm, Server)` is True because of `spec=Server`.
+        assert AuthorizationService.can_delete_server(
+            orm, _user(user_id=5, role=Role.user)
+        )
+        assert not AuthorizationService.can_delete_server(
+            orm, _user(user_id=6, role=Role.user)
+        )
+
+    def test_defensive_path_accepts_owner_id_attribute(self):
+        """Falls back to ``getattr(server, 'owner_id', None)`` for
+        anything that is neither a `Server` nor a `ServerEntity`."""
+        bag = SimpleNamespace(owner_id=11)
+        assert AuthorizationService.can_delete_server(
+            bag, _user(user_id=11, role=Role.user)
+        )
+        assert not AuthorizationService.can_delete_server(
+            bag, _user(user_id=12, role=Role.user)
+        )
+        # Admin override works on the defensive path too.
+        assert AuthorizationService.can_delete_server(
+            bag, _user(user_id=999, role=Role.admin)
+        )
+
+
+# ---------------------------------------------------------------------------
+# can_delete_backup — same matrix on the backup side.
+# ---------------------------------------------------------------------------
+
+
+class TestCanDeleteBackup:
+    def test_admin_can_delete_any_backup(self):
+        backup = make_backup_entity(id=1, server_id=1, server_owner_id=99)
+        admin = _user(user_id=1, role=Role.admin)
+        assert AuthorizationService.can_delete_backup(backup, admin)
+
+    def test_owner_can_delete_via_server_owner_id_denormalized(self):
+        """Post-#274 ``BackupEntity`` carries ``server_owner_id``."""
+        backup = make_backup_entity(id=1, server_id=1, server_owner_id=7)
+        owner = _user(user_id=7, role=Role.user)
+        assert AuthorizationService.can_delete_backup(backup, owner)
+
+    def test_non_owner_cannot_delete_backup_entity(self):
+        backup = make_backup_entity(id=1, server_id=1, server_owner_id=7)
+        stranger = _user(user_id=8, role=Role.user)
+        assert not AuthorizationService.can_delete_backup(backup, stranger)
+
+    def test_legacy_orm_backup_reaches_through_relationship(self):
+        """Mock(spec=Backup).server.owner_id is the legacy path."""
+        orm = Mock(spec=Backup)
+        # The helper does `backup.server.owner_id`, so set up the
+        # nested attr explicitly.
+        orm.server = SimpleNamespace(owner_id=4)
+        assert AuthorizationService.can_delete_backup(
+            orm, _user(user_id=4, role=Role.user)
+        )
+        assert not AuthorizationService.can_delete_backup(
+            orm, _user(user_id=5, role=Role.user)
+        )
+
+    def test_defensive_path_uses_server_owner_id_attribute(self):
+        """For arbitrary objects, prefer denormalised ``server_owner_id``."""
+        bag = SimpleNamespace(server_owner_id=12)
+        assert AuthorizationService.can_delete_backup(
+            bag, _user(user_id=12, role=Role.user)
+        )
+        assert not AuthorizationService.can_delete_backup(
+            bag, _user(user_id=13, role=Role.user)
+        )
+
+    def test_defensive_path_falls_back_to_server_relationship(self):
+        """When ``server_owner_id`` is None, reach through ``.server``."""
+        bag = SimpleNamespace(server_owner_id=None, server=SimpleNamespace(owner_id=21))
+        assert AuthorizationService.can_delete_backup(
+            bag, _user(user_id=21, role=Role.user)
+        )
+        assert not AuthorizationService.can_delete_backup(
+            bag, _user(user_id=22, role=Role.user)
+        )
+
+    def test_defensive_path_handles_missing_server(self):
+        """No ``server_owner_id`` and no ``.server`` -> permission denied."""
+        bag = SimpleNamespace()
+        assert not AuthorizationService.can_delete_backup(
+            bag, _user(user_id=1, role=Role.user)
+        )
+
+
+# ---------------------------------------------------------------------------
+# filter_servers_for_user — the legacy misuse contract.
+# ---------------------------------------------------------------------------
+
+
+class TestFilterServersForUser:
+    def test_returns_servers_unchanged_when_db_provided(self):
+        """Phase 1: no filtering. ``db`` may be any truthy object."""
+        servers = [object(), object()]
+        result = AuthorizationService.filter_servers_for_user(
+            _user(), servers, db=object()
+        )
+        assert result is servers
+
+    def test_none_user_raises_attribute_error(self):
+        with pytest.raises(AttributeError):
+            AuthorizationService.filter_servers_for_user(None, [], db=object())
+
+    def test_none_db_raises_value_error(self):
+        """Mirrors the legacy contract: callers must pass a DB session."""
+        with pytest.raises(ValueError):
+            AuthorizationService.filter_servers_for_user(_user(), [], db=None)
+
+
+# ---------------------------------------------------------------------------
+# Defensive: ensure the FakeBackupRepository seeded backups round-trip
+# the ``server_owner_id`` field correctly. Catches accidental drift in
+# the fixture helper that would otherwise mask real coverage gaps.
+# ---------------------------------------------------------------------------
+
+
+def test_make_backup_entity_round_trips_server_owner_id():
+    backup = make_backup_entity(
+        id=1,
+        server_id=2,
+        status=BackupStatus.completed,
+        backup_type=BackupType.manual,
+        server_owner_id=5,
+    )
+    assert backup.server_owner_id == 5
+
+
+def test_make_server_entity_round_trips_owner_id_and_status():
+    srv = make_server_entity(
+        id=1,
+        owner_id=3,
+        status=ServerStatus.running,
+        server_type=ServerType.paper,
+    )
+    assert srv.owner_id == 3
+    assert srv.status == ServerStatus.running


### PR DESCRIPTION
## Summary

PR #290 (#228 PR 3) deleted ~2,184 LOC of legacy
`tests/unit/services/test_{authorization,visibility}_service*.py` — those
files were `pytest.mark.skip`-only and contributed 0% coverage, so the
deletion did not regress coverage *as measured*. However, the new
Hexagonal application services sat at:

- `app/servers/application/authorization.py`: **38.61%**
- `app/core/visibility/application/service.py`: **70.35%**

This PR adds two new fake-based test modules that re-pin every error
branch the legacy suite was meant to exercise.

## Changes

- `tests/unit/servers/application/test_authorization_coverage.py`
  - `check_server_access`: happy / soft-deleted / `ServerNotFoundError`
  - `check_backup_access`: happy / `BackupNotFoundError` /
    `BackupParentServerMissingError`
  - Phase 1 permission lattice (`can_create_*`, `can_modify_files`,
    `can_restore_backup`, …) for every role
  - Admin-only `can_schedule_backups`, plus `is_admin` /
    `is_operator_or_admin`
  - `can_delete_server` / `can_delete_backup` type-dispatch matrix:
    `ServerEntity` / `BackupEntity` lane, `Mock(spec=Server)` / legacy
    ORM `Backup.server` lane, defensive `getattr` fallback, and the
    no-server fallback
  - `filter_servers_for_user` misuse contract (`None` user / `None` db)

- `tests/unit/core/visibility/test_service_coverage.py`
  - `_check_visibility_access` fallthrough on unknown visibility type
  - `_check_role_based_access` empty-restriction grant-all
  - `get_resource_visibility_info`: none / role-based / specific-users
    payload shape
  - `migrate_existing_resources_to_public`: migrate-missing-only,
    no-op-skips-commit, empty-input
  - `_validate_role_configuration`: ROLE_BASED + invalid role, every
    illegal PRIVATE/PUBLIC/SPECIFIC_USERS + restriction combo, and the
    defensive unreachable fall-through

## Coverage

| Module | Before | After |
| --- | --- | --- |
| `app/servers/application/authorization.py` | 38.61% | **100.00%** |
| `app/core/visibility/application/service.py` | 70.35% | **100.00%** |

Both modules now sit well above the 90% target from the issue.

## Test plan

- [x] `uv run pytest tests/unit/servers/application/test_authorization_coverage.py tests/unit/core/visibility/test_service_coverage.py` → 44 passed
- [x] `uv run pytest tests/unit -m "not slow"` → 1166 passed, 5 skipped
- [x] `uv run ruff check tests/` → clean
- [x] `uv run ruff format --check tests/unit/...` → clean
- [x] `uv run pre-commit run --files <touched>` → all hooks pass

Tests are fake-based (reuse `FakeServerRepository`,
`FakeBackupRepository`, `FakeVisibilityRepository` /
`FakeVisibilityUnitOfWork`), deterministic, and complete in < 3s
combined. **No production code is modified.**

Resolves #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)