### PR TITLE
chore: add minimal flake.nix for reproducible dev environment (Resolves #172)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "mc-server-dashboard-api dev environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        python = pkgs.python313;
+        jdk    = pkgs.jdk21;
+      in {
+        devShells.default = pkgs.mkShell {
+          name = "mc-server-dashboard-api";
+
+          packages = with pkgs; [
+            python          # Python 3.13 interpreter (uv が venv 生成時に参照)
+            uv              # 主要 package manager
+            jdk             # Minecraft server / Java-required tests
+            pre-commit      # CLAUDE.md Rule 2/6 で必須
+            just            # task runner
+            git             # bit / pre-commit が依存
+          ];
+
+          # uv が Nix 管理外の Python を取りに行かないよう抑止
+          env = {
+            UV_PYTHON_DOWNLOADS  = "never";
+            UV_PYTHON            = "${python}/bin/python3.13";
+            JAVA_HOME            = "${jdk}";
+          };
+
+          shellHook = ''
+            # Minecraft 起動用 Java パスを Java discovery 機能へ橋渡し
+            export JAVA_21_PATH="${jdk}/bin/java"
+
+            echo "mc-server-dashboard-api devShell"
+            echo "  python : $(python3 --version)"
+            echo "  uv     : $(uv --version)"
+            echo "  java   : $(java -version 2>&1 | head -n1)"
+            echo ""
+            echo "Next: 'uv sync --group dev' then 'uv run pre-commit install'"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
## Summary

Adds a single new file, \`flake.nix\`, providing a Nix devShell with the system-layer toolchain required for this project. Python package resolution remains delegated to \`uv\` via the existing \`pyproject.toml\` / \`uv.lock\` workflow; this PR does **not** modify any existing file.

Resolves #172.

## Scope

- **devShell only** — build derivation is deferred to #175 (Dockerfile migration).
- nixpkgs channel: \`nixos-unstable\`.
- multi-system via \`flake-utils.lib.eachDefaultSystem\`.
- JDK: \`jdk21\` only (minimal). Additional JDK versions can be added in a follow-up PR if needed.

## System packages provided in devShell

| Package      | Purpose                                                        |
|--------------|----------------------------------------------------------------|
| \`python313\`  | Python 3.13 interpreter referenced by uv (\`UV_PYTHON\`)          |
| \`uv\`         | Primary package manager / venv builder                         |
| \`jdk21\`      | Required for Minecraft server processes & Java discovery tests |
| \`pre-commit\` | CLAUDE.md Rule 2 / Rule 6                                      |
| \`just\`       | Project task runner                                            |
| \`git\`        | Required by \`bit\` and pre-commit                               |

## Environment / shellHook

- \`UV_PYTHON_DOWNLOADS=never\` prevents uv from fetching a non-Nix Python.
- \`UV_PYTHON\` pins uv to the Nix-provided \`python3.13\`.
- \`JAVA_HOME\` set to the Nix-provided JDK.
- \`JAVA_21_PATH\` exported by shellHook so the app's Java discovery picks up the Nix JDK.
- shellHook prints versions and a hint to run \`uv sync --group dev\` then \`uv run pre-commit install\`.

## Out of scope (separate issues)

- \`.envrc\` / direnv integration → #173
- README documentation → #174
- Dockerfile migration / build derivation → #175
- No changes to \`pyproject.toml\`, \`.python-version\`, \`justfile\`, \`.env.example\` — existing uv workflow is unchanged.

## Verification (agent environment limitations)

Nix is **not** installed in the agent's environment, so the L2–L4 validations below cannot be performed locally. Verification performed:

- [x] Syntax review of \`flake.nix\` (attrset balance, \`let ... in\`, string interpolation, \`mkShell\` schema with \`env\` block which is supported on nixpkgs 24.05+).
- [x] No modification to existing tracked files (\`git diff --stat\` shows only \`flake.nix\` as new).
- [x] Existing uv workflow still passes: \`uv run pytest tests/unit -m \"not slow\"\` → **1168 passed, 5 skipped** (no regression; expected since this PR only adds an untracked-from-Python file).

## Requested reviewer/maintainer verification

Please run the following on a host with Nix installed (\`>= 2.18\` recommended, flakes enabled):

- [ ] \`nix flake check\` — confirms schema correctness and that all systems evaluate.
- [ ] \`nix develop\` — enters the shell successfully.
- [ ] Inside the shell:
  - [ ] \`python3 --version\` → \`Python 3.13.x\`
  - [ ] \`uv --version\` resolves
  - [ ] \`java -version\` → JDK 21
  - [ ] \`uv sync --group dev\` succeeds
  - [ ] \`uv run pytest tests/unit -m \"not slow\"\` passes inside the devShell

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>