### PR TITLE
refactor: rename mock_db_session, fix update_port fake, sweep stale comments (Resolves #307)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -218,12 +218,6 @@ async def _initialize_database_integration():
             make_database_integration_service,
         )
 
-        # NB(#285): the late-bound ``server_repository_factory`` on
-        # ``minecraft_server_manager`` was removed once the
-        # ``_validate_port_availability`` path started consuming an
-        # explicit ``ServerRepository`` argument (#272). No factory
-        # wiring is required here anymore.
-
         # Build a fresh integration service inside the running loop so
         # `initialize()` captures the correct loop for its sync→async
         # bridge, then publish it on the holder so legacy importers (the

--- a/app/servers/application/minecraft_server.py
+++ b/app/servers/application/minecraft_server.py
@@ -79,12 +79,9 @@ class MinecraftServerManager:
         # Configurable log queue size to prevent memory leaks
         self.log_queue_size = log_queue_size or settings.SERVER_LOG_QUEUE_SIZE
         self.java_check_timeout = settings.JAVA_CHECK_TIMEOUT
-        # NB(#285): the pre-#272 ``server_repository_factory`` indirection
-        # (``Callable[[Session], ServerRepository]``) was deleted as part
-        # of completing the ARCHITECTURE §4.2 cleanup. The port-conflict
-        # check inside ``_validate_port_availability`` now consumes a
-        # ``ServerRepository`` passed explicitly by the caller — no
-        # framework-typed factories remain on this class.
+        # The port-conflict check inside ``_validate_port_availability``
+        # consumes a ``ServerRepository`` passed explicitly by the caller
+        # (#272, #285) — no framework-typed factories remain on this class.
 
     def set_status_update_callback(
         self,
@@ -1390,11 +1387,9 @@ class MinecraftServerManager:
             )
         try:
             # First check database for servers using the same port through
