### PR TITLE
feat: add comprehensive health and readiness endpoints (Resolves #21)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -41,6 +41,23 @@ class Settings(BaseSettings):
     # Interval (seconds) between sweep runs in the scheduler loop.
     BACKUPS_CLEANUP_INTERVAL_SECONDS: int = 3600
 
+    # Health check configuration (Issue #21)
+    # Per-component timeout: individual ``HealthCheckPort.check()``
+    # invocations are bounded so one slow adapter cannot block the
+    # whole probe.
+    HEALTH_CHECK_PER_COMPONENT_TIMEOUT_SECONDS: float = 2.0
+    # Filesystem probe budget (used by the FilesystemHealthCheck when
+    # ``probe_writability=True``; the default os.access() path is
+    # already nearly free).
+    HEALTH_CHECK_FS_TIMEOUT_SECONDS: float = 1.0
+    # Global guardrail: aggregates of the per-component runs are
+    # bounded by this — defends against pathological misconfigurations
+    # where every probe sits at the per-component timeout.
+    HEALTH_CHECK_GLOBAL_TIMEOUT_SECONDS: float = 5.0
+    # Short cache so k8s probing at ~1 Hz does not amplify into a
+    # flood of database connections.
+    HEALTH_CHECK_CACHE_TTL_SECONDS: float = 2.0
+
     # CORS configuration
     CORS_ORIGINS: str = (
         "http://localhost:3000,http://127.0.0.1:3000,https://127.0.0.1:3000"
@@ -142,6 +159,21 @@ class Settings(BaseSettings):
             raise ValueError(
                 "BACKUPS_CLEANUP_INTERVAL_SECONDS must be between 60 and 86400 seconds"
             )
+        return v
+
+    @field_validator(
+        "HEALTH_CHECK_PER_COMPONENT_TIMEOUT_SECONDS",
+        "HEALTH_CHECK_FS_TIMEOUT_SECONDS",
+        "HEALTH_CHECK_GLOBAL_TIMEOUT_SECONDS",
+        "HEALTH_CHECK_CACHE_TTL_SECONDS",
+    )
+    @classmethod
+    def validate_health_check_timings(cls, v: float) -> float:
+        """All health-check timing knobs must be strictly positive and
+        below a 60s ceiling (anything larger would defeat the point of
+        a sub-second probe interval)."""
+        if v <= 0 or v > 60:
+            raise ValueError("health check timing settings must be in (0, 60] seconds")
         return v
 
     @property

--- a/app/health/__init__.py
+++ b/app/health/__init__.py
@@ -1,0 +1,11 @@
+"""Health check domain.
+
+Provides liveness and readiness probes plus a detailed admin-only
+component report. Layered after the hexagonal layout (ARCHITECTURE
+§4.2): the ``application`` layer is framework-agnostic, ``adapters``
+talk to the rest of the codebase via Ports, and the ``api`` layer is
+the FastAPI surface.
+
+Scope: Phase 1 of Issue #21 — endpoints + per-component checks. Phase 2
+(Prometheus-style metrics export) is tracked separately.
+"""

--- a/app/health/adapters/__init__.py
+++ b/app/health/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Concrete ``HealthCheckPort`` adapters wired in ``app.health.api.dependencies``."""

--- a/app/health/adapters/database_check.py
+++ b/app/health/adapters/database_check.py
@@ -1,0 +1,52 @@
+"""Database connectivity health check.
+
+Issues ``SELECT 1`` against the configured engine so we exercise the
+real connection pool the rest of the app uses (not just process-level
+liveness). Marked ``critical`` so a ``SELECT 1`` failure flips
+``/readyz`` to 503 — the app is useless without its database.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from app.health.domain.entities import ComponentHealth, HealthStatus
+from app.health.domain.ports import HealthCheckPort
+
+
+class DatabaseHealthCheck(HealthCheckPort):
+    name = "database"
+    critical = True
+
+    def __init__(self, engine: Engine) -> None:
+        self._engine = engine
+
+    async def check(self) -> ComponentHealth:
+        # ``Engine.connect()`` is synchronous; offload to the default
+        # executor so we do not block the event loop while the pool
+        # may be exhausted.
+        start = time.monotonic()
+        try:
+            await asyncio.to_thread(self._probe)
+        except Exception as exc:  # noqa: BLE001 — port contract
+            return ComponentHealth(
+                name=self.name,
+                status=HealthStatus.UNHEALTHY,
+                critical=self.critical,
+                message=f"{type(exc).__name__}: {exc}",
+                latency_ms=(time.monotonic() - start) * 1000.0,
+            )
+        return ComponentHealth(
+            name=self.name,
+            status=HealthStatus.HEALTHY,
+            critical=self.critical,
+            latency_ms=(time.monotonic() - start) * 1000.0,
+        )
+
+    def _probe(self) -> None:
+        with self._engine.connect() as conn:
+            conn.execute(text("SELECT 1"))

--- a/app/health/adapters/filesystem_check.py
+++ b/app/health/adapters/filesystem_check.py
@@ -1,0 +1,90 @@
+"""Filesystem writability health check.
+
+Validates that the ``servers/`` and ``backups/`` directories are
+present and writable. We probe with ``os.access(W_OK)`` rather than
+actually touching a file because:
+
+* probes happen on every ``/readyz`` call; even nanosecond-grade write
+  amplification adds up;
+* the underlying file systems may be network mounts where an actual
+  ``open(...,"w")`` would have side effects (e.g. atime updates).
+
+The detailed endpoint (``/api/v1/health/detail``) can opt into a
+real write test through ``probe_writability=True``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from app.health.domain.entities import ComponentHealth, HealthStatus
+from app.health.domain.ports import HealthCheckPort
+
+
+class FilesystemHealthCheck(HealthCheckPort):
+    name = "filesystem"
+    critical = True
+
+    def __init__(
+        self,
+        paths: list[Path] | None = None,
+        *,
+        probe_writability: bool = False,
+    ) -> None:
+        self._paths = paths or [Path("servers"), Path("backups")]
+        self._probe_writability = probe_writability
+
+    async def check(self) -> ComponentHealth:
+        start = time.monotonic()
+        try:
+            failing: list[str] = []
+            await asyncio.to_thread(self._inspect, failing)
+        except Exception as exc:  # noqa: BLE001 — port contract
+            return ComponentHealth(
+                name=self.name,
+                status=HealthStatus.UNHEALTHY,
+                critical=self.critical,
+                message=f"{type(exc).__name__}: {exc}",
+                latency_ms=(time.monotonic() - start) * 1000.0,
+            )
+
+        latency_ms = (time.monotonic() - start) * 1000.0
+        if failing:
+            return ComponentHealth(
+                name=self.name,
+                status=HealthStatus.UNHEALTHY,
+                critical=self.critical,
+                message="; ".join(failing),
+                latency_ms=latency_ms,
+                metadata={"failing_paths": failing},
+            )
+        return ComponentHealth(
+            name=self.name,
+            status=HealthStatus.HEALTHY,
+            critical=self.critical,
+            latency_ms=latency_ms,
+            metadata={"paths": [str(p) for p in self._paths]},
+        )
+
+    def _inspect(self, failing: list[str]) -> None:
+        for p in self._paths:
+            if not p.exists():
+                failing.append(f"{p}: missing")
+                continue
+            if not p.is_dir():
+                failing.append(f"{p}: not a directory")
+                continue
+            if not os.access(p, os.W_OK):
+                failing.append(f"{p}: not writable (os.access W_OK)")
+                continue
+            if self._probe_writability:
+                # Best-effort real write probe (used by /health/detail).
+                try:
+                    with tempfile.NamedTemporaryFile(dir=p, delete=True):
+                        pass
+                except OSError as exc:
+                    failing.append(f"{p}: write probe failed ({exc})")

--- a/app/health/adapters/scheduler_check.py
+++ b/app/health/adapters/scheduler_check.py
@@ -1,0 +1,89 @@
+"""Scheduler health checks (backup + version-update).
+
+Both schedulers are *non-critical* — the app degrades gracefully if a
+scheduler is not running (manual triggers still work). We therefore
+report ``DEGRADED`` rather than ``UNHEALTHY`` when the scheduler is
+not currently active. ``UNHEALTHY`` is reserved for the case where
+the underlying holder raises (e.g. lifespan never initialised it).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+from app.health.domain.entities import ComponentHealth, HealthStatus
+from app.health.domain.ports import HealthCheckPort
+
+
+class _SchedulerCheck(HealthCheckPort):
+    critical = False
+
+    def __init__(
+        self,
+        name: str,
+        is_running: Callable[[], bool],
+    ) -> None:
+        self.name = name
+        self._is_running = is_running
+
+    async def check(self) -> ComponentHealth:
+        start = time.monotonic()
+        try:
+            running = bool(self._is_running())
+        except Exception as exc:  # noqa: BLE001 — port contract
+            return ComponentHealth(
+                name=self.name,
+                status=HealthStatus.UNHEALTHY,
+                critical=self.critical,
+                message=f"{type(exc).__name__}: {exc}",
+                latency_ms=(time.monotonic() - start) * 1000.0,
+            )
+        latency_ms = (time.monotonic() - start) * 1000.0
+        if running:
+            return ComponentHealth(
+                name=self.name,
+                status=HealthStatus.HEALTHY,
+                critical=self.critical,
+                latency_ms=latency_ms,
+                metadata={"running": True},
+            )
+        return ComponentHealth(
+            name=self.name,
+            status=HealthStatus.DEGRADED,
+            critical=self.critical,
+            message="scheduler not running",
+            latency_ms=latency_ms,
+            metadata={"running": False},
+        )
+
+
+class BackupSchedulerHealthCheck(_SchedulerCheck):
+    """Pulls ``is_running`` lazily so a not-yet-initialised holder
+    surfaces as UNHEALTHY rather than raising at import time."""
+
+    def __init__(self) -> None:
+        super().__init__(name="backup_scheduler", is_running=_backup_running)
+
+
+class VersionUpdateSchedulerHealthCheck(_SchedulerCheck):
+    def __init__(self) -> None:
+        super().__init__(
+            name="version_update_scheduler",
+            is_running=_version_update_running,
+        )
+
+
+def _backup_running() -> bool:
+    # Late import: ``backup_scheduler_instance`` is populated during
+    # lifespan startup; importing at module load time would race the
+    # `_initialize_backup_scheduler()` step.
+    from app.backups import backup_scheduler_instance
+
+    return bool(backup_scheduler_instance.get().is_running)
+
+
+def _version_update_running() -> bool:
+    from app.versions.scheduler import version_update_scheduler
+
+    return bool(version_update_scheduler.is_running)

--- a/app/health/adapters/service_status_check.py
+++ b/app/health/adapters/service_status_check.py
@@ -1,0 +1,63 @@
+"""Bridge from the legacy ``ServiceStatus`` tracker to ``HealthCheckPort``.
+
+``ServiceStatus`` (in ``app.main``) tracks which startup phases
+succeeded during lifespan. We mirror its
+``database_integration_ready`` flag into a health component so the
+detail endpoint can show *both* live readiness (from
+``DatabaseHealthCheck``) and startup readiness (from the legacy
+tracker).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+from app.health.domain.entities import ComponentHealth, HealthStatus
+from app.health.domain.ports import HealthCheckPort
+
+
+class DatabaseIntegrationHealthCheck(HealthCheckPort):
+    """Read-only mirror of ``service_status.database_integration_ready``.
+
+    The flag flips at the end of ``_initialize_database_integration``
+    and never moves again, so we treat ``False`` as ``DEGRADED`` (the
+    rest of the app still works without it) rather than failing the
+    probe outright.
+    """
+
+    name = "database_integration"
+    critical = False
+
+    def __init__(self, get_ready: Callable[[], bool]) -> None:
+        self._get_ready = get_ready
+
+    async def check(self) -> ComponentHealth:
+        start = time.monotonic()
+        try:
+            ready = bool(self._get_ready())
+        except Exception as exc:  # noqa: BLE001 — port contract
+            return ComponentHealth(
+                name=self.name,
+                status=HealthStatus.UNHEALTHY,
+                critical=self.critical,
+                message=f"{type(exc).__name__}: {exc}",
+                latency_ms=(time.monotonic() - start) * 1000.0,
+            )
+        latency_ms = (time.monotonic() - start) * 1000.0
+        if ready:
+            return ComponentHealth(
+                name=self.name,
+                status=HealthStatus.HEALTHY,
+                critical=self.critical,
+                latency_ms=latency_ms,
+                metadata={"ready": True},
+            )
+        return ComponentHealth(
+            name=self.name,
+            status=HealthStatus.DEGRADED,
+            critical=self.critical,
+            message="database integration not initialised",
+            latency_ms=latency_ms,
+            metadata={"ready": False},
+        )

--- a/app/health/adapters/websocket_check.py
+++ b/app/health/adapters/websocket_check.py
@@ -1,0 +1,51 @@
+"""WebSocket monitoring health check.
+
+Reports whether the background ``WebSocketService._status_monitor_task``
+is alive. The probe uses the public ``is_monitoring()`` getter
+introduced by this change — adapters MUST NOT reach into the
+service's private state.
+"""
+
+from __future__ import annotations
+
+import time
+
+from app.health.domain.entities import ComponentHealth, HealthStatus
+from app.health.domain.ports import HealthCheckPort
+
+
+class WebSocketHealthCheck(HealthCheckPort):
+    name = "websocket_service"
+    critical = False
+
+    async def check(self) -> ComponentHealth:
+        start = time.monotonic()
+        try:
+            from app.websockets.application.service import websocket_service
+
+            monitoring = websocket_service.is_monitoring()
+        except Exception as exc:  # noqa: BLE001 — port contract
+            return ComponentHealth(
+                name=self.name,
+                status=HealthStatus.UNHEALTHY,
+                critical=self.critical,
+                message=f"{type(exc).__name__}: {exc}",
+                latency_ms=(time.monotonic() - start) * 1000.0,
+            )
+        latency_ms = (time.monotonic() - start) * 1000.0
+        if monitoring:
+            return ComponentHealth(
+                name=self.name,
+                status=HealthStatus.HEALTHY,
+                critical=self.critical,
+                latency_ms=latency_ms,
+                metadata={"monitoring": True},
+            )
+        return ComponentHealth(
+            name=self.name,
+            status=HealthStatus.DEGRADED,
+            critical=self.critical,
+            message="monitor task not running",
+            latency_ms=latency_ms,
+            metadata={"monitoring": False},
+        )

--- a/app/health/api/__init__.py
+++ b/app/health/api/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP surface for the health domain."""

--- a/app/health/api/dependencies.py
+++ b/app/health/api/dependencies.py
@@ -1,0 +1,69 @@
+"""FastAPI dependency wiring for the health domain.
+
+A single module-level ``HealthCheckService`` instance is cached
+between requests so the in-memory TTL cache survives — k8s probes
+hit at ~1 Hz and re-instantiating per request would defeat the
+point.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+from app.core.config import settings
+from app.core.database import engine
+from app.health.adapters.database_check import DatabaseHealthCheck
+from app.health.adapters.filesystem_check import FilesystemHealthCheck
+from app.health.adapters.scheduler_check import (
+    BackupSchedulerHealthCheck,
+    VersionUpdateSchedulerHealthCheck,
+)
+from app.health.adapters.service_status_check import DatabaseIntegrationHealthCheck
+from app.health.adapters.websocket_check import WebSocketHealthCheck
+from app.health.application.service import HealthCheckConfig, HealthCheckService
+
+
+def _build_config() -> HealthCheckConfig:
+    return HealthCheckConfig(
+        per_component_timeout_seconds=settings.HEALTH_CHECK_PER_COMPONENT_TIMEOUT_SECONDS,
+        global_timeout_seconds=settings.HEALTH_CHECK_GLOBAL_TIMEOUT_SECONDS,
+        cache_ttl_seconds=settings.HEALTH_CHECK_CACHE_TTL_SECONDS,
+    )
+
+
+def _resolve_database_integration_ready() -> bool:
+    """Late-bind to ``app.main.service_status`` to avoid an import
+    cycle (``app.main`` already imports ``app.health.api.router``).
+    """
+    from app.main import service_status
+
+    return bool(service_status.database_integration_ready)
+
+
+@lru_cache(maxsize=1)
+def get_health_check_service() -> HealthCheckService:
+    """Return the process-wide ``HealthCheckService`` singleton.
+
+    Lazy construction means tests can swap the adapters via
+    ``app.dependency_overrides`` without paying for unused probes.
+    """
+    return HealthCheckService(
+        checks=[
+            DatabaseHealthCheck(engine),
+            FilesystemHealthCheck(
+                paths=[Path("servers"), Path("backups")],
+                probe_writability=False,
+            ),
+            DatabaseIntegrationHealthCheck(_resolve_database_integration_ready),
+            BackupSchedulerHealthCheck(),
+            WebSocketHealthCheck(),
+            VersionUpdateSchedulerHealthCheck(),
+        ],
+        config=_build_config(),
+    )
+
+
+def reset_health_check_service_cache() -> None:
+    """Reset the singleton — used by tests that mutate settings."""
+    get_health_check_service.cache_clear()

--- a/app/health/api/router.py
+++ b/app/health/api/router.py
@@ -1,0 +1,190 @@
+"""Health / readiness HTTP router.
+
+Endpoint matrix (see PR description for the full table):
+
+* ``GET /healthz``                 — k8s liveness, no DB I/O.
+* ``GET /readyz`` / ``GET /ready`` — k8s readiness (alias), runs all
+  registered checks.
+* ``GET /api/v1/health/detail``    — admin-only verbose report.
+
+The legacy back-compat endpoints (``/health`` and ``/api/v1/health``)
+live in ``app.main`` so existing imports keep working; they now
+delegate to ``HealthCheckService`` via ``build_legacy_payload``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+
+from app.auth.dependencies import get_current_user
+from app.health.api.dependencies import get_health_check_service
+from app.health.api.schemas import (
+    ComponentHealthResponse,
+    HealthResponse,
+    LegacyHealthResponse,
+)
+from app.health.application.service import HealthCheckService
+from app.health.domain.entities import HealthStatus, OverallHealth
+from app.servers.application.authorization import AuthorizationService
+from app.users.models import User
+
+router = APIRouter(tags=["health"])
+
+
+def _to_response(overall: OverallHealth) -> HealthResponse:
+    return HealthResponse(
+        status=overall.status,
+        checked_at=overall.checked_at,
+        components=[
+            ComponentHealthResponse(
+                name=c.name,
+                status=c.status,
+                critical=c.critical,
+                message=c.message,
+                latency_ms=c.latency_ms,
+                checked_at=c.checked_at,
+                metadata=dict(c.metadata),
+            )
+            for c in overall.components
+        ],
+    )
+
+
+@router.get(
+    "/healthz",
+    response_model=HealthResponse,
+    summary="Kubernetes liveness probe",
+)
+async def liveness(
+    service: HealthCheckService = Depends(get_health_check_service),
+) -> HealthResponse:
+    """Cheap liveness probe — never touches the database."""
+    return _to_response(service.liveness())
+
+
+async def _readiness_response(service: HealthCheckService) -> Response:
+    overall = await service.readiness()
+    payload = _to_response(overall).model_dump(mode="json")
+    status_code = 200 if overall.is_ready else 503
+    return Response(
+        content=json.dumps(payload),
+        status_code=status_code,
+        media_type="application/json",
+    )
+
+
+@router.get(
+    "/readyz",
+    summary="Kubernetes readiness probe",
+    responses={200: {"model": HealthResponse}, 503: {"model": HealthResponse}},
+)
+async def readiness(
+    service: HealthCheckService = Depends(get_health_check_service),
+) -> Response:
+    """Aggregates every registered check; 503 if any critical component fails."""
+    return await _readiness_response(service)
+
+
+@router.get(
+    "/ready",
+    summary="Readiness probe (alias of /readyz)",
+    responses={200: {"model": HealthResponse}, 503: {"model": HealthResponse}},
+)
+async def readiness_alias(
+    service: HealthCheckService = Depends(get_health_check_service),
+) -> Response:
+    return await _readiness_response(service)
+
+
+@router.get(
+    "/api/v1/health/detail",
+    response_model=HealthResponse,
+    summary="Detailed health report (admin only)",
+)
+async def health_detail(
+    current_user: User = Depends(get_current_user),
+    service: HealthCheckService = Depends(get_health_check_service),
+) -> HealthResponse:
+    """Admin-only verbose report.
+
+    Bypasses the TTL cache so the operator always sees live data, and
+    returns 200 regardless of readiness — the response body carries
+    the diagnostic status so admins can inspect a failing system
+    without the 503 short-circuiting downstream tooling.
+    """
+    if not AuthorizationService.is_admin(current_user):
+        raise HTTPException(
+            status_code=403,
+            detail="Only administrators can view detailed health data",
+        )
+    overall = await service.readiness(use_cache=False)
+    return _to_response(overall)
+
+
+# ---------------------------------------------------------------------------
+# Legacy back-compat helper
+# ---------------------------------------------------------------------------
+
+
+_LEGACY_NAME_MAP = {
+    "database": "database",
+    "database_integration": "database_integration",
+    "backup_scheduler": "backup_scheduler",
+    "websocket_service": "websocket_service",
+    "version_update_scheduler": "version_update_scheduler",
+}
+
+
+async def build_legacy_payload(service: HealthCheckService) -> tuple[dict[str, Any], int]:
+    """Render an ``OverallHealth`` into the pre-#21 ``LegacyHealthResponse`` shape.
+
+    Returns ``(payload, status_code)``. The status code rules match
+    the previous implementation: 503 when the database (the only
+    truly critical component) is failing, 200 otherwise — including
+    ``status="degraded"``.
+    """
+    overall = await service.readiness()
+    by_name = {c.name: c for c in overall.components}
+
+    services: dict[str, str] = {}
+    failed_services: list[str] = []
+    for legacy_key, component_name in _LEGACY_NAME_MAP.items():
+        component = by_name.get(component_name)
+        if component is None or component.status is HealthStatus.HEALTHY:
+            services[legacy_key] = "operational"
+        else:
+            services[legacy_key] = "failed"
+            failed_services.append(legacy_key)
+
+    db_component = by_name.get("database")
+    db_healthy = db_component is not None and db_component.status is HealthStatus.HEALTHY
+
+    if db_healthy:
+        top_status = "healthy"
+        message = (
+            "All services operational"
+            if not failed_services
+            else "Running with degraded functionality: " + ", ".join(failed_services)
+        )
+        status_code = 200
+    else:
+        top_status = "degraded"
+        message = (
+            "Running with degraded functionality: " + ", ".join(failed_services)
+            if failed_services
+            else "Database unavailable"
+        )
+        status_code = 503
+
+    payload = LegacyHealthResponse(
+        status=top_status,
+        timestamp=datetime.now(timezone.utc),
+        services=services,
+        failed_services=failed_services,
+        message=message,
+    ).model_dump(mode="json")
+    return payload, status_code

--- a/app/health/api/schemas.py
+++ b/app/health/api/schemas.py
@@ -1,0 +1,43 @@
+"""Pydantic DTOs for the health/readiness endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Mapping, Optional
+
+from pydantic import BaseModel, Field
+
+from app.health.domain.entities import HealthStatus
+
+
+class ComponentHealthResponse(BaseModel):
+    name: str
+    status: HealthStatus
+    critical: bool
+    message: Optional[str] = None
+    latency_ms: Optional[float] = None
+    checked_at: datetime
+    metadata: Mapping[str, Any] = Field(default_factory=dict)
+
+
+class HealthResponse(BaseModel):
+    """Standard response shape for liveness / readiness / detail."""
+
+    status: HealthStatus
+    checked_at: datetime
+    components: list[ComponentHealthResponse] = Field(default_factory=list)
+
+
+class LegacyHealthResponse(BaseModel):
+    """Back-compat shape returned by ``/health`` and ``/api/v1/health``.
+
+    Matches the structure emitted by the pre-#21 endpoints so existing
+    dashboards keep working. Internally the values come from the new
+    ``HealthCheckService``, but the wire format does not change.
+    """
+
+    status: str
+    timestamp: datetime
+    services: dict[str, str]
+    failed_services: list[str]
+    message: str

--- a/app/health/application/__init__.py
+++ b/app/health/application/__init__.py
@@ -1,0 +1,5 @@
+"""Application layer for the health domain.
+
+Per ARCHITECTURE §4.2 this layer is framework-agnostic — it must not
+import FastAPI, Starlette or any other transport concern.
+"""

--- a/app/health/application/service.py
+++ b/app/health/application/service.py
@@ -1,0 +1,197 @@
+"""HealthCheckService — aggregates per-component probes.
+
+Responsibilities:
+
+* Run every registered ``HealthCheckPort`` with a per-component
+  timeout so a single slow check cannot block the whole probe.
+* Cache the last aggregated result for a short TTL — k8s probes us at
+  ~1 Hz and a flood of liveness traffic should not amplify into a
+  flood of database connections.
+* Provide a separate liveness path that does *not* touch dependencies
+  (kubelet liveness probes must remain cheap and self-contained).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Sequence
+
+from app.health.domain.entities import (
+    ComponentHealth,
+    HealthStatus,
+    OverallHealth,
+    aggregate,
+)
+from app.health.domain.ports import HealthCheckPort
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class HealthCheckConfig:
+    """Service-level knobs.
+
+    All values come from ``app.core.config.settings`` — this dataclass
+    just bundles them so the service stays decoupled from pydantic.
+    """
+
+    per_component_timeout_seconds: float = 2.0
+    global_timeout_seconds: float = 5.0
+    cache_ttl_seconds: float = 2.0
+
+
+class HealthCheckService:
+    """Composes ``HealthCheckPort`` adapters into an ``OverallHealth``.
+
+    The service is meant to be instantiated once per process (it owns
+    the cache). Tests should construct a fresh instance per scenario.
+    """
+
+    def __init__(
+        self,
+        checks: Sequence[HealthCheckPort],
+        config: HealthCheckConfig | None = None,
+    ) -> None:
+        self._checks = list(checks)
+        self._config = config or HealthCheckConfig()
+        # Cache stores ``(monotonic_timestamp, OverallHealth)`` so
+        # eviction stays oblivious to wall-clock jumps.
+        self._cache: tuple[float, OverallHealth] | None = None
+        self._cache_lock = asyncio.Lock()
+
+    @property
+    def config(self) -> HealthCheckConfig:
+        return self._config
+
+    @property
+    def checks(self) -> list[HealthCheckPort]:
+        """Expose registered checks for debugging / introspection."""
+        return list(self._checks)
+
+    def liveness(self) -> OverallHealth:
+        """Cheap synchronous liveness signal.
+
+        Returns ``HEALTHY`` as long as the process is responsive enough
+        to execute Python. No dependency I/O is performed. The
+        component list is intentionally empty — ``/healthz`` only needs
+        the top-level status code.
+        """
+        now = datetime.now(timezone.utc)
+        return OverallHealth(
+            status=HealthStatus.HEALTHY,
+            components=[],
+            checked_at=now,
+        )
+
+    async def readiness(self, *, use_cache: bool = True) -> OverallHealth:
+        """Run every registered check and return the aggregate.
+
+        Args:
+            use_cache: ``True`` (default) honours the configured TTL;
+                ``False`` forces a fresh evaluation (used by
+                ``/api/v1/health/detail`` so admins always see live
+                data when debugging).
+        """
+        if use_cache:
+            cached = self._read_cache()
+            if cached is not None:
+                return cached
+
+        async with self._cache_lock:
+            # Re-check after acquiring the lock — another coroutine
+            # may have populated the cache while we waited.
+            if use_cache:
+                cached = self._read_cache()
+                if cached is not None:
+                    return cached
+
+            components = await self._run_all()
+            overall = OverallHealth(
+                status=aggregate(components),
+                components=components,
+                checked_at=datetime.now(timezone.utc),
+            )
+            self._cache = (time.monotonic(), overall)
+            return overall
+
+    def _read_cache(self) -> OverallHealth | None:
+        if self._cache is None:
+            return None
+        stored_at, value = self._cache
+        if (time.monotonic() - stored_at) <= self._config.cache_ttl_seconds:
+            return value
+        return None
+
+    async def _run_all(self) -> list[ComponentHealth]:
+        """Run all checks concurrently with a global guardrail.
+
+        Each probe is also wrapped in its own ``wait_for`` so a slow
+        adapter degrades gracefully without dragging down its peers.
+        """
+
+        async def _run_one(check: HealthCheckPort) -> ComponentHealth:
+            start = time.monotonic()
+            try:
+                result = await asyncio.wait_for(
+                    check.check(),
+                    timeout=self._config.per_component_timeout_seconds,
+                )
+                return result
+            except asyncio.TimeoutError:
+                elapsed_ms = (time.monotonic() - start) * 1000.0
+                logger.warning(
+                    "Health check timed out: name=%s timeout=%.2fs",
+                    check.name,
+                    self._config.per_component_timeout_seconds,
+                )
+                return ComponentHealth(
+                    name=check.name,
+                    status=HealthStatus.UNHEALTHY,
+                    critical=check.critical,
+                    message=(
+                        f"timeout after {self._config.per_component_timeout_seconds:.2f}s"
+                    ),
+                    latency_ms=elapsed_ms,
+                )
+            except Exception as exc:  # noqa: BLE001 — adapter contract
+                # Adapters SHOULD NOT raise (see HealthCheckPort
+                # contract); if one does, surface the failure rather
+                # than poisoning the whole probe.
+                elapsed_ms = (time.monotonic() - start) * 1000.0
+                logger.exception("Health check raised unexpectedly: name=%s", check.name)
+                return ComponentHealth(
+                    name=check.name,
+                    status=HealthStatus.UNHEALTHY,
+                    critical=check.critical,
+                    message=f"{type(exc).__name__}: {exc}",
+                    latency_ms=elapsed_ms,
+                )
+
+        try:
+            return await asyncio.wait_for(
+                asyncio.gather(*[_run_one(c) for c in self._checks]),
+                timeout=self._config.global_timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            # Global guardrail tripped — synthesize an UNHEALTHY
+            # component per registered check so the response still
+            # carries useful diagnostic shape.
+            logger.error(
+                "Global health check timed out after %.2fs",
+                self._config.global_timeout_seconds,
+            )
+            return [
+                ComponentHealth(
+                    name=check.name,
+                    status=HealthStatus.UNHEALTHY,
+                    critical=check.critical,
+                    message=(
+                        f"global timeout after {self._config.global_timeout_seconds:.2f}s"
+                    ),
+                )
+                for check in self._checks
+            ]

--- a/app/health/domain/__init__.py
+++ b/app/health/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Health domain layer (entities + ports)."""

--- a/app/health/domain/entities.py
+++ b/app/health/domain/entities.py
@@ -1,0 +1,82 @@
+"""Framework-agnostic health entities.
+
+Three statuses model the typical traffic-light readiness convention:
+
+* ``HEALTHY``    — the component answered within its budget.
+* ``DEGRADED``   — the component answered but reported a non-fatal
+  warning (e.g. a non-critical scheduler is not running).
+* ``UNHEALTHY``  — the component failed or timed out.
+
+``OverallHealth.status`` is derived from the worst component status,
+constrained by ``critical``:
+
+* any critical component ``UNHEALTHY`` => overall ``UNHEALTHY``
+* otherwise, if any component ``UNHEALTHY`` or ``DEGRADED`` => overall
+  ``DEGRADED``
+* else ``HEALTHY``
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Mapping
+
+
+class HealthStatus(str, Enum):
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNHEALTHY = "unhealthy"
+
+
+_EMPTY_METADATA: Mapping[str, Any] = MappingProxyType({})
+
+
+@dataclass(frozen=True)
+class ComponentHealth:
+    """Result of a single ``HealthCheckPort.check()`` invocation."""
+
+    name: str
+    status: HealthStatus
+    critical: bool
+    message: str | None = None
+    latency_ms: float | None = None
+    checked_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    metadata: Mapping[str, Any] = field(default_factory=lambda: _EMPTY_METADATA)
+
+
+@dataclass(frozen=True)
+class OverallHealth:
+    """Aggregate readiness result returned by ``HealthCheckService``."""
+
+    status: HealthStatus
+    components: list[ComponentHealth]
+    checked_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @property
+    def is_ready(self) -> bool:
+        """True iff no critical component is unhealthy.
+
+        Used by ``/readyz`` to decide between 200 and 503. Degraded
+        non-critical components keep the probe at 200 so kubelet does
+        not yank traffic during a transient backup-scheduler hiccup.
+        """
+        return not any(
+            c.critical and c.status is HealthStatus.UNHEALTHY for c in self.components
+        )
+
+
+def aggregate(components: list[ComponentHealth]) -> HealthStatus:
+    """Reduce per-component statuses to an overall status.
+
+    See module docstring for the rules.
+    """
+    if any(c.critical and c.status is HealthStatus.UNHEALTHY for c in components):
+        return HealthStatus.UNHEALTHY
+    if any(
+        c.status in (HealthStatus.UNHEALTHY, HealthStatus.DEGRADED) for c in components
+    ):
+        return HealthStatus.DEGRADED
+    return HealthStatus.HEALTHY

--- a/app/health/domain/ports.py
+++ b/app/health/domain/ports.py
@@ -1,0 +1,29 @@
+"""Ports exposed by the health domain.
+
+The single ``HealthCheckPort`` is intentionally tiny: each component
+adapter implements ``check()`` returning a ``ComponentHealth``. The
+application service composes them, applies per-component timeouts,
+and aggregates results.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from app.health.domain.entities import ComponentHealth
+
+
+@runtime_checkable
+class HealthCheckPort(Protocol):
+    """Single-component health probe.
+
+    Implementations MUST NOT raise — translate failures into a
+    ``ComponentHealth`` carrying ``HealthStatus.UNHEALTHY`` and a
+    diagnostic ``message``. The aggregating service relies on this
+    invariant to avoid one flaky adapter taking down the whole probe.
+    """
+
+    name: str
+    critical: bool
+
+    async def check(self) -> ComponentHealth: ...

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ import logging
 from contextlib import asynccontextmanager
 from typing import Any, Dict
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app import __version__
@@ -20,6 +20,10 @@ from app.core.error_handlers import register_exception_handlers
 from app.core.visibility_router import router as visibility_router
 from app.files.router import router as files_router
 from app.groups.router import router as groups_router
+from app.health.api.dependencies import get_health_check_service
+from app.health.api.router import build_legacy_payload
+from app.health.api.router import router as health_router
+from app.health.application.service import HealthCheckService
 from app.middleware.audit_middleware import AuditMiddleware
 from app.middleware.performance_monitoring import (
     PerformanceMonitoringMiddleware,
@@ -400,93 +404,43 @@ register_exception_handlers(app)
 
 
 @app.get("/health", tags=["health"])
-async def health_check():
-    """Health check endpoint with service status information"""
+async def health_check(
+    service: HealthCheckService = Depends(get_health_check_service),
+):
+    """Legacy health check endpoint.
+
+    Wire format is preserved for backward compatibility; the actual
+    component evaluation is delegated to ``HealthCheckService`` (Issue
+    #21). New consumers should prefer ``/healthz``, ``/readyz``, or
+    ``/api/v1/health/detail``.
+    """
     import json
-    from datetime import datetime
 
     from fastapi import Response
 
-    status = service_status.get_status()
-
-    response_data = {
-        "status": "healthy" if status["healthy"] else "degraded",
-        "timestamp": datetime.now().isoformat(),
-        "services": {
-            "database": "operational" if status["database"] else "failed",
-            "database_integration": (
-                "operational" if status["database_integration"] else "failed"
-            ),
-            "backup_scheduler": "operational" if status["backup_scheduler"] else "failed",
-            "websocket_service": (
-                "operational" if status["websocket_service"] else "failed"
-            ),
-            "version_update_scheduler": (
-                "operational" if status["version_update_scheduler"] else "failed"
-            ),
-        },
-        "failed_services": status["failed_services"],
-        "message": (
-            "All services operational"
-            if status["healthy"]
-            else f"Running with degraded functionality: {', '.join(status['failed_services'])}"
-        ),
-    }
-
-    # Return appropriate HTTP status based on service health
-    if not status["healthy"]:
-        return Response(
-            content=json.dumps(response_data),
-            status_code=503,
-            media_type="application/json",
-        )
-
-    return response_data
+    payload, status_code = await build_legacy_payload(service)
+    return Response(
+        content=json.dumps(payload),
+        status_code=status_code,
+        media_type="application/json",
+    )
 
 
 @app.get("/api/v1/health", tags=["health"])
-async def health_check_v1():
-    """Health check endpoint with service status information"""
+async def health_check_v1(
+    service: HealthCheckService = Depends(get_health_check_service),
+):
+    """Legacy ``/api/v1/health`` alias — see :func:`health_check`."""
     import json
-    from datetime import datetime
 
     from fastapi import Response
 
-    status = service_status.get_status()
-
-    response_data = {
-        "status": "healthy" if status["healthy"] else "degraded",
-        "timestamp": datetime.now().isoformat(),
-        "services": {
-            "database": "operational" if status["database"] else "failed",
-            "database_integration": (
-                "operational" if status["database_integration"] else "failed"
-            ),
-            "backup_scheduler": "operational" if status["backup_scheduler"] else "failed",
-            "websocket_service": (
-                "operational" if status["websocket_service"] else "failed"
-            ),
-            "version_update_scheduler": (
-                "operational" if status["version_update_scheduler"] else "failed"
-            ),
-        },
-        "failed_services": status["failed_services"],
-        "message": (
-            "All services operational"
-            if status["healthy"]
-            else f"Running with degraded functionality: {', '.join(status['failed_services'])}"
-        ),
-    }
-
-    # Return appropriate HTTP status based on service health
-    if not status["healthy"]:
-        return Response(
-            content=json.dumps(response_data),
-            status_code=503,
-            media_type="application/json",
-        )
-
-    return response_data
+    payload, status_code = await build_legacy_payload(service)
+    return Response(
+        content=json.dumps(payload),
+        status_code=status_code,
+        media_type="application/json",
+    )
 
 
 @app.get("/metrics", tags=["monitoring"])
@@ -557,3 +511,9 @@ app.include_router(versions_router, prefix="/api/v1/versions", tags=["versions"]
 app.include_router(websockets_router, prefix="/api/v1/ws", tags=["websockets"])
 app.include_router(visibility_router, prefix="/api/v1", tags=["visibility"])
 app.include_router(audit_router, tags=["audit"])
+
+# Health / readiness endpoints (Issue #21). Mounted without a prefix
+# so ``/healthz``, ``/readyz`` and ``/ready`` keep their canonical
+# k8s paths; the admin detail endpoint declares its own
+# ``/api/v1/health/detail`` path on the route.
+app.include_router(health_router)

--- a/app/middleware/audit_middleware.py
+++ b/app/middleware/audit_middleware.py
@@ -217,6 +217,10 @@ class AuditMiddleware(BaseHTTPMiddleware):
         if self.exclude_health_checks and request.url.path in [
             "/health",
             "/api/v1/health",
+            "/healthz",
+            "/readyz",
+            "/ready",
+            "/api/v1/health/detail",
             "/metrics",
             "/api/v1/metrics",
             "/monitoring",

--- a/app/middleware/performance_monitoring.py
+++ b/app/middleware/performance_monitoring.py
@@ -209,6 +209,10 @@ class PerformanceMonitoringMiddleware(BaseHTTPMiddleware):
         if request.url.path in [
             "/health",
             "/api/v1/health",
+            "/healthz",
+            "/readyz",
+            "/ready",
+            "/api/v1/health/detail",
             "/metrics",
             "/api/v1/metrics",
             "/monitoring",

--- a/app/websockets/application/service.py
+++ b/app/websockets/application/service.py
@@ -202,6 +202,16 @@ class WebSocketService:
             except asyncio.CancelledError:
                 pass
 
+    def is_monitoring(self) -> bool:
+        """Whether the background status monitor task is currently alive.
+
+        Public accessor introduced for the health-check adapter
+        (Issue #21) so consumers do not have to touch the private
+        ``_status_monitor_task`` attribute.
+        """
+        task = self._status_monitor_task
+        return task is not None and not task.done()
+
     async def handle_connection(
         self, websocket: WebSocket, server_id: int, user: User, db: Session
     ):

--- a/tests/integration/core/_health_helpers.py
+++ b/tests/integration/core/_health_helpers.py
@@ -1,0 +1,87 @@
+"""Test helpers for the legacy ``/health`` / ``/api/v1/health`` endpoints.
+
+Post-#21 the legacy endpoints delegate to ``HealthCheckService`` while
+keeping their pre-existing wire format. These helpers build canned
+component fixtures and the ``override_health_service`` context
+manager that swaps the FastAPI dependency for the duration of a test.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Iterable, Iterator
+
+from app.health.api.dependencies import get_health_check_service
+from app.health.application.service import HealthCheckConfig, HealthCheckService
+from app.health.domain.entities import (
+    ComponentHealth,
+    HealthStatus,
+    OverallHealth,
+    aggregate,
+)
+from app.main import app
+
+
+class _StubService(HealthCheckService):
+    def __init__(self, overall: OverallHealth) -> None:
+        super().__init__(
+            checks=[],
+            config=HealthCheckConfig(
+                per_component_timeout_seconds=1.0,
+                global_timeout_seconds=2.0,
+                cache_ttl_seconds=0.0,
+            ),
+        )
+        self._overall = overall
+
+    async def readiness(self, *, use_cache: bool = True) -> OverallHealth:
+        return self._overall
+
+
+@contextmanager
+def override_health_service(
+    components: Iterable[ComponentHealth],
+) -> Iterator[None]:
+    """Override ``get_health_check_service`` for the duration of a test."""
+    comp_list = list(components)
+    overall = OverallHealth(
+        status=aggregate(comp_list),
+        components=comp_list,
+        checked_at=datetime.now(timezone.utc),
+    )
+    app.dependency_overrides[get_health_check_service] = lambda: _StubService(overall)
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_health_check_service, None)
+
+
+def unhealthy_database_components() -> list[ComponentHealth]:
+    return [
+        ComponentHealth(
+            name="database",
+            status=HealthStatus.UNHEALTHY,
+            critical=True,
+            message="connection refused",
+        ),
+        ComponentHealth(name="filesystem", status=HealthStatus.HEALTHY, critical=True),
+    ]
+
+
+def partial_failure_components() -> list[ComponentHealth]:
+    """Database healthy, two non-critical subsystems down."""
+    return [
+        ComponentHealth(name="database", status=HealthStatus.HEALTHY, critical=True),
+        ComponentHealth(name="filesystem", status=HealthStatus.HEALTHY, critical=True),
+        ComponentHealth(
+            name="database_integration",
+            status=HealthStatus.DEGRADED,
+            critical=False,
+        ),
+        ComponentHealth(
+            name="backup_scheduler",
+            status=HealthStatus.DEGRADED,
+            critical=False,
+        ),
+    ]

--- a/tests/integration/core/test_lifespan.py
+++ b/tests/integration/core/test_lifespan.py
@@ -140,48 +140,42 @@ class TestHealthEndpointComprehensive:
             assert data["failed_services"] == []
 
     def test_health_endpoint_unhealthy_database(self, client):
-        """Test health endpoint when database is unhealthy"""
-        with patch("app.main.service_status") as mock_status:
-            mock_status.is_healthy.return_value = False
-            mock_status.get_status.return_value = {
-                "database": False,
-                "database_integration": True,
-                "backup_scheduler": True,
-                "websocket_service": True,
-                "version_update_scheduler": True,
-                "failed_services": ["database"],
-                "healthy": False,
-            }
+        """Test health endpoint when database is unhealthy.
 
+        Post-#21: the legacy wire format is preserved, but the
+        underlying evaluation goes through ``HealthCheckService``. We
+        therefore override the service rather than poking
+        ``service_status``.
+        """
+        from tests.integration.core._health_helpers import (
+            override_health_service,
+            unhealthy_database_components,
+        )
+
+        with override_health_service(unhealthy_database_components()):
             response = client.get("/api/v1/health")
 
-            assert response.status_code == 503
-            data = response.json()
-            assert data["status"] == "degraded"
-            assert data["services"]["database"] == "failed"
-            assert "database" in data["failed_services"]
+        assert response.status_code == 503
+        data = response.json()
+        assert data["status"] == "degraded"
+        assert data["services"]["database"] == "failed"
+        assert "database" in data["failed_services"]
 
     def test_health_endpoint_partial_failures(self, client):
-        """Test health endpoint with some failed services"""
-        with patch("app.main.service_status") as mock_status:
-            mock_status.is_healthy.return_value = True  # Database is healthy
-            mock_status.get_status.return_value = {
-                "database": True,
-                "database_integration": False,
-                "backup_scheduler": False,
-                "websocket_service": True,
-                "version_update_scheduler": True,
-                "failed_services": ["database_integration", "backup_scheduler"],
-                "healthy": True,
-            }
+        """Test health endpoint with some failed services (#21 wire compat)."""
+        from tests.integration.core._health_helpers import (
+            override_health_service,
+            partial_failure_components,
+        )
 
+        with override_health_service(partial_failure_components()):
             response = client.get("/api/v1/health")
 
-            assert response.status_code == 200  # Still healthy due to database
-            data = response.json()
-            assert data["status"] == "healthy"
-            assert data["services"]["database"] == "operational"
-            assert len(data["failed_services"]) == 2
+        assert response.status_code == 200  # Still healthy due to database
+        data = response.json()
+        assert data["status"] == "healthy"
+        assert data["services"]["database"] == "operational"
+        assert len(data["failed_services"]) == 2
 
     def test_metrics_endpoint_basic_functionality(self, client):
         """Test metrics endpoint returns expected structure"""
@@ -655,26 +649,20 @@ class TestApiV1EndpointsNew:
             assert data["failed_services"] == []
 
     def test_api_v1_health_endpoint_unhealthy_database(self, client):
-        """Test /api/v1/health endpoint when database is unhealthy"""
-        with patch("app.main.service_status") as mock_status:
-            mock_status.is_healthy.return_value = False
-            mock_status.get_status.return_value = {
-                "database": False,
-                "database_integration": True,
-                "backup_scheduler": True,
-                "websocket_service": True,
-                "version_update_scheduler": True,
-                "failed_services": ["database"],
-                "healthy": False,
-            }
+        """Test /api/v1/health endpoint when database is unhealthy (#21 wire compat)."""
+        from tests.integration.core._health_helpers import (
+            override_health_service,
+            unhealthy_database_components,
+        )
 
+        with override_health_service(unhealthy_database_components()):
             response = client.get("/api/v1/health")
 
-            assert response.status_code == 503
-            data = response.json()
-            assert data["status"] == "degraded"
-            assert data["services"]["database"] == "failed"
-            assert "database" in data["failed_services"]
+        assert response.status_code == 503
+        data = response.json()
+        assert data["status"] == "degraded"
+        assert data["services"]["database"] == "failed"
+        assert "database" in data["failed_services"]
 
     def test_api_v1_metrics_endpoint_basic_functionality(self, client):
         """Test /api/v1/metrics endpoint returns expected structure"""

--- a/tests/integration/health/test_endpoints.py
+++ b/tests/integration/health/test_endpoints.py
@@ -1,0 +1,268 @@
+"""Integration tests for the health/readiness endpoints.
+
+Uses ``app.dependency_overrides`` to swap the ``HealthCheckService``
+for a stub whose readiness payload we control directly. This avoids
+flakiness from probing real schedulers / WebSocket task state during
+unit-style integration tests.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Sequence
+
+import pytest
+
+from app.health.api.dependencies import get_health_check_service
+from app.health.application.service import HealthCheckConfig, HealthCheckService
+from app.health.domain.entities import (
+    ComponentHealth,
+    HealthStatus,
+    OverallHealth,
+)
+from app.main import app
+
+
+class _StubService(HealthCheckService):
+    """Minimal stub: pre-computed ``OverallHealth`` short-circuits readiness."""
+
+    def __init__(self, overall: OverallHealth) -> None:
+        super().__init__(
+            checks=[],
+            config=HealthCheckConfig(
+                per_component_timeout_seconds=1.0,
+                global_timeout_seconds=2.0,
+                cache_ttl_seconds=0.0,
+            ),
+        )
+        self._overall = overall
+
+    async def readiness(self, *, use_cache: bool = True) -> OverallHealth:
+        return self._overall
+
+
+def _make_overall(*components: ComponentHealth) -> OverallHealth:
+    from app.health.domain.entities import aggregate
+
+    return OverallHealth(
+        status=aggregate(list(components)),
+        components=list(components),
+        checked_at=datetime.now(timezone.utc),
+    )
+
+
+def _override_with(components: Sequence[ComponentHealth]):
+    overall = _make_overall(*components)
+    app.dependency_overrides[get_health_check_service] = lambda: _StubService(overall)
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    app.dependency_overrides.pop(get_health_check_service, None)
+
+
+# ---------------------------------------------------------------------------
+# /healthz — liveness
+# ---------------------------------------------------------------------------
+
+
+def test_healthz_returns_200_without_db_check(client):
+    # Even with a failing DB stub, liveness must not run readiness.
+    _override_with(
+        [
+            ComponentHealth(
+                name="database",
+                status=HealthStatus.UNHEALTHY,
+                critical=True,
+            )
+        ]
+    )
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "healthy"
+    assert body["components"] == []
+
+
+# ---------------------------------------------------------------------------
+# /readyz and its alias /ready
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", ["/readyz", "/ready"])
+def test_readiness_200_when_all_healthy(client, path):
+    _override_with(
+        [
+            ComponentHealth(name="database", status=HealthStatus.HEALTHY, critical=True),
+            ComponentHealth(
+                name="filesystem", status=HealthStatus.HEALTHY, critical=True
+            ),
+        ]
+    )
+    response = client.get(path)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "healthy"
+    assert {c["name"] for c in body["components"]} == {"database", "filesystem"}
+
+
+@pytest.mark.parametrize("path", ["/readyz", "/ready"])
+def test_readiness_503_when_critical_fails(client, path):
+    _override_with(
+        [
+            ComponentHealth(
+                name="database",
+                status=HealthStatus.UNHEALTHY,
+                critical=True,
+                message="connection refused",
+            ),
+        ]
+    )
+    response = client.get(path)
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "unhealthy"
+
+
+@pytest.mark.parametrize("path", ["/readyz", "/ready"])
+def test_readiness_200_when_only_non_critical_fails(client, path):
+    _override_with(
+        [
+            ComponentHealth(name="database", status=HealthStatus.HEALTHY, critical=True),
+            ComponentHealth(
+                name="backup_scheduler",
+                status=HealthStatus.DEGRADED,
+                critical=False,
+            ),
+        ]
+    )
+    response = client.get(path)
+    # Non-critical degradation does not flip status code to 503.
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "degraded"
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/health/detail — admin only
+# ---------------------------------------------------------------------------
+
+
+def test_detail_requires_auth(client):
+    response = client.get("/api/v1/health/detail")
+    assert response.status_code in (401, 403)
+
+
+def test_detail_rejects_non_admin(client, user_headers):
+    _override_with(
+        [ComponentHealth(name="database", status=HealthStatus.HEALTHY, critical=True)]
+    )
+    response = client.get("/api/v1/health/detail", headers=user_headers)
+    assert response.status_code == 403
+
+
+def test_detail_allows_admin(client, admin_headers):
+    _override_with(
+        [
+            ComponentHealth(name="database", status=HealthStatus.HEALTHY, critical=True),
+            ComponentHealth(
+                name="backup_scheduler",
+                status=HealthStatus.DEGRADED,
+                critical=False,
+                message="not running",
+            ),
+        ]
+    )
+    response = client.get("/api/v1/health/detail", headers=admin_headers)
+    assert response.status_code == 200
+    body = response.json()
+    names = {c["name"] for c in body["components"]}
+    assert names == {"database", "backup_scheduler"}
+    # Detail endpoint returns 200 even with degraded components so
+    # admins can inspect a failing system; the body carries the state.
+    assert body["status"] == "degraded"
+
+
+# ---------------------------------------------------------------------------
+# Legacy /health and /api/v1/health — wire format preserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", ["/health", "/api/v1/health"])
+def test_legacy_health_shape_when_healthy(client, path):
+    _override_with(
+        [
+            ComponentHealth(name="database", status=HealthStatus.HEALTHY, critical=True),
+            ComponentHealth(
+                name="filesystem", status=HealthStatus.HEALTHY, critical=True
+            ),
+            ComponentHealth(
+                name="database_integration",
+                status=HealthStatus.HEALTHY,
+                critical=False,
+            ),
+            ComponentHealth(
+                name="backup_scheduler",
+                status=HealthStatus.HEALTHY,
+                critical=False,
+            ),
+            ComponentHealth(
+                name="websocket_service",
+                status=HealthStatus.HEALTHY,
+                critical=False,
+            ),
+            ComponentHealth(
+                name="version_update_scheduler",
+                status=HealthStatus.HEALTHY,
+                critical=False,
+            ),
+        ]
+    )
+    response = client.get(path)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "healthy"
+    assert body["services"]["database"] == "operational"
+    assert body["services"]["backup_scheduler"] == "operational"
+    assert body["failed_services"] == []
+    assert "All services operational" in body["message"]
+
+
+@pytest.mark.parametrize("path", ["/health", "/api/v1/health"])
+def test_legacy_health_503_when_db_fails(client, path):
+    _override_with(
+        [
+            ComponentHealth(
+                name="database",
+                status=HealthStatus.UNHEALTHY,
+                critical=True,
+            ),
+        ]
+    )
+    response = client.get(path)
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "degraded"
+    assert "database" in body["failed_services"]
+
+
+@pytest.mark.parametrize("path", ["/health", "/api/v1/health"])
+def test_legacy_health_200_when_only_non_critical_fails(client, path):
+    _override_with(
+        [
+            ComponentHealth(name="database", status=HealthStatus.HEALTHY, critical=True),
+            ComponentHealth(
+                name="backup_scheduler",
+                status=HealthStatus.UNHEALTHY,
+                critical=False,
+            ),
+        ]
+    )
+    response = client.get(path)
+    # Pre-#21 behaviour: DB-up means 200 even if subsystems failed.
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "healthy"
+    assert body["services"]["backup_scheduler"] == "failed"
+    assert body["failed_services"] == ["backup_scheduler"]

--- a/tests/unit/health/test_adapters.py
+++ b/tests/unit/health/test_adapters.py
@@ -1,0 +1,127 @@
+"""Unit tests for the ``app.health.adapters.*`` checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+
+from app.health.adapters.database_check import DatabaseHealthCheck
+from app.health.adapters.filesystem_check import FilesystemHealthCheck
+from app.health.adapters.scheduler_check import _SchedulerCheck
+from app.health.adapters.service_status_check import DatabaseIntegrationHealthCheck
+from app.health.adapters.websocket_check import WebSocketHealthCheck
+from app.health.domain.entities import HealthStatus
+
+
+class TestDatabaseHealthCheck:
+    @pytest.mark.asyncio
+    async def test_healthy_engine(self) -> None:
+        engine = create_engine("sqlite:///:memory:")
+        result = await DatabaseHealthCheck(engine).check()
+        assert result.status is HealthStatus.HEALTHY
+        assert result.critical is True
+        assert result.latency_ms is not None
+
+    @pytest.mark.asyncio
+    async def test_broken_engine_unhealthy(self) -> None:
+        # Point at a non-existent driver to provoke a connection
+        # failure inside ``Engine.connect()``.
+        engine = create_engine("sqlite:////nonexistent/path/to/db.sqlite")
+
+        # Force a real probe by monkeypatching ``connect`` to raise:
+        def _boom(*args, **kwargs):
+            raise RuntimeError("connection refused")
+
+        engine.connect = _boom  # type: ignore[method-assign]
+        result = await DatabaseHealthCheck(engine).check()
+        assert result.status is HealthStatus.UNHEALTHY
+        assert "connection refused" in (result.message or "")
+
+
+class TestFilesystemHealthCheck:
+    @pytest.mark.asyncio
+    async def test_healthy_when_paths_writable(self, tmp_path: Path) -> None:
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        result = await FilesystemHealthCheck([a, b]).check()
+        assert result.status is HealthStatus.HEALTHY
+
+    @pytest.mark.asyncio
+    async def test_missing_directory_unhealthy(self, tmp_path: Path) -> None:
+        result = await FilesystemHealthCheck([tmp_path / "missing"]).check()
+        assert result.status is HealthStatus.UNHEALTHY
+        assert "missing" in (result.message or "")
+
+    @pytest.mark.asyncio
+    async def test_writability_probe_when_enabled(self, tmp_path: Path) -> None:
+        result = await FilesystemHealthCheck([tmp_path], probe_writability=True).check()
+        assert result.status is HealthStatus.HEALTHY
+
+
+class TestSchedulerCheck:
+    @pytest.mark.asyncio
+    async def test_running_is_healthy(self) -> None:
+        check = _SchedulerCheck(name="sched", is_running=lambda: True)
+        result = await check.check()
+        assert result.status is HealthStatus.HEALTHY
+        assert result.critical is False
+
+    @pytest.mark.asyncio
+    async def test_not_running_is_degraded(self) -> None:
+        check = _SchedulerCheck(name="sched", is_running=lambda: False)
+        result = await check.check()
+        assert result.status is HealthStatus.DEGRADED
+
+    @pytest.mark.asyncio
+    async def test_raising_is_unhealthy(self) -> None:
+        def _boom() -> bool:
+            raise RuntimeError("holder empty")
+
+        check = _SchedulerCheck(name="sched", is_running=_boom)
+        result = await check.check()
+        assert result.status is HealthStatus.UNHEALTHY
+        assert "holder empty" in (result.message or "")
+
+
+class TestWebSocketHealthCheck:
+    @pytest.mark.asyncio
+    async def test_returns_status_for_monitoring_service(self, monkeypatch) -> None:
+        class _FakeWS:
+            def is_monitoring(self) -> bool:
+                return True
+
+        import app.websockets.application.service as svc_mod
+
+        monkeypatch.setattr(svc_mod, "websocket_service", _FakeWS())
+        result = await WebSocketHealthCheck().check()
+        assert result.status is HealthStatus.HEALTHY
+
+    @pytest.mark.asyncio
+    async def test_reports_degraded_when_not_monitoring(self, monkeypatch) -> None:
+        class _FakeWS:
+            def is_monitoring(self) -> bool:
+                return False
+
+        import app.websockets.application.service as svc_mod
+
+        monkeypatch.setattr(svc_mod, "websocket_service", _FakeWS())
+        result = await WebSocketHealthCheck().check()
+        assert result.status is HealthStatus.DEGRADED
+
+
+class TestDatabaseIntegrationCheck:
+    @pytest.mark.asyncio
+    async def test_ready(self) -> None:
+        check = DatabaseIntegrationHealthCheck(lambda: True)
+        result = await check.check()
+        assert result.status is HealthStatus.HEALTHY
+
+    @pytest.mark.asyncio
+    async def test_not_ready_is_degraded(self) -> None:
+        check = DatabaseIntegrationHealthCheck(lambda: False)
+        result = await check.check()
+        assert result.status is HealthStatus.DEGRADED

--- a/tests/unit/health/test_service.py
+++ b/tests/unit/health/test_service.py
@@ -1,0 +1,198 @@
+"""Unit tests for ``HealthCheckService`` aggregation, timeout, caching."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from app.health.application.service import HealthCheckConfig, HealthCheckService
+from app.health.domain.entities import ComponentHealth, HealthStatus, aggregate
+from app.health.domain.ports import HealthCheckPort
+
+
+class _StubCheck(HealthCheckPort):
+    def __init__(
+        self,
+        *,
+        name: str,
+        critical: bool,
+        status: HealthStatus,
+        delay: float = 0.0,
+        raises: BaseException | None = None,
+        message: str | None = None,
+    ) -> None:
+        self.name = name
+        self.critical = critical
+        self._status = status
+        self._delay = delay
+        self._raises = raises
+        self._message = message
+        self.call_count = 0
+
+    async def check(self) -> ComponentHealth:
+        self.call_count += 1
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        if self._raises is not None:
+            raise self._raises
+        return ComponentHealth(
+            name=self.name,
+            status=self._status,
+            critical=self.critical,
+            message=self._message,
+            checked_at=datetime.now(timezone.utc),
+        )
+
+
+def _config(**overrides: float) -> HealthCheckConfig:
+    defaults = {
+        "per_component_timeout_seconds": 0.5,
+        "global_timeout_seconds": 1.5,
+        "cache_ttl_seconds": 5.0,
+    }
+    defaults.update(overrides)
+    return HealthCheckConfig(**defaults)  # type: ignore[arg-type]
+
+
+class TestAggregate:
+    def test_all_healthy(self) -> None:
+        comps = [
+            ComponentHealth(name="a", status=HealthStatus.HEALTHY, critical=True),
+            ComponentHealth(name="b", status=HealthStatus.HEALTHY, critical=False),
+        ]
+        assert aggregate(comps) is HealthStatus.HEALTHY
+
+    def test_non_critical_failure_degrades(self) -> None:
+        comps = [
+            ComponentHealth(name="a", status=HealthStatus.HEALTHY, critical=True),
+            ComponentHealth(name="b", status=HealthStatus.UNHEALTHY, critical=False),
+        ]
+        assert aggregate(comps) is HealthStatus.DEGRADED
+
+    def test_critical_failure_unhealthy(self) -> None:
+        comps = [
+            ComponentHealth(name="a", status=HealthStatus.UNHEALTHY, critical=True),
+            ComponentHealth(name="b", status=HealthStatus.HEALTHY, critical=False),
+        ]
+        assert aggregate(comps) is HealthStatus.UNHEALTHY
+
+    def test_degraded_alone_propagates(self) -> None:
+        comps = [
+            ComponentHealth(name="a", status=HealthStatus.DEGRADED, critical=False),
+        ]
+        assert aggregate(comps) is HealthStatus.DEGRADED
+
+
+class TestLiveness:
+    @pytest.mark.asyncio
+    async def test_liveness_does_not_call_adapters(self) -> None:
+        check = _StubCheck(name="db", critical=True, status=HealthStatus.HEALTHY)
+        service = HealthCheckService([check], config=_config())
+        result = service.liveness()
+        assert result.status is HealthStatus.HEALTHY
+        assert result.components == []
+        assert check.call_count == 0
+
+
+class TestReadinessAggregation:
+    @pytest.mark.asyncio
+    async def test_all_healthy(self) -> None:
+        checks = [
+            _StubCheck(name="db", critical=True, status=HealthStatus.HEALTHY),
+            _StubCheck(name="fs", critical=True, status=HealthStatus.HEALTHY),
+        ]
+        service = HealthCheckService(checks, config=_config())
+        result = await service.readiness()
+        assert result.status is HealthStatus.HEALTHY
+        assert result.is_ready is True
+        assert {c.name for c in result.components} == {"db", "fs"}
+
+    @pytest.mark.asyncio
+    async def test_critical_failure_blocks_readiness(self) -> None:
+        checks = [
+            _StubCheck(name="db", critical=True, status=HealthStatus.UNHEALTHY),
+            _StubCheck(name="ws", critical=False, status=HealthStatus.HEALTHY),
+        ]
+        service = HealthCheckService(checks, config=_config())
+        result = await service.readiness()
+        assert result.status is HealthStatus.UNHEALTHY
+        assert result.is_ready is False
+
+    @pytest.mark.asyncio
+    async def test_non_critical_failure_stays_ready(self) -> None:
+        checks = [
+            _StubCheck(name="db", critical=True, status=HealthStatus.HEALTHY),
+            _StubCheck(name="ws", critical=False, status=HealthStatus.UNHEALTHY),
+        ]
+        service = HealthCheckService(checks, config=_config())
+        result = await service.readiness()
+        assert result.status is HealthStatus.DEGRADED
+        # Non-critical failure leaves readiness intact: the kubelet
+        # should not pull traffic just because the backup scheduler is
+        # asleep.
+        assert result.is_ready is True
+
+
+class TestPerComponentTimeout:
+    @pytest.mark.asyncio
+    async def test_slow_adapter_times_out_to_unhealthy(self) -> None:
+        slow = _StubCheck(
+            name="db",
+            critical=True,
+            status=HealthStatus.HEALTHY,
+            delay=0.5,
+        )
+        fast = _StubCheck(name="fs", critical=False, status=HealthStatus.HEALTHY)
+        service = HealthCheckService(
+            [slow, fast],
+            config=_config(per_component_timeout_seconds=0.05),
+        )
+        result = await service.readiness()
+        by_name = {c.name: c for c in result.components}
+        assert by_name["db"].status is HealthStatus.UNHEALTHY
+        assert "timeout" in (by_name["db"].message or "")
+        # Fast adapter should still return successfully.
+        assert by_name["fs"].status is HealthStatus.HEALTHY
+
+    @pytest.mark.asyncio
+    async def test_raising_adapter_is_captured(self) -> None:
+        boom = _StubCheck(
+            name="fs",
+            critical=True,
+            status=HealthStatus.HEALTHY,
+            raises=RuntimeError("disk on fire"),
+        )
+        service = HealthCheckService([boom], config=_config())
+        result = await service.readiness()
+        assert result.components[0].status is HealthStatus.UNHEALTHY
+        assert "disk on fire" in (result.components[0].message or "")
+
+
+class TestCache:
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_check(self) -> None:
+        check = _StubCheck(name="db", critical=True, status=HealthStatus.HEALTHY)
+        service = HealthCheckService([check], config=_config(cache_ttl_seconds=10.0))
+        await service.readiness()
+        await service.readiness()
+        await service.readiness()
+        assert check.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_cache_bypass_forces_rerun(self) -> None:
+        check = _StubCheck(name="db", critical=True, status=HealthStatus.HEALTHY)
+        service = HealthCheckService([check], config=_config(cache_ttl_seconds=10.0))
+        await service.readiness()
+        await service.readiness(use_cache=False)
+        assert check.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_cache_expires(self) -> None:
+        check = _StubCheck(name="db", critical=True, status=HealthStatus.HEALTHY)
+        service = HealthCheckService([check], config=_config(cache_ttl_seconds=0.01))
+        await service.readiness()
+        await asyncio.sleep(0.05)
+        await service.readiness()
+        assert check.call_count == 2


### PR DESCRIPTION
## Summary

Introduces a new `app/health/` domain implementing the k8s-style liveness / readiness probe surface called out by Issue #21. Phase 1 only — Phase 2 (Prometheus-style metrics export) is recommended to be tracked as a separate issue.

## Endpoints

| Path | Auth | Status code |
|---|---|---|
| `GET /healthz` | none | always 200; no dependency I/O |
| `GET /readyz` | none | 503 iff a critical component is UNHEALTHY; 200 otherwise (incl. `status="degraded"`) |
| `GET /ready` | none | alias of `/readyz` (Issue wording) |
| `GET /api/v1/health/detail` | admin | always 200 (body carries diagnostic state); bypasses TTL cache |
| `GET /health` | none | legacy wire format preserved; 503 iff database is UNHEALTHY (same as pre-#21) |
| `GET /api/v1/health` | none | legacy wire format preserved (same rules as `/health`) |

## Architecture

Follows the hexagonal layout from ARCHITECTURE §4.2:

* `app/health/domain/` — `HealthStatus`, `ComponentHealth`, `OverallHealth`, `HealthCheckPort` Protocol.
* `app/health/application/service.py` — `HealthCheckService` with concurrent per-component timeouts, a global guardrail, and a short (configurable, default 2 s) TTL cache so probes hitting at ~1 Hz do not amplify into connection pool pressure. Framework-agnostic.
* `app/health/adapters/` — DB (`SELECT 1`), filesystem (`os.access(W_OK)` + optional real-write probe), backup scheduler, websocket monitor, version-update scheduler, plus a bridge mirroring `service_status.database_integration_ready`.
* `app/health/api/` — Pydantic DTOs, dependency wiring with `functools.lru_cache` so the singleton survives between requests, and the FastAPI router.

## Other changes

* `WebSocketService.is_monitoring()` — public getter added so the health adapter does not touch `_status_monitor_task` directly.
* Both middlewares (audit, performance) get the new probe paths added to their exclusion lists so probes do not pollute audit logs or metrics.
* Legacy `/health` and `/api/v1/health` keep their exact wire format (status field, services dict, failed_services list, message) but now compute it through `HealthCheckService` via `build_legacy_payload`.
* Four new config knobs (`HEALTH_CHECK_*`) with validation.

## Out of scope

* **Phase 2** (Prometheus-style metrics export) — recommend a separate issue. The existing `/metrics` and `/api/v1/metrics` endpoints remain untouched.

## Test plan

- [x] `uv run ruff check / format` on touched files — clean
- [x] `uv run pytest tests/unit/health tests/integration/health -m "not slow"` — 41 pass
- [x] `uv run pytest tests/unit -m "not slow"` — 1235 pass
- [x] `uv run pytest tests/unit tests/integration -m "not slow"` — 1689 pass
- [x] `uv run pre-commit run --files <touched>` — pass

New tests:
* `tests/unit/health/test_service.py` — aggregation, timeout, cache
* `tests/unit/health/test_adapters.py` — each adapter's failure modes
* `tests/integration/health/test_endpoints.py` — all four new endpoints plus legacy wire-format compat (incl. admin auth)

Existing tests:
* `tests/integration/core/test_lifespan.py` — three legacy health tests migrated to override the new service instead of patching `service_status`; helper extracted to `tests/integration/core/_health_helpers.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)