### PR TITLE
fix: restore granted=False permission_check_denied audit event (Resolves #302)

### DIFF
--- a/app/servers/routers/control.py
+++ b/app/servers/routers/control.py
@@ -54,8 +54,22 @@ async def start_server(
     in 'stopped' or 'error' state to be started.
     """
     try:
-        # Check ownership/admin access
-        server_entity = await auth.check_server_access(server_id, current_user)
+        # Check ownership/admin access. Wrap so we can re-emit the
+        # ``permission_check_denied`` audit event lost by PR #301 when
+        # the application layer stopped depending on FastAPI (#302).
+        try:
+            server_entity = await auth.check_server_access(server_id, current_user)
+        except ServerNotFoundError:
+            AuditService.log_permission_check(
+                request=request,
+                resource_type="server",
+                resource_id=server_id,
+                permission="access",
+                granted=False,
+                user_id=current_user.id,
+                details={"reason": "server_not_found"},
+            )
+            raise
 
         # Re-emit the permission-check audit event that previously lived
         # inside ``AuthorizationService.check_server_access``; the
@@ -466,8 +480,22 @@ async def send_server_command(
     Some dangerous commands are blocked for safety.
     """
     try:
-        # Check ownership/admin access
-        server = await auth.check_server_access(server_id, current_user)
+        # Check ownership/admin access. Wrap so we can re-emit the
+        # ``permission_check_denied`` audit event lost by PR #301 when
+        # the application layer stopped depending on FastAPI (#302).
+        try:
+            server = await auth.check_server_access(server_id, current_user)
+        except ServerNotFoundError:
+            AuditService.log_permission_check(
+                request=http_request,
+                resource_type="server",
+                resource_id=server_id,
+                permission="access",
+                granted=False,
+                user_id=current_user.id,
+                details={"reason": "server_not_found"},
+            )
+            raise
 
         # Re-emit the permission-check audit event that previously lived
         # inside ``AuthorizationService.check_server_access``; the

--- a/tests/unit/servers/test_control_router.py
+++ b/tests/unit/servers/test_control_router.py
@@ -824,6 +824,80 @@ class TestServerControlRouter:
             )
         assert exc_info.value.status_code == 403
 
+    # ---------------- granted=False audit (regression #302) ----------------
+
+    @pytest.mark.asyncio
+    @patch("app.servers.routers.control.AuditService")
+    async def test_start_server_logs_permission_denied_on_missing_server(
+        self, mock_audit, mock_request, regular_user, mock_db_session
+    ):
+        """Regression for #302: ``start_server`` must emit the
+        ``permission_check_denied`` audit event before re-raising
+        ``ServerNotFoundError`` (which the global handler maps to 404).
+
+        PR #301 lifted FastAPI dependencies out of
+        ``AuthorizationService`` and the failure-side audit emit was
+        dropped along the way; the router is now responsible for it.
+        """
+        from app.servers.domain.exceptions import ServerNotFoundError
+
+        auth = AsyncMock(spec=AuthorizationService)
+        auth.check_server_access = AsyncMock(
+            side_effect=ServerNotFoundError("Server not found")
+        )
+
+        with pytest.raises(ServerNotFoundError):
+            await start_server(
+                server_id=999,
+                request=mock_request,
+                current_user=regular_user,
+                db=mock_db_session,
+                auth=auth,
+            )
+
+        mock_audit.log_permission_check.assert_called_once()
+        kwargs = mock_audit.log_permission_check.call_args.kwargs
+        assert kwargs["granted"] is False
+        assert kwargs["resource_type"] == "server"
+        assert kwargs["resource_id"] == 999
+        assert kwargs["permission"] == "access"
+        assert kwargs["user_id"] == regular_user.id
+        assert kwargs["details"] == {"reason": "server_not_found"}
+
+    @pytest.mark.asyncio
+    @patch("app.servers.routers.control.AuditService")
+    async def test_send_server_command_logs_permission_denied_on_missing_server(
+        self, mock_audit, mock_request, regular_user, mock_db_session
+    ):
+        """Regression for #302: ``send_server_command`` must also emit
+        the ``permission_check_denied`` audit event before re-raising."""
+        from app.servers.domain.exceptions import ServerNotFoundError
+
+        auth = AsyncMock(spec=AuthorizationService)
+        auth.check_server_access = AsyncMock(
+            side_effect=ServerNotFoundError("Server not found")
+        )
+
+        command_request = ServerCommandRequest(command="say hi")
+        with pytest.raises(ServerNotFoundError):
+            await send_server_command(
+                server_id=999,
+                command_request=command_request,
+                http_request=mock_request,
+                current_user=regular_user,
+                db=mock_db_session,
+                auth=auth,
+            )
+
+        mock_audit.log_permission_check.assert_called_once()
+        kwargs = mock_audit.log_permission_check.call_args.kwargs
+        assert kwargs["granted"] is False
+        assert kwargs["resource_type"] == "server"
+        assert kwargs["resource_id"] == 999
+        assert kwargs["permission"] == "access"
+        assert kwargs["user_id"] == regular_user.id
+        assert kwargs["details"] == {"reason": "server_not_found"}
+
     @pytest.mark.asyncio
     @patch("app.servers.routers.control.minecraft_server_manager")
     @patch("app.servers.routers.control.settings")


### PR DESCRIPTION
## Summary

PR #301 (Resolves #273 + #292) lifted FastAPI dependencies out of `AuthorizationService` and moved the success-side `permission_check_granted` audit emit into `app/servers/routers/control.py`. The **failure-side** event (`granted=False`, `details={"reason": "server_not_found"}`) was lost in the move — `ServerNotFoundError` now bubbles to the global handler in `app/core/error_handlers.py`, which returns 404 but does not touch the audit log.

This regresses audit/compliance: failed access attempts to nonexistent server IDs are no longer recorded, which matters for detecting probing/scanning activity.

## Why router-level wrap (issue Option 2)

- Smallest change; matches the existing router-owns-audit pattern that PR #301 introduced for the success path.
- Both production callsites (`start_server`, `send_server_command`) already accept the FastAPI `Request` for the success-side audit emit, so the wrapper has everything it needs.
- The handler-level alternative (Option 1) would need to bridge `current_user` through `request.state`; the middleware alternative (Option 3) is larger.

## Changes

- `app/servers/routers/control.py`: wrap the two `check_server_access` calls (`start_server`, `send_server_command`) in a local `try/except ServerNotFoundError`. On miss, emit `AuditService.log_permission_check(..., granted=False, details={"reason": "server_not_found"})` then re-raise so the global handler still maps the exception to 404. Field shape matches the pre-#301 emit.
- `tests/unit/servers/test_control_router.py`: add two regression tests asserting that both endpoints emit the denied audit event with the expected fields when `auth.check_server_access` raises `ServerNotFoundError`.

## Scope notes

- Only `ServerNotFoundError` is wrapped. The pre-#301 `check_backup_access` failure path never emitted an audit event (it raised 404 directly without calling `log_permission_check`), so `BackupNotFoundError` / `BackupParentServerMissingError` are out of scope here.
- `ServerAccessError` is not raised by `check_server_access` today (Phase 1 lets every authenticated user access every server), so no wrapper is needed for it.

## Test plan

- [x] `uv run ruff check app/servers/routers/control.py tests/unit/servers/test_control_router.py` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run pytest tests/unit/servers/test_control_router.py` 35 passed
- [x] New regression tests verify both endpoints emit the denied event with `granted=False`, `resource_type=server`, `permission=access`, and `details={"reason": "server_not_found"}`

Resolves #302