-            # the injected ``ServerRepository``. The legacy
-            # ``server_repository_factory`` indirection (which used to
-            # take a ``Session``) was removed in #285; callers now pass
-            # the already-built repository in alongside the entity,
-            # mirroring the rest of the application layer.
+            # the injected ``ServerRepository``. Callers pass the
+            # already-built repository in alongside the entity (#272,
+            # #285), mirroring the rest of the application layer.
             if server_repository is not None:
                 conflicts = await server_repository.list_by_port(
                     server.port,

--- a/tests/integration/test_daemon_lifecycle_comprehensive.py
+++ b/tests/integration/test_daemon_lifecycle_comprehensive.py
@@ -82,11 +82,11 @@ class TestDaemonLifecycleComprehensive:
         return mock
 
     @pytest.fixture
-    def mock_db_session(self):
-        """Fake ``ServerRepository`` returned under the legacy fixture name.
+    def mock_server_repo(self):
+        """Fake ``ServerRepository`` for the manager's port-conflict check.
 
-        After #272 the manager accepts a repository (not a session) as
-        ``start_server``'s second argument.
+        After #272 ``start_server`` takes a ``ServerRepository`` as its
+        second argument.
         """
         repo = Mock()
         repo.list_by_port = AsyncMock(return_value=[])
@@ -119,7 +119,7 @@ class TestDaemonLifecycleComprehensive:
 
     @pytest.mark.asyncio
     async def test_daemon_creation_complete_lifecycle(
-        self, manager, daemon_test_server, mock_db_session, mock_java_service
+        self, manager, daemon_test_server, mock_server_repo, mock_java_service
     ):
         """Test complete daemon creation lifecycle from start to finish"""
 
@@ -174,7 +174,7 @@ class TestDaemonLifecycleComprehensive:
                                             side_effect=_fake_create_task,
                                         ):
                                             result = await manager.start_server(
-                                                daemon_test_server, mock_db_session
+                                                daemon_test_server, mock_server_repo
                                             )
 
                                             # Verify successful start
@@ -188,7 +188,7 @@ class TestDaemonLifecycleComprehensive:
 
     @pytest.mark.asyncio
     async def test_daemon_creation_failure_lifecycle(
-        self, manager, daemon_test_server, mock_db_session, mock_java_service
+        self, manager, daemon_test_server, mock_server_repo, mock_java_service
     ):
         """Test daemon creation failure handling"""
 
@@ -235,7 +235,7 @@ class TestDaemonLifecycleComprehensive:
                                         return_value=None,
                                     ):
                                         result = await manager.start_server(
-                                            daemon_test_server, mock_db_session
+                                            daemon_test_server, mock_server_repo
                                         )
 
                                         # Verify failure handling
@@ -389,7 +389,7 @@ class TestDaemonLifecycleComprehensive:
 
     @pytest.mark.asyncio
     async def test_daemon_full_integration_lifecycle(
-        self, manager, daemon_test_server, mock_db_session, mock_java_service
+        self, manager, daemon_test_server, mock_server_repo, mock_java_service
     ):
         """Test complete daemon lifecycle integration"""
 
@@ -441,7 +441,7 @@ class TestDaemonLifecycleComprehensive:
                                         ):
                                             # Start server
                                             result = await manager.start_server(
-                                                daemon_test_server, mock_db_session
+                                                daemon_test_server, mock_server_repo
                                             )
                                             assert result is True
 

--- a/tests/integration/test_minecraft_server_lifecycle.py
+++ b/tests/integration/test_minecraft_server_lifecycle.py
@@ -87,32 +87,36 @@ online-mode=true
         )
 
     @pytest.fixture
-    def mock_db_session(self, lifecycle_server):
+    def mock_server_repo(self, lifecycle_server):
         """Fake ``ServerRepository`` for the manager's port-conflict check.
 
-        Kept under the legacy ``mock_db_session`` name to minimise churn
-        across this file: after #272 the manager's ``start_server`` and
-        ``_validate_port_availability`` take a ``ServerRepository`` as
-        their second argument (no more ``Session``), so we yield a fake
-        repo here directly.
+        After #272 ``start_server`` / ``_validate_port_availability``
+        take a ``ServerRepository`` as their second argument.
 
         The pre-flight sync inside ``start_server`` may call
         ``update_port`` because the lifecycle fixture writes a fixed
         ``server-port=25565`` into ``server.properties`` while the
-        entity carries a freshly-allocated random port. The mock
-        returns an updated copy of the input ORM-shaped row so the
-        manager keeps reading the same ``directory_path`` / ``max_memory``
-        / ``id`` attributes downstream.
+        entity carries a freshly-allocated random port. The fake
+        returns a real ``ServerEntity`` (matching production) rebuilt
+        from the lifecycle fixture's fields so the manager keeps
+        reading the same ``directory_path`` / ``max_memory`` / ``id``
+        attributes downstream.
         """
-        from copy import copy
+        from tests.unit.servers.fakes import make_server_entity
 
         repo = Mock()
         repo.list_by_port = AsyncMock(return_value=[])
 
         async def _update_port(server_id, port):
-            updated = copy(lifecycle_server)
-            updated.port = port
-            return updated
+            return make_server_entity(
+                id=lifecycle_server.id,
+                name=lifecycle_server.name,
+                directory_path=lifecycle_server.directory_path,
+                minecraft_version=lifecycle_server.minecraft_version,
+                server_type=lifecycle_server.server_type,
+                port=port,
+                max_memory=lifecycle_server.max_memory,
+            )
 
         repo.update_port = AsyncMock(side_effect=_update_port)
         return repo
@@ -189,7 +193,7 @@ sys.exit(0)
         self,
         manager,
         lifecycle_server,
-        mock_db_session,
+        mock_server_repo,
         mock_java_service,
         long_running_process_command,
     ):
@@ -234,7 +238,7 @@ sys.exit(0)
 
                             # Execute complete startup workflow
                             result = await manager.start_server(
-                                lifecycle_server, mock_db_session
+                                lifecycle_server, mock_server_repo
                             )
 
                             # Verify successful startup
@@ -291,7 +295,7 @@ sys.exit(0)
 
     @pytest.mark.asyncio
     async def test_server_startup_port_validation_failure_workflow(
-        self, manager, lifecycle_server, mock_db_session, mock_java_service
+        self, manager, lifecycle_server, mock_server_repo, mock_java_service
     ):
         """Test server startup with port validation failure (lines 266-274)"""
 
@@ -317,7 +321,7 @@ sys.exit(0)
                         "app.servers.application.minecraft_server.logger"
                     ) as mock_logger:
                         result = await manager.start_server(
-                            lifecycle_server, mock_db_session
+                            lifecycle_server, mock_server_repo
                         )
 
                         # Verify failure
@@ -339,7 +343,7 @@ sys.exit(0)
 
     @pytest.mark.asyncio
     async def test_server_startup_java_compatibility_failure_workflow(
-        self, manager, lifecycle_server, mock_db_session
+        self, manager, lifecycle_server, mock_server_repo
     ):
         """Test server startup with Java compatibility failure (lines 277-284)"""
 
@@ -353,7 +357,7 @@ sys.exit(0)
             mock_java_service,
         ):
             with patch("app.servers.application.minecraft_server.logger") as mock_logger:
-                result = await manager.start_server(lifecycle_server, mock_db_session)
+                result = await manager.start_server(lifecycle_server, mock_server_repo)
 
                 # Verify failure
                 assert result is False
@@ -369,7 +373,7 @@ sys.exit(0)
 
     @pytest.mark.asyncio
     async def test_server_startup_file_validation_failure_workflow(
-        self, manager, lifecycle_server, mock_db_session, mock_java_service
+        self, manager, lifecycle_server, mock_server_repo, mock_java_service
     ):
         """Test server startup with file validation failure (lines 290-298)"""
 
@@ -382,7 +386,7 @@ sys.exit(0)
             mock_java_service,
         ):
             with patch("app.servers.application.minecraft_server.logger") as mock_logger:
-                result = await manager.start_server(lifecycle_server, mock_db_session)
+                result = await manager.start_server(lifecycle_server, mock_server_repo)
 
                 # Verify failure
                 assert result is False
@@ -398,7 +402,7 @@ sys.exit(0)
 
     @pytest.mark.asyncio
     async def test_server_startup_process_creation_failure(
-        self, manager, lifecycle_server, mock_db_session, mock_java_service
+        self, manager, lifecycle_server, mock_server_repo, mock_java_service
     ):
         """Test server startup with process creation failure (lines 336-343)"""
 
@@ -411,7 +415,9 @@ sys.exit(0)
                 with patch(
                     "app.servers.application.minecraft_server.logger"
                 ) as mock_logger:
-                    result = await manager.start_server(lifecycle_server, mock_db_session)
+                    result = await manager.start_server(
+                        lifecycle_server, mock_server_repo
+                    )
 
                     # Verify failure
                     assert result is False
@@ -433,7 +439,7 @@ sys.exit(0)
 
     @pytest.mark.asyncio
     async def test_server_startup_process_immediate_exit(
-        self, manager, lifecycle_server, mock_db_session, mock_java_service
+        self, manager, lifecycle_server, mock_server_repo, mock_java_service
     ):
         """Test server startup with process immediate exit (lines 351-376)"""
 
@@ -465,7 +471,7 @@ sys.exit(0)
                         "app.servers.application.minecraft_server.logger"
                     ) as mock_logger:
                         result = await manager.start_server(
-                            lifecycle_server, mock_db_session
+                            lifecycle_server, mock_server_repo
                         )
 
                         # Should initially succeed (daemon creation succeeded)

--- a/tests/integration/test_minecraft_server_simple.py
+++ b/tests/integration/test_minecraft_server_simple.py
@@ -81,12 +81,11 @@ class TestMinecraftServerManagerSimpleIntegration:
         return MockJavaService()
 
     @pytest.fixture
-    def mock_db_session(self):
-        """Fake ``ServerRepository`` returned under the legacy fixture name.
+    def mock_server_repo(self):
+        """Fake ``ServerRepository`` for the manager's port-conflict check.
 
-        After #272 the manager accepts a repository (not a session) as
-        ``start_server`` / ``_validate_port_availability``'s second
-        argument. Keeping the fixture name to minimise churn.
+        After #272 ``start_server`` / ``_validate_port_availability``
+        take a ``ServerRepository`` as their second argument.
         """
         repo = Mock()
         repo.list_by_port = AsyncMock(return_value=[])
@@ -241,7 +240,7 @@ class TestMinecraftServerManagerSimpleIntegration:
 
     @pytest.mark.asyncio
     async def test_start_server_already_running(
-        self, manager, simple_server, mock_db_session
+        self, manager, simple_server, mock_server_repo
     ):
         """Test lines 253-255: Server already running"""
         # Add server to processes dict
@@ -257,7 +256,7 @@ class TestMinecraftServerManagerSimpleIntegration:
         manager.processes[1] = server_process
 
         with patch("app.servers.application.minecraft_server.logger") as mock_logger:
-            result = await manager.start_server(simple_server, mock_db_session)
+            result = await manager.start_server(simple_server, mock_server_repo)
 
             assert result is False
             mock_logger.warning.assert_called_with("Server 1 is already running")

--- a/tests/unit/utils/test_port_validation.py
+++ b/tests/unit/utils/test_port_validation.py
@@ -38,11 +38,9 @@ def _make_entity(*, port: int = 25565, server_id: int = 1) -> ServerEntity:
 class TestPortValidation:
     """Test cases for `_validate_port_availability` after #272.
 
-    The port-conflict lookup now goes through the explicitly-injected
-    ``ServerRepository.list_by_port(...)`` — the previous
-    ``server_repository_factory`` indirection is gone for this code
-    path. Tests construct a fake repository and pass it as the second
-    argument instead.
+    The port-conflict lookup goes through the explicitly-injected
+    ``ServerRepository.list_by_port(...)``. Tests construct a fake
+    repository and pass it as the second argument.
     """
 
     @pytest.fixture


### PR DESCRIPTION
## Summary

Follow-up to PR #309 (which removed the `server_repository_factory` plumbing per task 1 of Issue #307). This PR handles the remaining cleanup tasks:

- **Task 2 — fixture rename**: `mock_db_session` -> `mock_server_repo` across the 3 integration test files that touch `MinecraftServerManager.start_server` / `_validate_port_availability`. After #272 the fixture returns a `FakeServerRepository`, not a `Session`, so the legacy name was misleading.
- **Task 3 — `update_port` fake**: `tests/integration/test_minecraft_server_lifecycle.py` previously returned `copy(lifecycle_server)` (an ORM `Server` row); production returns a `ServerEntity`. Switched to `make_server_entity(...)` so the fake matches the production contract instead of accidentally overlapping on attribute names.
- **Task 4 — stale comment sweep**: trimmed `server_repository_factory` mentions from `app/main.py`, `app/servers/application/minecraft_server.py` (x2), and `tests/unit/utils/test_port_validation.py`. The indirection no longer exists, so the historical explanations have been condensed.

After this PR, `rg server_repository_factory app/ tests/` returns no hits, closing #307.

## Files changed

- `app/main.py` — drop stale `# NB(#285): the late-bound server_repository_factory...` comment
- `app/servers/application/minecraft_server.py` — trim two `server_repository_factory` history blocks to the actually-relevant contract
- `tests/integration/test_minecraft_server_lifecycle.py` — rename fixture + replace `update_port` fake to return a real `ServerEntity` via `make_server_entity(...)`
- `tests/integration/test_daemon_lifecycle_comprehensive.py` — rename fixture
- `tests/integration/test_minecraft_server_simple.py` — rename fixture
- `tests/unit/utils/test_port_validation.py` — tighten docstring

## Test plan

- [x] `uv run pytest tests/integration/test_minecraft_server_lifecycle.py tests/integration/test_daemon_lifecycle_comprehensive.py tests/integration/test_minecraft_server_simple.py` — 38 passed
- [x] `uv run pytest tests/unit/utils/test_port_validation.py` — 9 passed
- [x] `uv run ruff check` on touched files — clean (pre-existing E722 lints in `test_minecraft_server_lifecycle.py` are unchanged and unrelated)
- [x] `uv run ruff format` applied
- [x] `rg server_repository_factory app/ tests/` returns no hits
- [ ] CI confirms full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>