### PR TITLE
test: consolidate conftest fixtures into helpers (Resolves #168)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,6 @@ from unittest.mock import Mock  # noqa: E402
 
 import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
-from passlib.context import CryptContext  # noqa: E402
 from sqlalchemy import create_engine  # noqa: E402
 from sqlalchemy.orm import sessionmaker  # noqa: E402
 
@@ -32,7 +31,13 @@ from app.main import app  # noqa: E402
 from app.users.adapters.uow import SqlAlchemyUsersUnitOfWork  # noqa: E402
 from app.users.application.service import UserService  # noqa: E402
 from app.users.domain.value_objects import Role  # noqa: E402
-from app.users.models import User  # noqa: E402
+
+# Shared helpers; safe to import here because they themselves only import
+# from `app.*` (which is now configured with the worker-local DATABASE_URL).
+from tests.helpers.auth import auth_headers_for  # noqa: E402
+from tests.helpers.security import pwd_context  # noqa: E402,F401  (re-exported)
+from tests.helpers.servers import make_server  # noqa: E402
+from tests.helpers.users import make_user  # noqa: E402
 
 SQLALCHEMY_DATABASE_URL = f"sqlite:///{test_db_path}"
 
@@ -43,9 +48,6 @@ engine = create_engine(
     echo=False,
 )
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-# テスト用の軽量なパスワードハッシュ化（高速化のため）
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto", bcrypt__rounds=4)
 
 
 def override_get_db():
@@ -131,69 +133,53 @@ def client(db):
 @pytest.fixture
 def test_user(db):
     """テスト用ユーザーを作成"""
-    hashed_password = pwd_context.hash("testpassword")
-    user = User(
+    return make_user(
+        db,
         username="testuser",
         email="test@example.com",
-        hashed_password=hashed_password,
+        password="testpassword",
         role=Role.user,
         is_approved=True,
     )
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-    return user
 
 
 @pytest.fixture
 def admin_user(db):
     """テスト用管理者ユーザーを作成"""
-    hashed_password = pwd_context.hash("adminpassword")
-    user = User(
+    return make_user(
+        db,
         username="admin",
         email="admin@example.com",
-        hashed_password=hashed_password,
+        password="adminpassword",
         role=Role.admin,
         is_approved=True,
     )
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-    return user
 
 
 @pytest.fixture
 def unapproved_user(db):
     """未承認のテスト用ユーザーを作成"""
-    hashed_password = pwd_context.hash("unapprovedpassword")
-    user = User(
+    return make_user(
+        db,
         username="unapproved",
         email="unapproved@example.com",
-        hashed_password=hashed_password,
+        password="unapprovedpassword",
         role=Role.user,
         is_approved=False,
     )
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-    return user
 
 
 @pytest.fixture
 def operator_user(db):
     """テスト用オペレーターユーザーを作成"""
-    hashed_password = pwd_context.hash("operatorpassword")
-    user = User(
+    return make_user(
+        db,
         username="operator",
         email="operator@example.com",
-        hashed_password=hashed_password,
+        password="operatorpassword",
         role=Role.operator,
         is_approved=True,
     )
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-    return user
 
 
 @pytest.fixture
@@ -203,47 +189,33 @@ def user_service(db):
 
 
 @pytest.fixture
-def admin_headers(client, admin_user):
-    """管理者用認証ヘッダーを生成"""
-    login_data = {"username": admin_user.username, "password": "adminpassword"}
-    response = client.post("/api/v1/auth/token", data=login_data)
-    if response.status_code != 200:
-        print(f"Login failed: {response.status_code} - {response.text}")
-    response_data = response.json()
-    token = response_data["access_token"]
-    return {"Authorization": f"Bearer {token}"}
+def admin_headers(admin_user):
+    """管理者用認証ヘッダーを生成 (JWT 直接生成、login 経由しない)"""
+    return auth_headers_for(admin_user.username)
 
 
 @pytest.fixture
-def user_headers(client, test_user):
-    """一般ユーザー用認証ヘッダーを生成"""
-    login_data = {"username": test_user.username, "password": "testpassword"}
-    response = client.post("/api/v1/auth/token", data=login_data)
-    token = response.json()["access_token"]
-    return {"Authorization": f"Bearer {token}"}
+def user_headers(test_user):
+    """一般ユーザー用認証ヘッダーを生成 (JWT 直接生成、login 経由しない)"""
+    return auth_headers_for(test_user.username)
+
+
+@pytest.fixture
+def operator_headers(operator_user):
+    """オペレーター用認証ヘッダーを生成 (JWT 直接生成、login 経由しない)"""
+    return auth_headers_for(operator_user.username)
+
+
+@pytest.fixture
+def unapproved_headers(unapproved_user):
+    """未承認ユーザー用認証ヘッダーを生成 (JWT 直接生成、login 経由しない)"""
+    return auth_headers_for(unapproved_user.username)
 
 
 @pytest.fixture
 def sample_server(db, admin_user):
     """テスト用サーバーを作成"""
-    from app.servers.models import Server, ServerStatus, ServerType
-
-    server = Server(
-        name="Test Server",
-        description="A test server",
-        minecraft_version="1.20.1",
-        server_type=ServerType.vanilla,
-        status=ServerStatus.stopped,
-        directory_path="./servers/1",
-        port=25565,
-        max_memory=1024,
-        max_players=20,
-        owner_id=admin_user.id,
-    )
-    db.add(server)
-    db.commit()
-    db.refresh(server)
-    return server
+    return make_server(db, admin_user)
 
 
 @pytest.fixture

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,12 @@
+"""Shared test helpers (Issue #168).
+
+Centralizes fixtures and helpers that were previously duplicated across
+multiple test files: authentication header construction, password
+hashing context, user / server factory functions, and re-exports of
+domain-port fakes.
+
+Modules in this package may import from `app.*`. Because the root
+`tests/conftest.py` sets `DATABASE_URL` BEFORE any `app.*` import (see
+Issue #210), nothing in this package may be imported from the root
+conftest at module-level. Import lazily inside fixtures instead.
+"""

--- a/tests/helpers/auth.py
+++ b/tests/helpers/auth.py
@@ -1,0 +1,30 @@
+"""Authentication header helpers for test fixtures (Issue #168).
+
+Previously, four integration test files each defined their own
+identical `get_auth_headers(username)`. This module consolidates the
+implementation. Use `auth_headers_for(username)` for new tests; the old
+name is kept as `get_auth_headers` for drop-in replacement.
+"""
+
+from typing import Dict
+
+from app.auth.auth import create_access_token
+
+
+def auth_headers_for(username: str) -> Dict[str, str]:
+    """Return an Authorization header for `username` (JWT directly minted).
+
+    Bypasses the `/api/v1/auth/token` endpoint, which keeps fixtures
+    fast and decouples them from the auth router. Login-path coverage
+    lives in dedicated auth router tests.
+    """
+    token = create_access_token(data={"sub": username})
+    return {"Authorization": f"Bearer {token}"}
+
+
+# Backwards-compatible alias for drop-in replacement of the historical
+# per-file `get_auth_headers(username)` helpers.
+get_auth_headers = auth_headers_for
+
+
+__all__ = ["auth_headers_for", "get_auth_headers"]

--- a/tests/helpers/security.py
+++ b/tests/helpers/security.py
@@ -1,0 +1,13 @@
+"""Shared bcrypt context for test fixtures (Issue #168).
+
+Tests use `bcrypt__rounds=4` to keep hashing fast in CI. Centralizing
+the `CryptContext` instance prevents accidental regressions to the
+production default (rounds=12), which was previously possible in any
+test file that constructed its own `CryptContext`.
+"""
+
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto", bcrypt__rounds=4)
+
+__all__ = ["pwd_context"]

--- a/tests/helpers/servers.py
+++ b/tests/helpers/servers.py
@@ -1,0 +1,56 @@
+"""Server factory helpers for test fixtures (Issue #168).
+
+Provides `make_server(db, owner, **kw)` to standardize the inline
+`Server(...)` construction blocks that previously appeared across many
+integration test files. The defaults mirror the legacy `sample_server`
+fixture.
+"""
+
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.servers.models import Server, ServerStatus, ServerType
+from app.users.models import User
+
+
+def make_server(
+    db: Session,
+    owner: User,
+    *,
+    name: str = "Test Server",
+    description: str = "A test server",
+    minecraft_version: str = "1.20.1",
+    server_type: ServerType = ServerType.vanilla,
+    status: ServerStatus = ServerStatus.stopped,
+    directory_path: str = "./servers/1",
+    port: int = 25565,
+    max_memory: int = 1024,
+    max_players: int = 20,
+    **extra: Any,
+) -> Server:
+    """Create and persist a `Server` row owned by `owner`.
+
+    Extra keyword args are forwarded to the `Server` constructor for
+    columns we don't model explicitly (e.g. `template_id`).
+    """
+    server = Server(
+        name=name,
+        description=description,
+        minecraft_version=minecraft_version,
+        server_type=server_type,
+        status=status,
+        directory_path=directory_path,
+        port=port,
+        max_memory=max_memory,
+        max_players=max_players,
+        owner_id=owner.id,
+        **extra,
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    return server
+
+
+__all__ = ["make_server"]

--- a/tests/helpers/users.py
+++ b/tests/helpers/users.py
@@ -1,0 +1,52 @@
+"""User factory helpers for test fixtures (Issue #168).
+
+`make_user(db, **kw)` provides a single creation path for `User`
+rows so tests don't repeat the same insert / commit / refresh dance.
+Defaults match the legacy `test_user` fixture (role=user, approved).
+"""
+
+from typing import Any, Optional
+
+from sqlalchemy.orm import Session
+
+from app.users.domain.value_objects import Role
+from app.users.models import User
+from tests.helpers.security import pwd_context
+
+
+def make_user(
+    db: Session,
+    *,
+    username: str = "testuser",
+    email: Optional[str] = None,
+    password: str = "testpassword",
+    role: Role = Role.user,
+    is_active: bool = True,
+    is_approved: bool = True,
+    **extra: Any,
+) -> User:
+    """Create and persist a `User` row.
+
+    - `email` defaults to ``f"{username}@example.com"`` if not provided.
+    - `password` is hashed with the shared test `pwd_context`
+      (rounds=4) so test setup stays fast.
+    - Extra keyword args are forwarded verbatim to the `User`
+      constructor, letting callers set columns we don't model
+      explicitly (e.g. timestamps for migration tests).
+    """
+    user = User(
+        username=username,
+        email=email if email is not None else f"{username}@example.com",
+        hashed_password=pwd_context.hash(password),
+        role=role,
+        is_active=is_active,
+        is_approved=is_approved,
+        **extra,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+__all__ = ["make_user"]

--- a/tests/infrastructure/test_parallel_execution_isolation.py
+++ b/tests/infrastructure/test_parallel_execution_isolation.py
@@ -35,23 +35,19 @@ def test_database_file_creation(db):
 
 def test_test_isolation_simple_data(db):
     """テスト間でのデータ分離を確認（シンプルテスト1）"""
-    from passlib.context import CryptContext
-
     from app.users.domain.value_objects import Role
     from app.users.models import User
-
-    pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto", bcrypt__rounds=4)
+    from tests.helpers.users import make_user
 
     # テストユーザーを作成
-    test_user = User(
+    make_user(
+        db,
         username="isolation_test_1",
         email="test1@isolation.com",
-        hashed_password=pwd_context.hash("password"),
+        password="password",
         role=Role.user,
         is_approved=True,
     )
-    db.add(test_user)
-    db.commit()
 
     # ユーザーが存在することを確認
     found_user = db.query(User).filter(User.username == "isolation_test_1").first()
@@ -61,23 +57,19 @@ def test_test_isolation_simple_data(db):
 
 def test_test_isolation_different_data(db):
     """テスト間でのデータ分離を確認（シンプルテスト2）"""
-    from passlib.context import CryptContext
-
     from app.users.domain.value_objects import Role
     from app.users.models import User
-
-    pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto", bcrypt__rounds=4)
+    from tests.helpers.users import make_user
 
     # 異なるテストユーザーを作成
-    test_user = User(
+    make_user(
+        db,
         username="isolation_test_2",
         email="test2@isolation.com",
-        hashed_password=pwd_context.hash("password"),
+        password="password",
         role=Role.admin,
         is_approved=True,
     )
-    db.add(test_user)
-    db.commit()
 
     # 前のテストのユーザーが存在しないことを確認（分離されている）
     previous_user = db.query(User).filter(User.username == "isolation_test_1").first()

--- a/tests/infrastructure/test_templates_router_infrastructure.py
+++ b/tests/infrastructure/test_templates_router_infrastructure.py
@@ -5,9 +5,6 @@ Does not test actual API functionality - use integration tests for that
 """
 
 import pytest
-from fastapi.testclient import TestClient
-
-from app.main import app
 
 
 class TestTemplatesRouterConfiguration:
@@ -63,10 +60,7 @@ class TestTemplatesRouterSchemas:
 class TestTemplatesRouterAPI:
     """Basic API endpoint tests for templates router"""
 
-    @pytest.fixture
-    def client(self):
-        """Create test client"""
-        return TestClient(app)
+    # `client` fixture provided by tests/conftest.py (Issue #168).
 
     def test_templates_router_in_app(self, client):
         """Test that templates router is included in the app"""

--- a/tests/integration/api/test_backup_router_comprehensive.py
+++ b/tests/integration/api/test_backup_router_comprehensive.py
@@ -12,7 +12,6 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import status
 
-from app.auth.auth import create_access_token
 from app.backups.api.dependencies import get_backup_service
 from app.backups.application.service import BackupService
 from app.backups.domain.entities import (
@@ -30,12 +29,7 @@ from app.main import app
 from app.servers.models import Server, ServerType
 from app.users.domain.value_objects import Role
 from app.users.models import User
-
-
-def get_auth_headers(username: str):
-    """Generate authentication headers"""
-    token = create_access_token(data={"sub": username})
-    return {"Authorization": f"Bearer {token}"}
+from tests.helpers.auth import auth_headers_for as get_auth_headers
 
 
 def make_entity(

--- a/tests/integration/api/test_backup_scheduler_api_permissions.py
+++ b/tests/integration/api/test_backup_scheduler_api_permissions.py
@@ -2,16 +2,16 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app.auth.auth import create_access_token
 from app.backups import backup_scheduler_instance
 from app.backups.adapters.uow import SqlAlchemyBackupsUnitOfWork
 from app.backups.application.scheduler import BackupSchedulerService
 from app.backups.models import BackupSchedule
-from app.main import app
 from app.servers.adapters.read_port import SqlAlchemyServerReadPort
 from app.servers.models import Server
 from app.users.domain.value_objects import Role
 from app.users.models import User
+from tests.helpers.auth import auth_headers_for
+from tests.helpers.users import make_user
 
 
 @pytest.fixture(autouse=True)
@@ -36,75 +36,38 @@ def _bootstrap_scheduler_instance(db: Session):
 class TestBackupSchedulerAPIPermissions:
     """Backup scheduler API permission tests"""
 
-    @pytest.fixture
-    def client(self):
-        """Test client"""
-        return TestClient(app)
-
-    # Use admin_user from conftest.py
+    # `client` and `admin_user` come from the root conftest.
 
     @pytest.fixture
-    def operator_user(self, db: Session):
-        """Operator user"""
-        # Check if operator user already exists
-        existing_user = db.query(User).filter_by(username="operator_user").first()
-        if existing_user:
-            return existing_user
-
-        user = User(
+    def operator_user(self, db: Session) -> User:
+        """Operator user (distinct from the root `operator_user` fixture
+        because permission tests assert against a per-test username)."""
+        return make_user(
+            db,
             username="operator_user",
             email="operator@example.com",
-            hashed_password="hashed_password",
             role=Role.operator,
-            is_active=True,
-            is_approved=True,
         )
-        db.add(user)
-        db.commit()
-        db.refresh(user)
-        return user
 
     @pytest.fixture
-    def regular_user(self, db: Session):
-        """Regular user"""
-        # Check if regular user already exists
-        existing_user = db.query(User).filter_by(username="regular_user").first()
-        if existing_user:
-            return existing_user
-
-        user = User(
+    def regular_user(self, db: Session) -> User:
+        """Regular user."""
+        return make_user(
+            db,
             username="regular_user",
             email="user@example.com",
-            hashed_password="hashed_password",
             role=Role.user,
-            is_active=True,
-            is_approved=True,
         )
-        db.add(user)
-        db.commit()
-        db.refresh(user)
-        return user
 
     @pytest.fixture
-    def other_user(self, db: Session):
-        """Other user (not server owner)"""
-        # Check if other user already exists
-        existing_user = db.query(User).filter_by(username="other_user").first()
-        if existing_user:
-            return existing_user
-
-        user = User(
+    def other_user(self, db: Session) -> User:
+        """Other user (not server owner)."""
+        return make_user(
+            db,
             username="other_user",
             email="other@example.com",
-            hashed_password="hashed_password",
             role=Role.operator,
-            is_active=True,
-            is_approved=True,
         )
-        db.add(user)
-        db.commit()
-        db.refresh(user)
-        return user
 
     @pytest.fixture
     def owner_server(self, db: Session, operator_user: User):
@@ -145,9 +108,8 @@ class TestBackupSchedulerAPIPermissions:
         return server
 
     def get_auth_headers(self, user: User):
-        """Get authentication header"""
-        token = create_access_token(data={"sub": user.username})
-        return {"Authorization": f"Bearer {token}"}
+        """Get authentication header (delegated to shared helper)."""
+        return auth_headers_for(user.username)
 
     def test_create_schedule_as_server_owner(
         self, client: TestClient, db: Session, operator_user: User, owner_server: Server

--- a/tests/integration/api/test_file_router.py
+++ b/tests/integration/api/test_file_router.py
@@ -4,17 +4,11 @@ from unittest.mock import AsyncMock, patch
 
 from fastapi import HTTPException, status
 
-from app.auth.auth import create_access_token
 from app.core.exceptions import (
     FileOperationException,
 )
 from app.types import FileType
-
-
-def get_auth_headers(username: str):
-    """認証ヘッダーを生成"""
-    token = create_access_token(data={"sub": username})
-    return {"Authorization": f"Bearer {token}"}
+from tests.helpers.auth import auth_headers_for as get_auth_headers
 
 
 class TestFileRouter:
@@ -24,9 +18,7 @@ class TestFileRouter:
         "app.servers.application.authorization.AuthorizationService.check_server_access",
         new_callable=AsyncMock,
     )
-    @patch(
-        "app.files.application.management.file_management_service.get_server_files"
-    )
+    @patch("app.files.application.management.file_management_service.get_server_files")
     def test_get_server_files_success(
         self, mock_get_files, mock_check_access, client, admin_user
     ):
@@ -68,9 +60,7 @@ class TestFileRouter:
         "app.servers.application.authorization.AuthorizationService.check_server_access",
         new_callable=AsyncMock,
     )
-    @patch(
-        "app.files.application.management.file_management_service.get_server_files"
-    )
+    @patch("app.files.application.management.file_management_service.get_server_files")
     def test_get_server_files_with_path_filter(
         self, mock_get_files, mock_check_access, client, admin_user
     ):
@@ -88,9 +78,7 @@ class TestFileRouter:
         "app.servers.application.authorization.AuthorizationService.check_server_access",
         new_callable=AsyncMock,
     )
-    @patch(
-        "app.files.application.management.file_management_service.get_server_files"
-    )
+    @patch("app.files.application.management.file_management_service.get_server_files")
     def test_get_server_files_with_type_filter(
         self, mock_get_files, mock_check_access, client, admin_user
     ):
@@ -110,9 +98,7 @@ class TestFileRouter:
         "app.servers.application.authorization.AuthorizationService.check_server_access",
         new_callable=AsyncMock,
     )
-    @patch(
-        "app.files.application.management.file_management_service.get_server_files"
-    )
+    @patch("app.files.application.management.file_management_service.get_server_files")
     @patch("app.files.application.management.file_management_service.read_file")
     def test_read_file_success(
         self, mock_read_file, mock_get_files, mock_check_access, client, admin_user
@@ -147,9 +133,7 @@ class TestFileRouter:
         "app.servers.application.authorization.AuthorizationService.check_server_access",
         new_callable=AsyncMock,
     )
-    @patch(
-        "app.files.application.management.file_management_service.get_server_files"
-    )
+    @patch("app.files.application.management.file_management_service.get_server_files")
     @patch("app.files.application.management.file_management_service.read_file")
     def test_read_file_with_encoding(
         self, mock_read_file, mock_get_files, mock_check_access, client, admin_user
@@ -183,9 +167,7 @@ class TestFileRouter:
         "app.servers.application.authorization.AuthorizationService.check_server_access",
         new_callable=AsyncMock,
     )
-    @patch(
-        "app.files.application.management.file_management_service.get_server_files"
-    )
+    @patch("app.files.application.management.file_management_service.get_server_files")
     @patch(
         "app.files.application.management.file_management_service.read_image_as_base64"
     )
@@ -419,9 +401,7 @@ class TestFileRouter:
         new_callable=AsyncMock,
     )
     @patch("app.servers.application.authorization.AuthorizationService.can_modify_files")
-    @patch(
-        "app.files.application.management.file_management_service.create_directory"
-    )
+    @patch("app.files.application.management.file_management_service.create_directory")
     def test_create_directory_success(
         self, mock_create_dir, mock_can_modify, mock_check_access, client, admin_user
     ):

--- a/tests/integration/api/test_user_api.py
+++ b/tests/integration/api/test_user_api.py
@@ -5,13 +5,7 @@ Tests HTTP API layer for user management, registration, and administrative opera
 
 from fastapi import status
 
-from app.auth.auth import create_access_token
-
-
-def get_auth_headers(username: str):
-    """Generate authentication header"""
-    token = create_access_token(data={"sub": username})
-    return {"Authorization": f"Bearer {token}"}
+from tests.helpers.auth import auth_headers_for as get_auth_headers
 
 
 class TestUserRegistrationAPI:

--- a/tests/integration/audit/test_audit_repository.py
+++ b/tests/integration/audit/test_audit_repository.py
@@ -22,6 +22,7 @@ from app.audit.domain.entities import AuditEventCommand, LogFilters
 from app.audit.models import AuditLog
 from app.users.domain.value_objects import Role
 from app.users.models import User
+from tests.helpers.users import make_user
 
 
 @pytest.fixture
@@ -56,18 +57,12 @@ def writer(db):
 
 @pytest.fixture
 def seeded_user(db):
-    user = User(
+    return make_user(
+        db,
         username="audit-target",
         email="audit-target@example.com",
-        hashed_password="x",
         role=Role.user,
-        is_active=True,
-        is_approved=True,
     )
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-    return user
 
 
 @pytest.mark.asyncio

--- a/tests/integration/files/test_toctou.py
+++ b/tests/integration/files/test_toctou.py
@@ -21,28 +21,21 @@ from app.files.adapters.uow import SqlAlchemyFilesUnitOfWork
 from app.files.application.service import FileHistoryService
 from app.files.models import FileEditHistory
 from app.servers.adapters.read_port import SqlAlchemyServerReadPort
-from app.servers.models import Server, ServerStatus, ServerType
+from app.servers.models import Server
 from tests.conftest import TestingSessionLocal
+from tests.helpers.servers import make_server
 
 
 @pytest.fixture
 def server(db, admin_user) -> Server:
-    s = Server(
+    return make_server(
+        db,
+        admin_user,
         name="TOCTOU Test Server",
         description="for file-history TOCTOU tests",
-        minecraft_version="1.20.1",
-        server_type=ServerType.vanilla,
-        status=ServerStatus.stopped,
         directory_path="./servers/toctou",
         port=25700,
-        max_memory=1024,
-        max_players=20,
-        owner_id=admin_user.id,
     )
-    db.add(s)
-    db.commit()
-    db.refresh(s)
-    return s
 
 
 @pytest.mark.asyncio

--- a/tests/integration/groups/test_server_group_repository.py
+++ b/tests/integration/groups/test_server_group_repository.py
@@ -12,7 +12,8 @@ import pytest
 from app.groups.adapters.repository import SqlAlchemyServerGroupRepository
 from app.groups.domain.entities import AttachServerGroupCommand
 from app.groups.models import Group, GroupType, ServerGroup
-from app.servers.models import Server, ServerStatus, ServerType
+from app.servers.models import Server, ServerStatus
+from tests.helpers.servers import make_server
 
 
 @pytest.fixture
@@ -28,31 +29,22 @@ def _seed_group(db, owner_id: int, *, name: str = "g", type=GroupType.op) -> Gro
     return row
 
 
-def _seed_server(
-    db, owner_id: int, *, name: str, directory_path: str = "./servers/x"
-) -> Server:
-    row = Server(
+def _seed_server(db, owner, *, name: str, directory_path: str = "./servers/x") -> Server:
+    """Wrapper around `tests.helpers.servers.make_server` retaining the
+    existing call sites' shape (name=, directory_path=)."""
+    return make_server(
+        db,
+        owner,
         name=name,
         description=None,
-        minecraft_version="1.20.1",
-        server_type=ServerType.vanilla,
-        status=ServerStatus.stopped,
         directory_path=directory_path,
-        port=25565,
-        max_memory=1024,
-        max_players=20,
-        owner_id=owner_id,
     )
-    db.add(row)
-    db.commit()
-    db.refresh(row)
-    return row
 
 
 @pytest.mark.asyncio
 async def test_attach_and_find(repository, db, admin_user):
     group = _seed_group(db, admin_user.id)
-    server = _seed_server(db, admin_user.id, name="sA")
+    server = _seed_server(db, admin_user, name="sA")
 
     entity = await repository.attach(
         AttachServerGroupCommand(server_id=server.id, group_id=group.id, priority=3)
@@ -69,8 +61,8 @@ async def test_attach_and_find(repository, db, admin_user):
 @pytest.mark.asyncio
 async def test_count_for_group(repository, db, admin_user):
     group = _seed_group(db, admin_user.id)
-    s1 = _seed_server(db, admin_user.id, name="s1", directory_path="./servers/s1")
-    s2 = _seed_server(db, admin_user.id, name="s2", directory_path="./servers/s2")
+    s1 = _seed_server(db, admin_user, name="s1", directory_path="./servers/s1")
+    s2 = _seed_server(db, admin_user, name="s2", directory_path="./servers/s2")
 
     await repository.attach(AttachServerGroupCommand(server_id=s1.id, group_id=group.id))
     await repository.attach(AttachServerGroupCommand(server_id=s2.id, group_id=group.id))
@@ -82,8 +74,8 @@ async def test_count_for_group(repository, db, admin_user):
 @pytest.mark.asyncio
 async def test_list_server_ids_for_group(repository, db, admin_user):
     group = _seed_group(db, admin_user.id)
-    s1 = _seed_server(db, admin_user.id, name="s1", directory_path="./servers/s1")
-    s2 = _seed_server(db, admin_user.id, name="s2", directory_path="./servers/s2")
+    s1 = _seed_server(db, admin_user, name="s1", directory_path="./servers/s1")
+    s2 = _seed_server(db, admin_user, name="s2", directory_path="./servers/s2")
 
     await repository.attach(AttachServerGroupCommand(server_id=s1.id, group_id=group.id))
     await repository.attach(AttachServerGroupCommand(server_id=s2.id, group_id=group.id))
@@ -97,7 +89,7 @@ async def test_list_server_ids_for_group(repository, db, admin_user):
 async def test_list_groups_for_server_priority_desc(repository, db, admin_user):
     g_lo = _seed_group(db, admin_user.id, name="low")
     g_hi = _seed_group(db, admin_user.id, name="high")
-    s = _seed_server(db, admin_user.id, name="srv")
+    s = _seed_server(db, admin_user, name="srv")
 
     await repository.attach(
         AttachServerGroupCommand(server_id=s.id, group_id=g_lo.id, priority=1)
@@ -114,7 +106,7 @@ async def test_list_groups_for_server_priority_desc(repository, db, admin_user):
 @pytest.mark.asyncio
 async def test_list_server_dirs_for_group(repository, db, admin_user):
     group = _seed_group(db, admin_user.id)
-    s = _seed_server(db, admin_user.id, name="srv", directory_path="./servers/dirX")
+    s = _seed_server(db, admin_user, name="srv", directory_path="./servers/dirX")
     await repository.attach(AttachServerGroupCommand(server_id=s.id, group_id=group.id))
     db.commit()
 
@@ -135,7 +127,7 @@ async def test_list_attachments_for_server_returns_view_with_player_count(
         ]
     )
     db.commit()
-    s = _seed_server(db, admin_user.id, name="srv")
+    s = _seed_server(db, admin_user, name="srv")
     await repository.attach(
         AttachServerGroupCommand(server_id=s.id, group_id=group.id, priority=4)
     )
@@ -154,7 +146,7 @@ async def test_list_attachments_for_group_carries_server_status(
     repository, db, admin_user
 ):
     group = _seed_group(db, admin_user.id)
-    s = _seed_server(db, admin_user.id, name="srvB", directory_path="./servers/srvB")
+    s = _seed_server(db, admin_user, name="srvB", directory_path="./servers/srvB")
     await repository.attach(
         AttachServerGroupCommand(server_id=s.id, group_id=group.id, priority=2)
     )
@@ -172,7 +164,7 @@ async def test_list_attachments_for_group_carries_server_status(
 @pytest.mark.asyncio
 async def test_detach_returns_true_then_false(repository, db, admin_user):
     group = _seed_group(db, admin_user.id)
-    s = _seed_server(db, admin_user.id, name="srv")
+    s = _seed_server(db, admin_user, name="srv")
     await repository.attach(AttachServerGroupCommand(server_id=s.id, group_id=group.id))
     db.commit()
 

--- a/tests/integration/test_approval_messages.py
+++ b/tests/integration/test_approval_messages.py
@@ -1,12 +1,6 @@
 from fastapi import status
 
-from app.auth.auth import create_access_token
-
-
-def get_auth_headers(username: str):
-    """認証ヘッダーを生成"""
-    token = create_access_token(data={"sub": username})
-    return {"Authorization": f"Bearer {token}"}
+from tests.helpers.auth import auth_headers_for as get_auth_headers
 
 
 class TestApprovalMessages:

--- a/tests/integration/test_main_comprehensive.py
+++ b/tests/integration/test_main_comprehensive.py
@@ -3,7 +3,6 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi.testclient import TestClient
 
 from app.main import ServiceStatus, app, service_status
 
@@ -116,10 +115,7 @@ class TestServiceStatusComprehensive:
 class TestHealthEndpointComprehensive:
     """Comprehensive tests for health check endpoints"""
 
-    @pytest.fixture
-    def client(self):
-        """Create test client"""
-        return TestClient(app)
+    # `client` fixture provided by tests/conftest.py (Issue #168).
 
     def test_health_endpoint_healthy_all_services(self, client):
         """Test health endpoint when all services are healthy"""
@@ -634,10 +630,7 @@ class TestApplicationConfiguration:
 class TestApiV1EndpointsNew:
     """Test new /api/v1 prefixed health and metrics endpoints (TDD approach)"""
 
-    @pytest.fixture
-    def client(self):
-        """Create test client"""
-        return TestClient(app)
+    # `client` fixture provided by tests/conftest.py (Issue #168).
 
     def test_api_v1_health_endpoint_healthy_all_services(self, client):
         """Test /api/v1/health endpoint when all services are healthy"""

--- a/tests/integration/test_refresh_token.py
+++ b/tests/integration/test_refresh_token.py
@@ -8,6 +8,7 @@ from app.auth.adapters.uow import SqlAlchemyAuthUnitOfWork
 from app.auth.application.service import AuthService
 from app.users.domain.value_objects import Role
 from app.users.models import RefreshToken, User
+from tests.helpers.users import make_user
 
 
 def _make_auth_service(db: Session) -> AuthService:
@@ -15,22 +16,18 @@ def _make_auth_service(db: Session) -> AuthService:
 
 
 def _insert_inactive_user(db: Session) -> User:
-    """Create a non-active user directly via ORM (test setup only)."""
-    from passlib.context import CryptContext
-
-    pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
-    user = User(
+    """Create a non-active user directly via the shared `make_user`
+    helper (test setup only). Uses the centralized rounds=4 bcrypt
+    context — see `tests.helpers.security.pwd_context` (#168)."""
+    return make_user(
+        db,
         username="inactive_user",
         email="inactive@example.com",
-        hashed_password=pwd.hash("testpassword"),
+        password="testpassword",
         role=Role.user,
         is_active=False,
         is_approved=True,
     )
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-    return user
 
 
 class TestRefreshTokenAPI:

--- a/tests/integration/test_server_export_import.py
+++ b/tests/integration/test_server_export_import.py
@@ -369,9 +369,13 @@ class TestServerExportImport:
         db.commit()
 
         # Create a stopped server with port 25565
-        from app.servers.models import Server
+        from tests.helpers.servers import make_server
 
-        stopped_server = Server(
+        # Existence of a row with this port is enough for the port-conflict
+        # check; the entity isn't referenced again in this test.
+        make_server(
+            db,
+            admin_user,
             name="Stopped Server",
             description="A stopped server",
             minecraft_version="1.21.6",
@@ -379,12 +383,7 @@ class TestServerExportImport:
             status=ServerStatus.stopped,
             directory_path="./servers/stopped_server",
             port=25565,
-            max_memory=1024,
-            max_players=20,
-            owner_id=admin_user.id,
         )
-        db.add(stopped_server)
-        db.commit()
 
         # Create test ZIP file
         zip_buffer = io.BytesIO()

--- a/tests/integration/test_server_port_conflicts.py
+++ b/tests/integration/test_server_port_conflicts.py
@@ -4,7 +4,8 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
-from app.servers.models import Server, ServerStatus, ServerType
+from app.servers.models import ServerStatus, ServerType
+from tests.helpers.servers import make_server
 
 # Every test in this file calls `POST /api/v1/servers`, which triggers
 # real Java discovery inside MinecraftServerManager — skip without a JRE.
@@ -31,7 +32,9 @@ class TestServerPortConflicts:
         db.add(version)
         db.commit()
         # Create a server with port 25565
-        first_server = Server(
+        make_server(
+            db,
+            admin_user,
             name="First Server",
             description="A server",
             minecraft_version="1.21.6",
@@ -39,12 +42,7 @@ class TestServerPortConflicts:
             status=ServerStatus.stopped,
             directory_path="./servers/first_server",
             port=25565,
-            max_memory=1024,
-            max_players=20,
-            owner_id=admin_user.id,
         )
-        db.add(first_server)
-        db.commit()
 
         # Mock JAR download and caching to avoid actual network calls
         with (
@@ -106,7 +104,9 @@ class TestServerPortConflicts:
         db.commit()
 
         # Create a stopped server with port 25566
-        stopped_server = Server(
+        make_server(
+            db,
+            admin_user,
             name="Stopped Server",
             description="A stopped server",
             minecraft_version="1.21.6",
@@ -114,12 +114,7 @@ class TestServerPortConflicts:
             status=ServerStatus.stopped,
             directory_path="./servers/stopped_server",
             port=25566,
-            max_memory=1024,
-            max_players=20,
-            owner_id=admin_user.id,
         )
-        db.add(stopped_server)
-        db.commit()
 
         # Mock JAR download and caching to avoid actual network calls
         with (
@@ -181,7 +176,9 @@ class TestServerPortConflicts:
         db.commit()
 
         # Create a starting server with port 25567
-        starting_server = Server(
+        make_server(
+            db,
+            admin_user,
             name="Starting Server",
             description="A starting server",
             minecraft_version="1.21.6",
@@ -189,12 +186,7 @@ class TestServerPortConflicts:
             status=ServerStatus.starting,
             directory_path="./servers/starting_server",
             port=25567,
-            max_memory=1024,
-            max_players=20,
-            owner_id=admin_user.id,
         )
-        db.add(starting_server)
-        db.commit()
 
         # Mock JAR download and caching to avoid actual network calls
         with (

--- a/tests/unit/auth/test_phase1_compliance.py
+++ b/tests/unit/auth/test_phase1_compliance.py
@@ -19,6 +19,7 @@ from app.servers.application.authorization import AuthorizationService
 from app.servers.models import Server, ServerStatus, ServerType
 from app.users.domain.value_objects import Role
 from app.users.models import User
+from tests.helpers.servers import make_server
 
 
 class TestPhase1ComplianceBasicOperations:
@@ -84,20 +85,15 @@ class TestPhase1ComplianceResourceAccess:
     ):
         """Test that users can view servers through visibility system (Phase 1+2)"""
         # Create a server owned by admin
-        server = Server(
+        server = make_server(
+            db,
+            admin_user,
             name="Test Server",
             description="Test server for visibility",
             minecraft_version="1.19.4",
-            server_type=ServerType.vanilla,
-            status=ServerStatus.stopped,
             directory_path="./servers/test_visibility",
             port=25565,
-            max_memory=1024,
-            max_players=20,
-            owner_id=admin_user.id,
         )
-        db.add(server)
-        db.commit()
 
         # New permission model: all users can access all servers regardless of visibility config
         try:
@@ -187,20 +183,15 @@ class TestPhase1ComplianceOperationalRequirements:
     def test_operate_servers_requirement(self, db: Session, test_user):
         """Test operate servers requirement - users can access servers they have visibility to"""
         # Create a server
-        server = Server(
+        server = make_server(
+            db,
+            test_user,  # User owns this server
             name="Operational Test Server",
             description="Test server operations",
             minecraft_version="1.19.4",
-            server_type=ServerType.vanilla,
-            status=ServerStatus.stopped,
             directory_path="./servers/operational_test",
             port=25567,
-            max_memory=1024,
-            max_players=20,
-            owner_id=test_user.id,  # User owns this server
         )
-        db.add(server)
-        db.commit()
 
         # User should be able to access their own server (owner privilege)
         try:

--- a/tests/unit/backups/fakes.py
+++ b/tests/unit/backups/fakes.py
@@ -4,11 +4,10 @@ These structurally implement the Protocols in
 `app.backups.domain.ports`. They let unit tests exercise the backups
 application service without a database.
 
-`FakeServerReadPort` is reused from `tests.unit.files.fakes` (or kept
-local here when the existing one lacks fields). For #227 we use a
-local lightweight `FakeServerReadPort` because the legacy
-`tests/unit/files/fakes.py` `get` method may not return all the fields
-the backup service touches.
+`FakeServerReadPort` is the unified implementation re-exported from
+`tests.unit.servers.fakes` (#168). The previous local copy is gone;
+import via `from tests.unit.backups.fakes import FakeServerReadPort`
+still works thanks to the re-export below.
 """
 
 from dataclasses import replace
@@ -30,8 +29,6 @@ from app.backups.domain.entities import (
     UpdateBackupScheduleCommand,
 )
 from app.backups.models import BackupStatus, BackupType, ScheduleAction
-from app.servers.domain.entities import ServerEntity
-from app.servers.models import ServerType
 
 
 def _utcnow() -> datetime:
@@ -308,50 +305,10 @@ class FakeBackupsUnitOfWork:
 
 
 # ---------------------------------------------------------------------------
-# Server read port fake
+# Server read port fake (re-exported from tests.unit.servers.fakes, #168)
 # ---------------------------------------------------------------------------
 
-
-class FakeServerReadPort:
-    """Lightweight `ServerReadPort` for backup unit tests."""
-
-    def __init__(self) -> None:
-        self._servers: Dict[int, ServerEntity] = {}
-
-    async def get_directory_path(self, server_id: int) -> Optional[str]:
-        s = self._servers.get(server_id)
-        return s.directory_path if s else None
-
-    async def get(self, server_id: int) -> Optional[ServerEntity]:
-        return self._servers.get(server_id)
-
-    def seed(
-        self,
-        *,
-        id: int,
-        owner_id: int = 1,
-        name: str = "srv",
-        directory_path: str = "/srv",
-        port: int = 25565,
-        server_type: ServerType = ServerType.vanilla,
-        minecraft_version: str = "1.20.1",
-        max_memory: int = 1024,
-        max_players: int = 20,
-    ) -> ServerEntity:
-        entity = ServerEntity(
-            id=id,
-            name=name,
-            directory_path=directory_path,
-            minecraft_version=minecraft_version,
-            server_type=server_type,
-            port=port,
-            max_memory=max_memory,
-            max_players=max_players,
-            owner_id=owner_id,
-        )
-        self._servers[id] = entity
-        return entity
-
+from tests.unit.servers.fakes import FakeServerReadPort  # noqa: E402,F401
 
 # ---------------------------------------------------------------------------
 # Helper for constructing entities in tests

--- a/tests/unit/files/fakes.py
+++ b/tests/unit/files/fakes.py
@@ -17,7 +17,6 @@ from app.files.domain.entities import (
     FileHistoryEntity,
     FileHistoryStatsEntity,
 )
-from app.servers.domain.entities import ServerEntity
 
 
 class FakeFileHistoryRepository:
@@ -205,36 +204,6 @@ class FakeFilesUnitOfWork:
         self.rolled_back += 1
 
 
-class FakeServerReadPort:
-    """Dict-backed `ServerReadPort` for unit tests.
-
-    Stores per-server `directory_path` and (optionally) a full
-    `ServerEntity` snapshot consumed by `ServerReadPort.get`. The two
-    stores are independent so that tests which only exercise the
-    file-history surface can stay terse, while templates / groups
-    tests can seed a full entity (including `owner_id`, which the
-    groups domain reads to apply the "admin-or-server-owner" rule —
-    see `app.groups.application.service._can_manage_server_groups`).
-    """
-
-    def __init__(
-        self,
-        paths: Optional[Dict[int, Optional[str]]] = None,
-        servers: Optional[Dict[int, ServerEntity]] = None,
-    ) -> None:
-        self._paths: Dict[int, Optional[str]] = dict(paths or {})
-        self._servers: Dict[int, ServerEntity] = dict(servers or {})
-
-    async def get_directory_path(self, server_id: int) -> Optional[str]:
-        return self._paths.get(server_id)
-
-    async def get(self, server_id: int) -> Optional[ServerEntity]:
-        return self._servers.get(server_id)
-
-    def set_path(self, server_id: int, path: Optional[str]) -> None:
-        self._paths[server_id] = path
-
-    def set_server(self, server: ServerEntity) -> None:
-        """Register a `ServerEntity` and mirror its `directory_path`."""
-        self._servers[server.id] = server
-        self._paths[server.id] = server.directory_path
+# `FakeServerReadPort` is consolidated in `tests.unit.servers.fakes`
+# (#168). Re-exported here so existing imports keep working.
+from tests.unit.servers.fakes import FakeServerReadPort  # noqa: E402,F401

--- a/tests/unit/servers/fakes.py
+++ b/tests/unit/servers/fakes.py
@@ -186,9 +186,7 @@ class FakeServerRepository:
             result[sid] = await self.update_status(sid, new_status)
         return result
 
-    async def update_port(
-        self, server_id: int, port: int
-    ) -> Optional[ServerEntity]:
+    async def update_port(self, server_id: int, port: int) -> Optional[ServerEntity]:
         existing = self._records.get(server_id)
         if existing is None:
             return None
@@ -284,7 +282,78 @@ def make_server_entity(
     )
 
 
+class FakeServerReadPort:
+    """Dict-backed `ServerReadPort` for unit tests.
+
+    Consolidates the previously duplicated FakeServerReadPort
+    implementations from `tests/unit/backups/fakes.py` and
+    `tests/unit/files/fakes.py` (Issue #168).
+
+    Stores per-server `directory_path` and (optionally) a full
+    `ServerEntity` snapshot consumed by `ServerReadPort.get`. The two
+    stores are kept independent so tests that only exercise
+    file-history surfaces stay terse, while groups/templates tests can
+    seed a full entity (including `owner_id`, which the groups domain
+    reads to apply the "admin-or-server-owner" rule — see
+    `app.groups.application.service._can_manage_server_groups`).
+    """
+
+    def __init__(
+        self,
+        paths: Optional[Dict[int, Optional[str]]] = None,
+        servers: Optional[Dict[int, ServerEntity]] = None,
+    ) -> None:
+        self._paths: Dict[int, Optional[str]] = dict(paths or {})
+        self._servers: Dict[int, ServerEntity] = dict(servers or {})
+
+    async def get_directory_path(self, server_id: int) -> Optional[str]:
+        if server_id in self._paths:
+            return self._paths[server_id]
+        s = self._servers.get(server_id)
+        return s.directory_path if s else None
+
+    async def get(self, server_id: int) -> Optional[ServerEntity]:
+        return self._servers.get(server_id)
+
+    def set_path(self, server_id: int, path: Optional[str]) -> None:
+        self._paths[server_id] = path
+
+    def set_server(self, server: ServerEntity) -> None:
+        """Register a `ServerEntity` and mirror its `directory_path`."""
+        self._servers[server.id] = server
+        self._paths[server.id] = server.directory_path
+
+    def seed(
+        self,
+        *,
+        id: int,
+        owner_id: int = 1,
+        name: str = "srv",
+        directory_path: str = "/srv",
+        port: int = 25565,
+        server_type: ServerType = ServerType.vanilla,
+        minecraft_version: str = "1.20.1",
+        max_memory: int = 1024,
+        max_players: int = 20,
+    ) -> ServerEntity:
+        """Seed a `ServerEntity` directly (backups-style API)."""
+        entity = ServerEntity(
+            id=id,
+            name=name,
+            directory_path=directory_path,
+            minecraft_version=minecraft_version,
+            server_type=server_type,
+            port=port,
+            max_memory=max_memory,
+            max_players=max_players,
+            owner_id=owner_id,
+        )
+        self.set_server(entity)
+        return entity
+
+
 __all__ = [
+    "FakeServerReadPort",
     "FakeServerRepository",
     "FakeServersUnitOfWork",
     "make_server_entity",


### PR DESCRIPTION
## Summary

Consolidates the duplicated test fixtures and helpers identified in #168 into a new `tests/helpers/` package, so every piece of test infrastructure has exactly one canonical implementation.

- New `tests/helpers/{security,auth,users,servers}.py` modules expose `pwd_context`, `auth_headers_for(username)` (alias `get_auth_headers`), `make_user(db, **kw)`, and `make_server(db, owner, **kw)`.
- Root `tests/conftest.py` fixtures now delegate to the helpers; `admin_headers`/`user_headers` switched to JWT-direct generation (login coverage stays in `tests/integration/api/test_auth_router.py`), and `operator_headers` / `unapproved_headers` are added for symmetry.
- `FakeServerReadPort` is unified in `tests/unit/servers/fakes.py`; `tests/unit/{backups,files}/fakes.py` re-export from there so existing imports keep working.
- Local `client(self)`, `operator_user/regular_user/other_user`, and per-file `get_auth_headers` fixtures across 5 files are dropped — they now use the root conftest.

## Before / After duplicate counts

| Surface | Before | After |
|---|---:|---:|
| `get_auth_headers(username)` definitions | 5 | 1 (`tests.helpers.auth.auth_headers_for`) |
| `FakeServerReadPort` class definitions | 2 | 1 (`tests.unit.servers.fakes`) |
| `CryptContext(...)` instances | 3 | 1 (`tests.helpers.security.pwd_context`) |
| Per-class `client(self)` fixtures | 4 | 0 |
| Inline `User(...)` fixtures with unhashed `hashed_password` | 3 | 0 (replaced via `make_user`, hashes via shared `pwd_context`) |

## Risk mitigations (#210 invariants)

- `tests/conftest.py` still sets `DATABASE_URL` BEFORE any `from app.*` import; helpers (which import from `app.*`) are imported only after that block.
- `engine`, `TestingSessionLocal`, and `get_worker_db_path` keep their module-level names because `tests/integration/files/test_toctou.py` and `tests/infrastructure/test_parallel_execution_isolation.py` import them directly.
- Identity-check verified: `from tests.unit.{servers,backups,files}.fakes import FakeServerReadPort` resolves to the same class object across all three modules.
- The unified `FakeServerReadPort` is a structural superset of both previous implementations (`_paths` is consulted first for `get_directory_path`, falling back to `_servers` only when a path was never explicitly set, preserving the `set_path(id, None)` "no longer resolvable" semantics used by `tests/unit/files/test_service_with_fake.py`).

## Test plan

- [x] `uv run ruff check tests/` — 3 pre-existing errors unchanged, none new.
- [x] `uv run ruff format --check tests/` — clean on touched files.
- [x] Unit smoke (`pytest tests/unit -m "not slow"`): **1168 passed, 5 skipped**.
- [x] Pre-push smoke (`pytest tests/unit tests/integration -m "not slow"`): **1604 passed, 10 skipped** (single-shot; pre-push hook itself surfaced parallel-SQLite flakes that reproduce on master and are unrelated to this PR — see Issue #210 invariants).
- [x] Full suite (`just test`): **1789 passed, 10 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)