### PR TITLE
feat: actionable error responses for server creation failures (Resolves #33)

### DIFF
--- a/app/core/error_handlers.py
+++ b/app/core/error_handlers.py
@@ -59,10 +59,17 @@ from app.groups.domain.exceptions import (
 )
 from app.servers.domain.exceptions import (
     InvalidServerStateError,
+    JavaCompatibilityError,
     ServerAccessError,
     ServerAlreadyExistsError,
+    ServerCreationRollbackError,
+    ServerDirectoryCreationError,
     ServerError,
+    ServerJarDownloadError,
+    ServerNameConflictError,
     ServerNotFoundError,
+    ServerPortConflictError,
+    UnsupportedMinecraftVersionError,
 )
 from app.templates.domain.exceptions import (
     TemplateAccessError,
@@ -124,9 +131,27 @@ def _domain_response(
     default_message: str,
     fallback_code: str,
 ) -> JSONResponse:
-    """Render a domain-exception payload (uses ``error_code`` if defined)."""
+    """Render a domain-exception payload (uses ``error_code`` if defined).
+
+    If the exception exposes an ``extra_details()`` method (Issue #33
+    introduced it on the new server-creation exceptions so structured
+    field-level context can travel through the same response envelope
+    used by 422 validation errors) the returned :class:`ErrorDetail`
+    list is forwarded into the response ``details`` array. Exceptions
+    that do not implement the method fall through to the legacy single
+    ``message`` shape unchanged.
+    """
     error_code = getattr(exc, "error_code", fallback_code) or fallback_code
     message = str(exc) or default_message
+    extra_details_fn = getattr(exc, "extra_details", None)
+    details: Optional[List[ErrorDetail]] = None
+    if callable(extra_details_fn):
+        try:
+            collected = extra_details_fn()
+            if collected:
+                details = list(collected)
+        except Exception:  # pragma: no cover - defensive
+            logger.exception("extra_details_failed", extra={"error_code": error_code})
     return JSONResponse(
         status_code=status_code,
         content=_build_payload(
@@ -134,6 +159,7 @@ def _domain_response(
             error_code=error_code,
             message=message,
             status_code=status_code,
+            details=details,
         ),
     )
 
@@ -181,6 +207,89 @@ def register_exception_handlers(app: FastAPI) -> None:
             status_code=status.HTTP_409_CONFLICT,
             default_message="Server is in an invalid state for this operation",
             fallback_code="SERVER_INVALID_STATE",
+        )
+
+    # --- Issue #33: actionable server-creation errors ----------------
+    # Registered before the generic ``ServerError`` handler so the more
+    # specific code/status pair wins (FastAPI matches on exception
+    # type, not order, but registering the specific handler ensures
+    # the dispatcher resolves it as the canonical mapping for that
+    # type — important when subclass relationships exist, e.g.
+    # ``ServerNameConflictError`` extends ``ServerAlreadyExistsError``
+    # which the dispatcher would otherwise short-circuit on).
+
+    @app.exception_handler(ServerNameConflictError)
+    async def _server_name_conflict(request: Request, exc: ServerNameConflictError):
+        return _domain_response(
+            request,
+            exc,
+            status_code=status.HTTP_409_CONFLICT,
+            default_message="Server name already taken",
+            fallback_code="SERVER_NAME_CONFLICT",
+        )
+
+    @app.exception_handler(ServerPortConflictError)
+    async def _server_port_conflict(request: Request, exc: ServerPortConflictError):
+        return _domain_response(
+            request,
+            exc,
+            status_code=status.HTTP_409_CONFLICT,
+            default_message="Port already in use by another server",
+            fallback_code="SERVER_PORT_CONFLICT",
+        )
+
+    @app.exception_handler(UnsupportedMinecraftVersionError)
+    async def _server_unsupported_version(
+        request: Request, exc: UnsupportedMinecraftVersionError
+    ):
+        return _domain_response(
+            request,
+            exc,
+            status_code=status.HTTP_400_BAD_REQUEST,
+            default_message="Minecraft version is not supported",
+            fallback_code="SERVER_UNSUPPORTED_VERSION",
+        )
+
+    @app.exception_handler(JavaCompatibilityError)
+    async def _server_java_incompatible(request: Request, exc: JavaCompatibilityError):
+        return _domain_response(
+            request,
+            exc,
+            status_code=status.HTTP_400_BAD_REQUEST,
+            default_message="No compatible Java runtime found",
+            fallback_code="SERVER_JAVA_INCOMPATIBLE",
+        )
+
+    @app.exception_handler(ServerJarDownloadError)
+    async def _server_jar_download_failed(request: Request, exc: ServerJarDownloadError):
+        return _domain_response(
+            request,
+            exc,
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            default_message="Failed to download server JAR from upstream",
+            fallback_code="SERVER_JAR_DOWNLOAD_FAILED",
+        )
+
+    @app.exception_handler(ServerDirectoryCreationError)
+    async def _server_directory_failed(
+        request: Request, exc: ServerDirectoryCreationError
+    ):
+        return _domain_response(
+            request,
+            exc,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            default_message="Failed to create server directory",
+            fallback_code="SERVER_DIRECTORY_FAILED",
+        )
+
+    @app.exception_handler(ServerCreationRollbackError)
+    async def _server_rollback_failed(request: Request, exc: ServerCreationRollbackError):
+        return _domain_response(
+            request,
+            exc,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            default_message="Server creation failed and rollback did not complete",
+            fallback_code="SERVER_CREATION_ROLLBACK_FAILED",
         )
 
     @app.exception_handler(ServerError)

--- a/app/servers/application/port_allocator.py
+++ b/app/servers/application/port_allocator.py
@@ -1,0 +1,87 @@
+"""Server port-allocation helpers (Issue #33).
+
+A single source of truth for "which ports are currently held by an
+active server" and "give me the next N free ports starting at
+``start_port``". Previously this logic was duplicated inline inside
+``app/servers/routers/import_export.py`` (the import path) and lived
+nowhere reusable for the pre-flight port check the create-server path
+needs.
+
+The check only considers servers in the active operational statuses
+(``running`` / ``starting``) — stopped servers are intentionally
+ignored so two servers can share a port as long as they never run
+concurrently. This matches the contract pinned by the existing
+:mod:`tests.integration.servers.test_port_conflicts` integration
+suite.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from app.servers.domain.ports import ServerRepository
+from app.servers.domain.value_objects import ServerStatus
+
+# Status values that mean the server is (or is about to be) bound to
+# the port. Keep in sync with the import-path heuristic — see the
+# in-line comment that used to live at
+# ``app/servers/routers/import_export.py``.
+_ACTIVE_STATUSES: List[ServerStatus] = [
+    ServerStatus.running,
+    ServerStatus.starting,
+]
+
+# Hard upper bound from RFC 6335. Anything above is reserved/invalid.
+_MAX_PORT = 65535
+
+
+async def find_available_ports(
+    repo: ServerRepository,
+    start_port: int,
+    *,
+    count: int = 3,
+) -> List[int]:
+    """Return up to ``count`` free ports starting from ``start_port``.
+
+    Walks the integer range monotonically; the search stops when
+    ``count`` ports have been collected or the port space is
+    exhausted. Returns an empty list when ``start_port`` is already
+    past ``_MAX_PORT``.
+
+    The function inspects the database only — it does not attempt a
+    socket bind to verify the port is reachable on the host. The
+    create-server path performs an additional socket-level check at
+    start time, see
+    :class:`app.servers.application.minecraft_server.MinecraftServerManager`.
+    """
+    if start_port > _MAX_PORT or count <= 0:
+        return []
+
+    used_servers = await repo.list_by_port(port=None, statuses=_ACTIVE_STATUSES)
+    used_ports = {s.port for s in used_servers}
+
+    suggestions: List[int] = []
+    candidate = max(start_port, 1024)
+    while candidate <= _MAX_PORT and len(suggestions) < count:
+        if candidate not in used_ports:
+            suggestions.append(candidate)
+        candidate += 1
+    return suggestions
+
+
+async def port_holder(
+    repo: ServerRepository,
+    port: int,
+) -> str | None:
+    """Return the name of the active server already using ``port``, or None.
+
+    "Active" matches :data:`_ACTIVE_STATUSES`. When multiple servers
+    hold the same port (shouldn't happen but is defended against) the
+    first one returned by the repository wins.
+    """
+    if port <= 0:
+        return None
+    holders = await repo.list_by_port(port=port, statuses=_ACTIVE_STATUSES)
+    if not holders:
+        return None
+    return holders[0].name

--- a/app/servers/application/service.py
+++ b/app/servers/application/service.py
@@ -43,10 +43,12 @@ import re
 import shlex
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from app.core.error_schemas import ErrorDetail
 from app.core.exceptions import (
     ConflictException,
+    FileOperationException,
     InvalidRequestException,
     handle_file_error,
 )
@@ -73,6 +75,10 @@ from app.servers.adapters._legacy_helpers import (
     validate_server_operation_legacy,
 )
 from app.servers.application.minecraft_server import minecraft_server_manager
+from app.servers.application.port_allocator import (
+    find_available_ports,
+    port_holder,
+)
 from app.servers.application.server_properties_generator import (
     server_properties_generator,
 )
@@ -80,6 +86,14 @@ from app.servers.domain.entities import (
     CreateServerCommand,
     ServerListSpec,
     UpdateServerCommand,
+)
+from app.servers.domain.exceptions import (
+    JavaCompatibilityError,
+    ServerCreationRollbackError,
+    ServerJarDownloadError,
+    ServerNameConflictError,
+    ServerPortConflictError,
+    UnsupportedMinecraftVersionError,
 )
 from app.servers.domain.ports import ServerRepository, ServersUnitOfWork
 from app.servers.models import (
@@ -101,6 +115,8 @@ from app.versions.application.java_compatibility import java_compatibility_servi
 # runtime (ARCHITECTURE §4.2, #285).
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+    from app.servers.schemas import ValidateServerCreationResponse
 
 logger = logging.getLogger(__name__)
 
@@ -423,42 +439,77 @@ class ServerService:
     ) -> ServerResponse:
         """Create a new Minecraft server.
 
+        Performs pre-flight validation (name uniqueness, port
+        availability among active servers, version support, Java
+        compatibility) **before** mutating the filesystem so failure
+        modes surface as actionable structured errors rather than
+        partially-created server directories (Issue #33).
+
         Uses the injected `ServersUnitOfWork` and `ServerRepository`
         when available; otherwise falls back to the legacy
         `ServerDatabaseService` path so test fixtures that construct
         `ServerService()` without DI continue to work.
         """
-        # Uniqueness check via repo (or legacy validation service when no DI).
-        if self._server_repo is not None:
-            existing = await self._server_repo.get_by_name(request.name)
-            if existing is not None:
-                raise ConflictException(
-                    f"Server with name '{request.name}' already exists"
-                )
-        else:
-            await self.validation_service.validate_server_uniqueness(request, db)
+        # ---- Pre-flight validation (Issue #33) -----------------------
+        # All checks below MUST raise domain exceptions with a stable
+        # ``error_code``; the global handler maps them to actionable
+        # HTTP responses.
+        await self._validate_creation_preconditions(request, db)
 
-        ServerSecurityValidator.validate_server_name(request.name)
-        ServerSecurityValidator.validate_memory_value(request.max_memory)
-
-        if not await self._is_version_supported_db(
-            db, request.server_type, request.minecraft_version
-        ):
-            raise InvalidRequestException(
-                f"Version {request.minecraft_version} is not supported for "
-                f"{request.server_type.value}. Minimum supported version: 1.8"
-            )
-
-        await self._validate_java_compatibility(request.minecraft_version)
-
+        # ---- Filesystem + persistence stage --------------------------
+        logger.info(
+            "server_create_step",
+            extra={
+                "stage": "directory_create",
+                "server_name": request.name,
+                "owner_id": owner.id,
+            },
+        )
         server_dir = await self.filesystem_service.create_server_directory(request.name)
 
         try:
-            await self.jar_service.get_server_jar(
-                request.server_type, request.minecraft_version, server_dir, db
+            logger.info(
+                "server_create_step",
+                extra={
+                    "stage": "jar_download",
+                    "server_name": request.name,
+                    "server_type": request.server_type.value,
+                    "minecraft_version": request.minecraft_version,
+                },
             )
+            try:
+                await self.jar_service.get_server_jar(
+                    request.server_type, request.minecraft_version, server_dir, db
+                )
+            except (
+                ServerJarDownloadError,
+                UnsupportedMinecraftVersionError,
+            ):
+                # Already an actionable domain exception — propagate.
+                raise
+            except FileOperationException as e:
+                # `_legacy_helpers.ServerJarService.get_server_jar`
+                # currently funnels every JAR failure through
+                # ``handle_file_error`` which re-raises as
+                # FileOperationException. Re-classify as a structured
+                # ``ServerJarDownloadError`` so the frontend gets a 502
+                # with a retry hint instead of a generic 500.
+                raise ServerJarDownloadError(
+                    server_type=request.server_type.value,
+                    version=request.minecraft_version,
+                    reason=str(e.detail) if e.detail else "unknown",
+                    retry_hint=(
+                        "Check upstream availability and retry. Clearing "
+                        "the JAR cache may help if a partial download "
+                        "is suspected."
+                    ),
+                ) from e
 
             # Persist via UoW + repo when DI wired; legacy path otherwise.
+            logger.info(
+                "server_create_step",
+                extra={"stage": "persist", "server_name": request.name},
+            )
             if self._uow is not None:
                 server = await self._create_via_uow(request, owner, server_dir)
             else:
@@ -466,6 +517,14 @@ class ServerService:
                     request, owner, str(server_dir), db
                 )
 
+            logger.info(
+                "server_create_step",
+                extra={
+                    "stage": "generate_files",
+                    "server_name": request.name,
+                    "server_id": server.id,
+                },
+            )
             await self.filesystem_service.generate_server_files(
                 server, request, server_dir
             )
@@ -508,9 +567,194 @@ class ServerService:
             return ServerResponse.model_validate(server)
 
         except Exception as e:
-            await self.filesystem_service.cleanup_server_directory(server_dir)
-            logger.error(f"Failed to create server {request.name}: {e}")
+            stage = "post_directory"
+            error_code = getattr(e, "error_code", e.__class__.__name__)
+            logger.exception(
+                "server_create_failed",
+                extra={
+                    "stage": stage,
+                    "error_code": error_code,
+                    "server_name": request.name,
+                },
+            )
+            try:
+                await self.filesystem_service.cleanup_server_directory(server_dir)
+            except Exception as cleanup_error:  # pragma: no cover - defensive
+                logger.error(
+                    "server_create_rollback_failed",
+                    extra={
+                        "stage": stage,
+                        "error_code": error_code,
+                        "server_name": request.name,
+                        "rollback_error": str(cleanup_error),
+                    },
+                )
+                # Surface the rollback failure to the caller so an
+                # operator can intervene (a stranded directory remains
+                # on disk). Chain the original error for traceability.
+                raise ServerCreationRollbackError(
+                    stage=stage,
+                    original_error=str(e),
+                ) from cleanup_error
             raise
+
+    async def _validate_creation_preconditions(
+        self, request: ServerCreateRequest, db: Session
+    ) -> None:
+        """Run all pre-flight checks for ``create_server`` (Issue #33).
+
+        Order is deliberate: cheap in-memory and DB-only checks first
+        (name, port), then the version lookup, then the Java probe
+        which may need to walk the filesystem. Each failure raises a
+        dedicated domain exception with an ``error_code`` and (where
+        relevant) structured ``extra_details``.
+        """
+        # ---- Name uniqueness ----
+        logger.info(
+            "server_create_step",
+            extra={"stage": "name_check", "server_name": request.name},
+        )
+        if self._server_repo is not None:
+            existing = await self._server_repo.get_by_name(request.name)
+            if existing is not None:
+                raise ServerNameConflictError(request.name)
+        else:
+            # Legacy fallback used by unit tests that construct
+            # ``ServerService()`` without DI. Translate the legacy
+            # ``ConflictException`` into the structured error so the
+            # router contract stays uniform.
+            try:
+                await self.validation_service.validate_server_uniqueness(request, db)
+            except ConflictException as e:
+                raise ServerNameConflictError(request.name) from e
+
+        # ---- Static safety checks ----
+        ServerSecurityValidator.validate_server_name(request.name)
+        ServerSecurityValidator.validate_memory_value(request.max_memory)
+
+        # ---- Port pre-flight ----
+        logger.info(
+            "server_create_step",
+            extra={
+                "stage": "port_check",
+                "server_name": request.name,
+                "port": request.port,
+            },
+        )
+        if self._server_repo is not None:
+            holder_name = await port_holder(self._server_repo, request.port)
+            if holder_name is not None:
+                suggestions = await find_available_ports(
+                    self._server_repo, start_port=request.port + 1, count=3
+                )
+                raise ServerPortConflictError(
+                    port=request.port,
+                    conflicting_server=holder_name,
+                    suggested_ports=suggestions,
+                )
+
+        # ---- Version support ----
+        logger.info(
+            "server_create_step",
+            extra={
+                "stage": "version_check",
+                "server_name": request.name,
+                "server_type": request.server_type.value,
+                "minecraft_version": request.minecraft_version,
+            },
+        )
+        try:
+            supported = await self._is_version_supported_db(
+                db, request.server_type, request.minecraft_version
+            )
+        except InvalidRequestException as e:
+            # Both DB and upstream lookups failed — surface as the
+            # version-unsupported domain code so the frontend can
+            # offer a retry instead of rendering a 500.
+            raise UnsupportedMinecraftVersionError(
+                version=request.minecraft_version,
+                server_type=request.server_type.value,
+            ) from e
+        if not supported:
+            raise UnsupportedMinecraftVersionError(
+                version=request.minecraft_version,
+                server_type=request.server_type.value,
+            )
+
+        # ---- Java compatibility ----
+        logger.info(
+            "server_create_step",
+            extra={
+                "stage": "java_check",
+                "server_name": request.name,
+                "minecraft_version": request.minecraft_version,
+            },
+        )
+        await self._validate_java_compatibility(request.minecraft_version)
+
+    async def validate_creation_request(
+        self, request: ServerCreateRequest, db: Session
+    ) -> "ValidateServerCreationResponse":
+        """Pre-validate a create-server request without mutating state.
+
+        Powers the ``POST /api/v1/servers/validate`` endpoint added under
+        Issue #33 so frontends can render inline validation feedback
+        before committing the user to the create button. Returns a
+        :class:`ValidateServerCreationResponse` with ``valid=False`` and
+        a populated ``warnings`` list on failure (rather than raising)
+        so the caller can render multiple issues at once.
+        """
+        from app.servers.schemas import ValidateServerCreationResponse
+
+        warnings: List[ErrorDetail] = []
+        try:
+            await self._validate_creation_preconditions(request, db)
+            valid = True
+        except (
+            ServerNameConflictError,
+            ServerPortConflictError,
+            UnsupportedMinecraftVersionError,
+            JavaCompatibilityError,
+        ) as exc:
+            valid = False
+            warnings.append(
+                ErrorDetail(
+                    field=None,
+                    message=str(exc),
+                    code=exc.error_code,
+                )
+            )
+            extra_fn = getattr(exc, "extra_details", None)
+            if callable(extra_fn):
+                try:
+                    warnings.extend(list(extra_fn()))
+                except Exception:  # pragma: no cover - defensive
+                    pass
+        except InvalidRequestException as exc:
+            valid = False
+            warnings.append(
+                ErrorDetail(
+                    field=None,
+                    message=str(exc.detail) if exc.detail else "invalid request",
+                    code=getattr(exc, "error_code", "INVALID_REQUEST"),
+                )
+            )
+
+        # Always provide at least one alternative port suggestion when
+        # the repo is wired — useful both for the conflict path and for
+        # frontends that want to show "free ports near your choice"
+        # affordances independent of any failure.
+        suggested_ports: List[int] = []
+        if self._server_repo is not None:
+            suggested_ports = await find_available_ports(
+                self._server_repo, start_port=request.port, count=3
+            )
+
+        return ValidateServerCreationResponse(
+            valid=valid,
+            warnings=warnings,
+            suggested_ports=suggested_ports,
+        )
 
     async def _create_via_uow(
         self, request: ServerCreateRequest, owner: User, server_dir: Path
@@ -932,7 +1176,21 @@ class ServerService:
             logger.error(f"Failed to sync server.properties for server {server.id}: {e}")
 
     async def _validate_java_compatibility(self, minecraft_version: str) -> None:
+        """Verify a compatible Java runtime is installed for ``minecraft_version``.
+
+        Raises :class:`JavaCompatibilityError` with structured context
+        (required version, available versions) so the frontend can
+        render an actionable install hint (Issue #33).
+        """
         try:
+            required_version: Optional[int] = None
+            try:
+                required_version = java_compatibility_service.get_required_java_version(
+                    minecraft_version
+                )
+            except Exception:  # pragma: no cover - best-effort metadata
+                required_version = None
+
             java_version = await java_compatibility_service.get_java_for_minecraft(
                 minecraft_version
             )
@@ -940,26 +1198,14 @@ class ServerService:
                 installations = (
                     await java_compatibility_service.discover_java_installations()
                 )
-                if not installations:
-                    raise InvalidRequestException(
-                        "No Java installations found. "
-                        "Please install OpenJDK and ensure it's accessible. "
-                        "You can also configure specific Java paths in .env file."
-                    )
-                else:
-                    available_versions = list(installations.keys())
-                    required_version = (
-                        java_compatibility_service.get_required_java_version(
-                            minecraft_version
-                        )
-                    )
-                    raise InvalidRequestException(
-                        f"Minecraft {minecraft_version} requires Java "
-                        f"{required_version}, but only Java {available_versions} are "
-                        "available. Please install Java "
-                        f"{required_version} or configure "
-                        f"JAVA_{required_version}_PATH in .env."
-                    )
+                available_versions: List[int] = (
+                    list(installations.keys()) if installations else []
+                )
+                raise JavaCompatibilityError(
+                    minecraft_version=minecraft_version,
+                    required_java=required_version,
+                    available_java=available_versions,
+                )
 
             is_compatible, compatibility_message = (
                 java_compatibility_service.validate_java_compatibility(
@@ -972,19 +1218,37 @@ class ServerService:
                     f"Java compatibility validation failed for Minecraft "
                     f"{minecraft_version}: {compatibility_message}"
                 )
-                raise InvalidRequestException(compatibility_message)
+                raise JavaCompatibilityError(
+                    minecraft_version=minecraft_version,
+                    required_java=required_version,
+                    available_java=[java_version.major_version],
+                    message=compatibility_message,
+                )
 
             logger.info(
                 f"Java compatibility validated for Minecraft {minecraft_version}: "
                 f"Using Java {java_version.major_version} at "
                 f"{java_version.executable_path}"
             )
-        except InvalidRequestException:
+        except JavaCompatibilityError:
             raise
+        except InvalidRequestException as e:
+            # Translate the legacy code-path (still raised by older
+            # ``java_compatibility_service`` failure modes) into the
+            # structured Issue #33 exception.
+            raise JavaCompatibilityError(
+                minecraft_version=minecraft_version,
+                required_java=None,
+                message=str(e.detail) if e.detail else str(e),
+            ) from e
         except Exception as e:
             error_message = f"Java compatibility validation failed: {e}"
             logger.error(error_message, exc_info=True)
-            raise InvalidRequestException(error_message)
+            raise JavaCompatibilityError(
+                minecraft_version=minecraft_version,
+                required_java=None,
+                message=error_message,
+            ) from e
 
 
 # Global default instance for legacy import paths. Constructed without

--- a/app/servers/domain/exceptions.py
+++ b/app/servers/domain/exceptions.py
@@ -7,10 +7,20 @@ the router's existing handlers keep working.
 
 These types are introduced under #228 (PR 1/3) and are unwired from
 the runtime in this PR; PR #2 rewires the callers.
+
+Issue #33 (actionable server-creation errors): each new fine-grained
+exception below carries an ``error_code`` and may optionally expose
+structured field-level context through ``extra_details()``. The global
+exception handler in :mod:`app.core.error_handlers` reads
+``extra_details()`` (when present) and surfaces it through the
+:class:`~app.core.error_schemas.ErrorResponse.details` array so the
+frontend can render actionable, code-driven UI without parsing English
+prose.
 """
 
-from typing import ClassVar
+from typing import ClassVar, List, Optional
 
+from app.core.error_schemas import ErrorDetail
 from app.core.exceptions import (
     ServerAccessDeniedException,
     ServerNotFoundException,
@@ -64,6 +74,316 @@ class InvalidServerStateError(ServerError):
     error_code: ClassVar[str] = "SERVER_INVALID_STATE"
 
 
+# ---------------------------------------------------------------------------
+# Issue #33: actionable server-creation errors
+# ---------------------------------------------------------------------------
+
+
+class ServerNameConflictError(ServerAlreadyExistsError):
+    """Raised when the requested server name collides with an existing one.
+
+    Inherits from :class:`ServerAlreadyExistsError` so existing
+    callers that pattern-match on the parent type (and the global
+    handler that maps it to HTTP 409) continue to work; the more
+    specific ``error_code`` ``SERVER_NAME_CONFLICT`` is surfaced
+    through the response payload so the frontend can target the
+    error precisely.
+    """
+
+    error_code: ClassVar[str] = "SERVER_NAME_CONFLICT"
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        super().__init__(
+            f"A server named '{name}' already exists. "
+            "Choose a different name or delete the existing server first."
+        )
+
+    def extra_details(self) -> List[ErrorDetail]:
+        return [
+            ErrorDetail(
+                field="name",
+                message=f"'{self.name}' is already taken",
+                code="SERVER_NAME_TAKEN",
+            )
+        ]
+
+
+class ServerPortConflictError(ServerError):
+    """Raised when the requested port is already used by an active server.
+
+    Carries the conflicting server name and a small list of suggested
+    free ports the caller may try instead. Mapped to HTTP 409.
+    """
+
+    error_code: ClassVar[str] = "SERVER_PORT_CONFLICT"
+
+    def __init__(
+        self,
+        port: int,
+        conflicting_server: Optional[str] = None,
+        suggested_ports: Optional[List[int]] = None,
+    ) -> None:
+        self.port = port
+        self.conflicting_server = conflicting_server
+        self.suggested_ports = list(suggested_ports or [])
+        msg = (
+            f"Port {port} is already in use"
+            + (f" by server '{conflicting_server}'." if conflicting_server else ".")
+            + " Choose a different port"
+        )
+        if self.suggested_ports:
+            msg += f" (suggested: {', '.join(str(p) for p in self.suggested_ports)})."
+        else:
+            msg += "."
+        super().__init__(msg)
+
+    def extra_details(self) -> List[ErrorDetail]:
+        details: List[ErrorDetail] = [
+            ErrorDetail(
+                field="port",
+                message=(
+                    f"Port {self.port} is already in use"
+                    + (
+                        f" by '{self.conflicting_server}'"
+                        if self.conflicting_server
+                        else ""
+                    )
+                ),
+                code="PORT_IN_USE",
+            )
+        ]
+        for suggestion in self.suggested_ports:
+            details.append(
+                ErrorDetail(
+                    field="port",
+                    message=str(suggestion),
+                    code="PORT_SUGGESTION",
+                )
+            )
+        return details
+
+
+class UnsupportedMinecraftVersionError(ServerError):
+    """Raised when the requested Minecraft version is unsupported.
+
+    Mapped to HTTP 400. Carries the offending version and server type
+    so the frontend can present an inline message on the version
+    selector.
+    """
+
+    error_code: ClassVar[str] = "SERVER_UNSUPPORTED_VERSION"
+
+    def __init__(self, version: str, server_type: str) -> None:
+        self.version = version
+        self.server_type = server_type
+        super().__init__(
+            f"Minecraft version '{version}' is not supported for server type "
+            f"'{server_type}'. Refresh the supported-versions list or pick "
+            "another version (minimum 1.8)."
+        )
+
+    def extra_details(self) -> List[ErrorDetail]:
+        return [
+            ErrorDetail(
+                field="minecraft_version",
+                message=(
+                    f"Version '{self.version}' is not supported for "
+                    f"server type '{self.server_type}'"
+                ),
+                code="VERSION_NOT_SUPPORTED",
+            ),
+            ErrorDetail(
+                field=None,
+                message="Refresh the supported-versions list or pick another version",
+                code="RESOLUTION_STEP",
+            ),
+        ]
+
+
+class JavaCompatibilityError(ServerError):
+    """Raised when no compatible Java runtime is available.
+
+    Mapped to HTTP 400. Carries the Minecraft version, the Java major
+    version the request requires, and the list of available Java major
+    versions so the frontend can render an actionable installation
+    hint.
+    """
+
+    error_code: ClassVar[str] = "SERVER_JAVA_INCOMPATIBLE"
+
+    def __init__(
+        self,
+        minecraft_version: str,
+        required_java: Optional[int],
+        available_java: Optional[List[int]] = None,
+        message: Optional[str] = None,
+    ) -> None:
+        self.minecraft_version = minecraft_version
+        self.required_java = required_java
+        self.available_java = list(available_java or [])
+        if message is None:
+            if self.available_java:
+                message = (
+                    f"Minecraft {minecraft_version} requires Java "
+                    f"{required_java}; only Java "
+                    f"{self.available_java} are available. "
+                    f"Install Java {required_java} or set "
+                    f"JAVA_{required_java}_PATH in your environment."
+                )
+            else:
+                message = (
+                    "No Java installations were detected. Install an OpenJDK "
+                    "build that matches the target Minecraft version and "
+                    "ensure the java binary is on PATH."
+                )
+        super().__init__(message)
+
+    def extra_details(self) -> List[ErrorDetail]:
+        details: List[ErrorDetail] = [
+            ErrorDetail(
+                field="minecraft_version",
+                message=(
+                    f"Requires Java {self.required_java}"
+                    if self.required_java is not None
+                    else "Requires a compatible Java runtime"
+                ),
+                code="JAVA_REQUIRED",
+            ),
+        ]
+        for ver in self.available_java:
+            details.append(
+                ErrorDetail(
+                    field=None,
+                    message=str(ver),
+                    code="JAVA_AVAILABLE",
+                )
+            )
+        if self.required_java is not None:
+            details.append(
+                ErrorDetail(
+                    field=None,
+                    message=(
+                        f"Install Java {self.required_java} or set "
+                        f"JAVA_{self.required_java}_PATH in .env"
+                    ),
+                    code="RESOLUTION_STEP",
+                )
+            )
+        return details
+
+
+class ServerJarDownloadError(ServerError):
+    """Raised when the server JAR download or integrity check fails.
+
+    Mapped to HTTP 502 — the dependency the API relies on (Mojang /
+    Paper / Forge upstream) misbehaved. Carries a structured
+    ``reason`` (``network`` / ``corrupted`` / ``upstream <status>``)
+    and a ``retry_hint`` the caller can render verbatim.
+    """
+
+    error_code: ClassVar[str] = "SERVER_JAR_DOWNLOAD_FAILED"
+
+    def __init__(
+        self,
+        server_type: str,
+        version: str,
+        reason: str,
+        retry_hint: Optional[str] = None,
+    ) -> None:
+        self.server_type = server_type
+        self.version = version
+        self.reason = reason
+        self.retry_hint = retry_hint
+        msg = f"Failed to download {server_type} {version} JAR ({reason})."
+        if retry_hint:
+            msg += f" {retry_hint}"
+        super().__init__(msg)
+
+    def extra_details(self) -> List[ErrorDetail]:
+        details: List[ErrorDetail] = [
+            ErrorDetail(
+                field=None,
+                message=self.reason,
+                code="JAR_DOWNLOAD_REASON",
+            )
+        ]
+        if self.retry_hint:
+            details.append(
+                ErrorDetail(
+                    field=None,
+                    message=self.retry_hint,
+                    code="RESOLUTION_STEP",
+                )
+            )
+        return details
+
+
+class ServerDirectoryCreationError(ServerError):
+    """Raised when the on-disk server directory cannot be created.
+
+    Mapped to HTTP 500. Distinct from
+    :class:`~app.core.exceptions.FileOperationException` so the
+    frontend can render a directory-specific message.
+    """
+
+    error_code: ClassVar[str] = "SERVER_DIRECTORY_FAILED"
+
+    def __init__(self, name: str, reason: str) -> None:
+        self.name = name
+        self.reason = reason
+        super().__init__(f"Failed to create server directory for '{name}': {reason}")
+
+    def extra_details(self) -> List[ErrorDetail]:
+        return [
+            ErrorDetail(
+                field=None,
+                message=self.reason,
+                code="DIRECTORY_CREATION_REASON",
+            ),
+            ErrorDetail(
+                field=None,
+                message=(
+                    "Check filesystem permissions on the servers/ directory and retry."
+                ),
+                code="RESOLUTION_STEP",
+            ),
+        ]
+
+
+class ServerCreationRollbackError(ServerError):
+    """Raised when cleanup after a failed server creation itself fails.
+
+    Mapped to HTTP 500. Surfaces both the original failure stage and
+    the rollback error so an operator can intervene manually (e.g.
+    remove a stranded ``servers/<name>`` directory).
+    """
+
+    error_code: ClassVar[str] = "SERVER_CREATION_ROLLBACK_FAILED"
+
+    def __init__(self, stage: str, original_error: str) -> None:
+        self.stage = stage
+        self.original_error = original_error
+        super().__init__(
+            f"Server creation failed at stage '{stage}' and cleanup did not "
+            f"complete cleanly: {original_error}"
+        )
+
+    def extra_details(self) -> List[ErrorDetail]:
+        return [
+            ErrorDetail(
+                field=None,
+                message=self.stage,
+                code="ROLLBACK_STAGE",
+            ),
+            ErrorDetail(
+                field=None,
+                message=self.original_error,
+                code="ROLLBACK_ORIGINAL_ERROR",
+            ),
+        ]
+
+
 # Re-export the legacy exceptions so callers migrating over to the
 # domain module can `from app.servers.domain.exceptions import ...`
 # without needing to keep two import paths.
@@ -73,6 +393,15 @@ __all__ = [
     "ServerAlreadyExistsError",
     "ServerAccessError",
     "InvalidServerStateError",
+    # Issue #33 — actionable creation errors
+    "ServerNameConflictError",
+    "ServerPortConflictError",
+    "UnsupportedMinecraftVersionError",
+    "JavaCompatibilityError",
+    "ServerJarDownloadError",
+    "ServerDirectoryCreationError",
+    "ServerCreationRollbackError",
+    # Legacy re-exports
     "ServerNotFoundException",
     "ServerAccessDeniedException",
 ]

--- a/app/servers/routers/import_export.py
+++ b/app/servers/routers/import_export.py
@@ -31,6 +31,7 @@ from app.servers.api.dependencies import (
     get_server_service,
 )
 from app.servers.application.authorization import AuthorizationService
+from app.servers.application.port_allocator import find_available_ports
 from app.servers.application.service import (
     ServerService,
 )
@@ -39,7 +40,7 @@ from app.servers.application.service import (
 )
 from app.servers.domain.exceptions import ServerAccessError, ServerNotFoundError
 from app.servers.domain.ports import ServerRepository
-from app.servers.models import ServerStatus, ServerType
+from app.servers.models import ServerType
 from app.servers.schemas import (
     ServerCreateRequest,
     ServerImportRequest,
@@ -270,28 +271,20 @@ async def import_server(
                         detail=f"Invalid export file: missing {field} in metadata",
                     )
 
-            # Find available port (only check running servers).
-            # Previous implementation applied Python's `not` to the
-            # SQLAlchemy is_deleted Column, which always evaluates to
-            # False, so `used_ports` was permanently empty and port
-            # 25565 was always offered even when occupied. Route
-            # through the Server Repository's
-            # `list_by_port(port=None, statuses=...)` which excludes
-            # soft-deleted rows by default.
-            used_servers = await server_repo.list_by_port(
-                port=None,
-                statuses=[ServerStatus.running, ServerStatus.starting],
+            # Find available port (only check active servers).
+            # Routed through the shared ``port_allocator`` helper so the
+            # active-status filter (running/starting) stays in lock-step
+            # with the create-server pre-flight check added under
+            # Issue #33.
+            suggestions = await find_available_ports(
+                server_repo, start_port=25565, count=1
             )
-            used_ports = {s.port for s in used_servers}
-
-            port = 25565
-            while port in used_ports:
-                port += 1
-                if port > 65535:
-                    raise HTTPException(
-                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                        detail="No available ports for server",
-                    )
+            if not suggestions:
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="No available ports for server",
+                )
+            port = suggestions[0]
 
             # Create server record
             create_request = ServerCreateRequest(

--- a/app/servers/routers/management.py
+++ b/app/servers/routers/management.py
@@ -16,7 +16,6 @@ from app.backups.domain.exceptions import (
     BackupParentServerMissingError,
 )
 from app.core.database import get_db
-from app.core.exceptions import ConflictException
 from app.servers.api.dependencies import (
     get_authorization_service,
     get_server_service,
@@ -36,6 +35,7 @@ from app.servers.schemas import (
     ServerListResponse,
     ServerResponse,
     ServerUpdateRequest,
+    ValidateServerCreationResponse,
 )
 from app.users.models import User
 
@@ -74,25 +74,46 @@ async def create_server(
     - **template_id**: Optional template to apply
     - **server_properties**: Custom server.properties overrides
     - **attach_groups**: Groups to attach on creation
+
+    Failure modes raise structured domain exceptions
+    (``SERVER_NAME_CONFLICT``, ``SERVER_PORT_CONFLICT``,
+    ``SERVER_UNSUPPORTED_VERSION``, ``SERVER_JAVA_INCOMPATIBLE``,
+    ``SERVER_JAR_DOWNLOAD_FAILED`` etc.) mapped to actionable HTTP
+    responses by the global handlers in
+    :mod:`app.core.error_handlers` (Issue #33).
     """
-    try:
-        # Phase 1: All users can create servers
-        if not AuthorizationService.can_create_server(current_user):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Insufficient permissions to create servers",
-            )
+    # Phase 1: All users can create servers
+    if not AuthorizationService.can_create_server(current_user):
+        raise ServerAccessError("Insufficient permissions to create servers")
 
-        server = await server_service.create_server(request, current_user, db)
-        return server
+    return await server_service.create_server(request, current_user, db)
 
-    except ConflictException as e:
-        raise e  # Already has proper HTTP status code
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to create server: {str(e)}",
-        )
+
+@router.post(
+    "/validate",
+    response_model=ValidateServerCreationResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def validate_server_creation(
+    request: ServerCreateRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    server_service: ServerService = Depends(get_server_service),
+):
+    """Pre-validate a server-creation request without persisting (Issue #33).
+
+    Mirrors the validation pipeline of ``POST /api/v1/servers`` so the
+    frontend can render inline error/warning UI before the user
+    commits. Returns ``200 OK`` with ``valid=false`` (rather than
+    raising) so multiple issues can be surfaced in one round-trip.
+
+    Authorization mirrors create — the same ``can_create_server`` gate
+    is enforced.
+    """
+    if not AuthorizationService.can_create_server(current_user):
+        raise ServerAccessError("Insufficient permissions to validate server creation")
+
+    return await server_service.validate_creation_request(request, db)
 
 
 @router.get("", response_model=ServerListResponse)

--- a/app/servers/schemas.py
+++ b/app/servers/schemas.py
@@ -374,3 +374,38 @@ class ServerExportResponse(BaseModel):
     file_size: int
     created_at: datetime
     download_url: str
+
+
+class ValidateServerCreationResponse(BaseModel):
+    """Response payload for ``POST /api/v1/servers/validate`` (Issue #33).
+
+    ``warnings`` reuses :class:`~app.core.error_schemas.ErrorDetail` so
+    the validation feedback shape is identical to the structured
+    ``details`` carried by failure responses (the frontend only needs
+    one renderer).
+    """
+
+    valid: bool = Field(
+        ..., description="True when the request would create successfully."
+    )
+    warnings: List["ErrorDetail"] = Field(
+        default_factory=list,
+        description=(
+            "Structured per-field issues. Empty when ``valid`` is True. "
+            "Each entry mirrors the ``details`` shape used by failure "
+            "responses so a single renderer covers both flows."
+        ),
+    )
+    suggested_ports: List[int] = Field(
+        default_factory=list,
+        description=(
+            "Up to 3 free ports starting near the requested one. Surfaced "
+            "even on a successful validation so frontends can render "
+            "near-by alternatives."
+        ),
+    )
+
+
+from app.core.error_schemas import ErrorDetail  # noqa: E402
+
+ValidateServerCreationResponse.model_rebuild()

--- a/tests/integration/servers/test_port_conflicts.py
+++ b/tests/integration/servers/test_port_conflicts.py
@@ -156,10 +156,17 @@ class TestServerPortConflicts:
         if server_dir.exists():
             shutil.rmtree(server_dir)
 
-    def test_create_server_allows_duplicate_ports_with_any_status(
+    def test_create_server_rejects_duplicate_port_when_existing_is_active(
         self, client: TestClient, admin_headers, db, admin_user
     ):
-        """Test that creating servers with duplicate ports is allowed regardless of existing server status"""
+        """Issue #33: creation must reject a port already held by an
+        active server (``starting`` or ``running``) and return a 409 with
+        structured ``suggested_ports`` so the frontend can offer free
+        alternatives without a second round-trip.
+
+        Stopped servers do NOT block reuse — that behaviour is preserved
+        by the two preceding tests.
+        """
         # First, create a version in the database to ensure it's supported
         from app.core.datetime_utils import utcnow
         from app.versions.models import MinecraftVersion
@@ -175,7 +182,7 @@ class TestServerPortConflicts:
         db.add(version)
         db.commit()
 
-        # Create a starting server with port 25567
+        # Create a starting server with port 25567 — this should block reuse
         make_server(
             db,
             admin_user,
@@ -200,10 +207,10 @@ class TestServerPortConflicts:
             mock_cache.return_value = "/cache/test-vanilla-1.21.6.jar"
             mock_copy.return_value = "/server/server.jar"
 
-            # Try to create another server with the same port - this should now succeed
+            # Try to create another server with the same port — must 409
             server_data = {
                 "name": "New Server",
-                "description": "This should succeed",
+                "description": "Conflicts with active server on 25567",
                 "minecraft_version": "1.21.6",
                 "server_type": "vanilla",
                 "port": 25567,
@@ -215,15 +222,26 @@ class TestServerPortConflicts:
                 "/api/v1/servers/", headers=admin_headers, json=server_data
             )
 
-            assert response.status_code == status.HTTP_201_CREATED
-            server_response = response.json()
-            assert server_response["port"] == 25567
-            assert server_response["name"] == "New Server"
+            assert response.status_code == status.HTTP_409_CONFLICT
+            body = response.json()
+            # Standardized error envelope (Issue #76): ``error`` is the
+            # machine code, ``details`` is a list of ErrorDetail entries.
+            assert body["error"] == "SERVER_PORT_CONFLICT"
+            details = body["details"]
+            assert isinstance(details, list) and len(details) >= 1
 
-        # Cleanup
-        import shutil
-        from pathlib import Path
+            # First detail is the conflict itself; subsequent entries
+            # (if any) are PORT_SUGGESTION candidates populated by
+            # ``port_allocator.find_available_ports``.
+            conflict = next(d for d in details if d["code"] == "PORT_IN_USE")
+            assert conflict["field"] == "port"
+            assert "25567" in conflict["message"]
+            assert "Starting Server" in conflict["message"]
 
-        server_dir = Path(server_response["directory_path"])
-        if server_dir.exists():
-            shutil.rmtree(server_dir)
+            suggestions = [
+                int(d["message"]) for d in details if d["code"] == "PORT_SUGGESTION"
+            ]
+            # Suggestions start after the held port and never include it.
+            assert 25567 not in suggestions
+            for suggested in suggestions:
+                assert suggested >= 25568

--- a/tests/integration/versions/test_database_version_integration.py
+++ b/tests/integration/versions/test_database_version_integration.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.core.exceptions import FileOperationException
 from app.servers.application.service import ServerJarService, ServerService
+from app.servers.domain.exceptions import UnsupportedMinecraftVersionError
 from app.servers.models import ServerType
 from app.servers.schemas import ServerCreateRequest
 from app.users.domain.value_objects import Role
@@ -177,8 +178,12 @@ class TestDatabaseVersionIntegration:
             port=25565,
         )
 
-        # Mock filesystem and validation to avoid unrelated errors
-        # Also mock jar service to ensure version validation happens first
+        # Mock filesystem and validation to avoid unrelated errors. The
+        # Issue #33 preflight calls ``ServerService._is_version_supported_db``
+        # directly (see ``_validate_creation_preconditions``) so we patch
+        # that and force it to report the version as unsupported; the
+        # resulting domain error is ``UnsupportedMinecraftVersionError``
+        # (HTTP 400 with ``error_code=SERVER_UNSUPPORTED_VERSION``).
         with (
             patch.object(
                 server_service.validation_service, "validate_server_uniqueness"
@@ -188,21 +193,22 @@ class TestDatabaseVersionIntegration:
                 server_service.filesystem_service, "create_server_directory"
             ) as mock_dir,
             patch.object(
-                server_service.jar_service, "_is_version_supported_db"
-            ) as mock_jar_version_check,
+                server_service, "_is_version_supported_db"
+            ) as mock_version_check,
         ):
             mock_unique.return_value = None
             mock_java.return_value = None
             mock_dir.return_value = Path("/tmp/test-server")
-            # Make jar service version check return False (unsupported)
-            mock_jar_version_check.return_value = False
+            # Make preflight version check return False (unsupported)
+            mock_version_check.return_value = False
 
-            # Should raise FileOperationException wrapping the version validation error
-            with pytest.raises(FileOperationException) as exc_info:
+            # Should raise the actionable domain exception introduced in
+            # Issue #33 (mapped to HTTP 400 by error_handlers.py).
+            with pytest.raises(UnsupportedMinecraftVersionError) as exc_info:
                 await server_service.create_server(request, mock_admin_user, db)
 
-            # Verify error message mentions unsupported version
-            assert "not supported" in str(exc_info.value.detail).lower()
+            assert exc_info.value.version == "1.99.99"
+            assert exc_info.value.server_type == "vanilla"
 
     @pytest.mark.asyncio
     async def test_database_only_performance(self, jar_service, db, sample_db_version):

--- a/tests/unit/core/test_error_handlers.py
+++ b/tests/unit/core/test_error_handlers.py
@@ -32,8 +32,13 @@ from app.groups.domain.exceptions import (
 )
 from app.middleware.audit_middleware import AuditMiddleware
 from app.servers.domain.exceptions import (
+    JavaCompatibilityError,
     ServerAccessError,
+    ServerJarDownloadError,
+    ServerNameConflictError,
     ServerNotFoundError,
+    ServerPortConflictError,
+    UnsupportedMinecraftVersionError,
 )
 from app.templates.domain.exceptions import TemplateNotFoundError
 
@@ -85,6 +90,40 @@ def _build_app() -> FastAPI:
     @app.get("/raise-template-not-found")
     def _template_nf():
         raise TemplateNotFoundError("nope")
+
+    # ---- Issue #33: server-creation actionable errors ----
+    @app.get("/raise-server-name-conflict")
+    def _server_name_conflict():
+        raise ServerNameConflictError("dup-name")
+
+    @app.get("/raise-server-port-conflict")
+    def _server_port_conflict():
+        raise ServerPortConflictError(
+            port=25565,
+            conflicting_server="other-server",
+            suggested_ports=[25566, 25567, 25568],
+        )
+
+    @app.get("/raise-server-unsupported-version")
+    def _server_unsupported_version():
+        raise UnsupportedMinecraftVersionError(version="0.1", server_type="vanilla")
+
+    @app.get("/raise-server-java-incompatible")
+    def _server_java_incompatible():
+        raise JavaCompatibilityError(
+            minecraft_version="1.21.1",
+            required_java=21,
+            available_java=[17],
+        )
+
+    @app.get("/raise-server-jar-download-failed")
+    def _server_jar_download_failed():
+        raise ServerJarDownloadError(
+            server_type="vanilla",
+            version="1.21.6",
+            reason="network",
+            retry_hint="Check internet connectivity",
+        )
 
     @app.get("/raise-legacy-not-found")
     def _legacy_nf():
@@ -157,6 +196,74 @@ class TestDomainExceptionHandlers:
         r = _client().get("/raise-template-not-found")
         assert r.status_code == 404
         assert r.json()["error"] == "TEMPLATE_NOT_FOUND"
+
+
+class TestServerCreationActionableErrors:
+    """Verify Issue #33 server-creation exceptions surface ``extra_details``."""
+
+    def test_server_name_conflict_returns_409_with_field_detail(self):
+        r = _client().get("/raise-server-name-conflict")
+        assert r.status_code == 409
+        body = r.json()
+        assert body["error"] == "SERVER_NAME_CONFLICT"
+        details = body.get("details") or []
+        # The name field detail comes from ``ServerNameConflictError.extra_details``.
+        assert any(
+            d.get("field") == "name" and d.get("code") == "SERVER_NAME_TAKEN"
+            for d in details
+        )
+
+    def test_server_port_conflict_returns_409_with_suggestions(self):
+        r = _client().get("/raise-server-port-conflict")
+        assert r.status_code == 409
+        body = r.json()
+        assert body["error"] == "SERVER_PORT_CONFLICT"
+        details = body.get("details") or []
+        # First entry pinpoints the conflicting port.
+        assert any(
+            d.get("field") == "port" and d.get("code") == "PORT_IN_USE" for d in details
+        )
+        # Suggested ports are appended with the ``PORT_SUGGESTION`` code.
+        suggestion_messages = [
+            d.get("message") for d in details if d.get("code") == "PORT_SUGGESTION"
+        ]
+        assert suggestion_messages == ["25566", "25567", "25568"]
+
+    def test_server_unsupported_version_returns_400(self):
+        r = _client().get("/raise-server-unsupported-version")
+        assert r.status_code == 400
+        body = r.json()
+        assert body["error"] == "SERVER_UNSUPPORTED_VERSION"
+        details = body.get("details") or []
+        assert any(d.get("code") == "VERSION_NOT_SUPPORTED" for d in details)
+        assert any(d.get("code") == "RESOLUTION_STEP" for d in details)
+
+    def test_server_java_incompatible_returns_400_with_available_versions(self):
+        r = _client().get("/raise-server-java-incompatible")
+        assert r.status_code == 400
+        body = r.json()
+        assert body["error"] == "SERVER_JAVA_INCOMPATIBLE"
+        details = body.get("details") or []
+        assert any(d.get("code") == "JAVA_REQUIRED" for d in details)
+        # Available Java versions encoded as ``JAVA_AVAILABLE`` rows.
+        available = [
+            d.get("message") for d in details if d.get("code") == "JAVA_AVAILABLE"
+        ]
+        assert "17" in available
+
+    def test_server_jar_download_failed_returns_502_with_retry_hint(self):
+        r = _client().get("/raise-server-jar-download-failed")
+        assert r.status_code == 502
+        body = r.json()
+        assert body["error"] == "SERVER_JAR_DOWNLOAD_FAILED"
+        details = body.get("details") or []
+        # The structured reason + retry hint travel through ``details``.
+        assert any(d.get("code") == "JAR_DOWNLOAD_REASON" for d in details)
+        assert any(
+            d.get("code") == "RESOLUTION_STEP"
+            and "internet connectivity" in (d.get("message") or "")
+            for d in details
+        )
 
 
 class TestLegacyAPIExceptionHandler:

--- a/tests/unit/servers/application/test_creation_preflight.py
+++ b/tests/unit/servers/application/test_creation_preflight.py
@@ -1,0 +1,240 @@
+"""Tests for ``ServerService`` creation pre-flight validation (Issue #33).
+
+These tests exercise the new ``_validate_creation_preconditions`` path
+and the public ``validate_creation_request`` API. They construct a
+``ServerService`` with a fake ``ServerRepository`` so the in-DB checks
+are exercised without standing up SQLAlchemy.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from app.servers.application.service import ServerService
+from app.servers.domain.entities import ServerEntity
+from app.servers.domain.exceptions import (
+    JavaCompatibilityError,
+    ServerNameConflictError,
+    ServerPortConflictError,
+    UnsupportedMinecraftVersionError,
+)
+from app.servers.models import ServerStatus, ServerType
+from app.servers.schemas import ServerCreateRequest
+from app.users.domain.value_objects import Role
+from app.users.models import User
+
+
+def _entity(*, id_: int, name: str, port: int, status: ServerStatus) -> ServerEntity:
+    """Build a minimal :class:`ServerEntity` for fake-repo responses.
+
+    Uses ``Mock(spec=ServerEntity)`` to dodge the frozen-dataclass
+    construction cost; only the attributes touched by the production
+    code under test (``name``, ``port``, ``id``) need to be set.
+    """
+    e = Mock(spec=ServerEntity)
+    e.id = id_
+    e.name = name
+    e.port = port
+    e.status = status
+    return e
+
+
+class _FakeServerRepo:
+    """Minimal in-memory ``ServerRepository`` stand-in for the tests."""
+
+    def __init__(
+        self,
+        *,
+        existing_name: Optional[str] = None,
+        port_owner: Optional[str] = None,
+        port_in_use: Optional[int] = None,
+    ) -> None:
+        self._existing_name = existing_name
+        self._port_owner = port_owner
+        self._port_in_use = port_in_use
+
+    async def get_by_name(self, name: str, *, include_deleted: bool = False):
+        if self._existing_name and name == self._existing_name:
+            return _entity(id_=1, name=name, port=25565, status=ServerStatus.stopped)
+        return None
+
+    async def list_by_port(
+        self,
+        port,
+        *,
+        statuses=None,
+        exclude_id=None,
+        include_deleted: bool = False,
+    ) -> List[ServerEntity]:
+        # The pre-flight check passes ``port=<requested>`` with the
+        # active-status filter; the suggestion lookup passes
+        # ``port=None``.
+        if port is None:
+            # Suggestions: report a single "running" server on port
+            # 25565 so the iterator hops past it when start_port==25566.
+            if self._port_in_use is not None:
+                return [
+                    _entity(
+                        id_=99,
+                        name=self._port_owner or "running-server",
+                        port=self._port_in_use,
+                        status=ServerStatus.running,
+                    )
+                ]
+            return []
+        # Specific port query
+        if self._port_in_use is not None and port == self._port_in_use:
+            return [
+                _entity(
+                    id_=99,
+                    name=self._port_owner or "running-server",
+                    port=port,
+                    status=ServerStatus.running,
+                )
+            ]
+        return []
+
+
+@pytest.fixture
+def owner():
+    u = Mock(spec=User)
+    u.id = 1
+    u.username = "tester"
+    u.role = Role.admin
+    return u
+
+
+@pytest.fixture
+def request_25565():
+    return ServerCreateRequest(
+        name="my-server",
+        description=None,
+        minecraft_version="1.21.6",
+        server_type=ServerType.vanilla,
+        port=25565,
+        max_memory=1024,
+        max_players=20,
+    )
+
+
+class TestNameConflict:
+    @pytest.mark.asyncio
+    async def test_create_server_raises_name_conflict(self, owner, request_25565):
+        repo = _FakeServerRepo(existing_name="my-server")
+        service = ServerService(server_repo=repo)
+
+        with pytest.raises(ServerNameConflictError) as exc:
+            await service.create_server(request_25565, owner, db=Mock())
+
+        assert exc.value.error_code == "SERVER_NAME_CONFLICT"
+        assert exc.value.name == "my-server"
+        details = exc.value.extra_details()
+        assert any(d.field == "name" for d in details)
+
+
+class TestPortConflict:
+    @pytest.mark.asyncio
+    async def test_port_conflict_includes_holder_and_suggestions(
+        self, owner, request_25565
+    ):
+        repo = _FakeServerRepo(
+            port_in_use=25565,
+            port_owner="running-server",
+        )
+        service = ServerService(server_repo=repo)
+        # Make the version + java probes pass so we hit the port branch.
+        service._is_version_supported_db = AsyncMock(return_value=True)
+        service._validate_java_compatibility = AsyncMock()
+
+        with pytest.raises(ServerPortConflictError) as exc:
+            await service.create_server(request_25565, owner, db=Mock())
+
+        assert exc.value.port == 25565
+        assert exc.value.conflicting_server == "running-server"
+        # Suggestions are computed starting at port+1; since the fake
+        # only reports port 25565 as taken, the first three free ports
+        # are 25566/25567/25568.
+        assert exc.value.suggested_ports[:3] == [25566, 25567, 25568]
+
+
+class TestUnsupportedVersion:
+    @pytest.mark.asyncio
+    async def test_unsupported_version_raises_structured_error(
+        self, owner, request_25565
+    ):
+        repo = _FakeServerRepo()
+        service = ServerService(server_repo=repo)
+        service._is_version_supported_db = AsyncMock(return_value=False)
+
+        with pytest.raises(UnsupportedMinecraftVersionError) as exc:
+            await service.create_server(request_25565, owner, db=Mock())
+
+        assert exc.value.version == "1.21.6"
+        assert exc.value.server_type == "vanilla"
+
+
+class TestJavaCompatibility:
+    @pytest.mark.asyncio
+    async def test_java_compatibility_failure_translated(
+        self, owner, request_25565, monkeypatch
+    ):
+        repo = _FakeServerRepo()
+        service = ServerService(server_repo=repo)
+        service._is_version_supported_db = AsyncMock(return_value=True)
+
+        # Patch the module-level java_compatibility_service so the
+        # "no java found" path is exercised.
+        from app.servers.application import service as svc_mod
+
+        fake_java = Mock()
+        fake_java.get_required_java_version = Mock(return_value=21)
+        fake_java.get_java_for_minecraft = AsyncMock(return_value=None)
+        fake_java.discover_java_installations = AsyncMock(return_value={17: object()})
+        monkeypatch.setattr(svc_mod, "java_compatibility_service", fake_java)
+
+        with pytest.raises(JavaCompatibilityError) as exc:
+            await service.create_server(request_25565, owner, db=Mock())
+
+        assert exc.value.required_java == 21
+        assert exc.value.available_java == [17]
+
+
+class TestValidateCreationRequest:
+    @pytest.mark.asyncio
+    async def test_validate_returns_warnings_on_port_conflict(self, owner, request_25565):
+        repo = _FakeServerRepo(port_in_use=25565, port_owner="running-server")
+        service = ServerService(server_repo=repo)
+        service._is_version_supported_db = AsyncMock(return_value=True)
+        service._validate_java_compatibility = AsyncMock()
+
+        result = await service.validate_creation_request(request_25565, db=Mock())
+
+        assert result.valid is False
+        # The warnings list carries the SERVER_PORT_CONFLICT entry plus
+        # the structured ``details`` rows derived from ``extra_details``.
+        warning_codes = {w.code for w in result.warnings}
+        assert "SERVER_PORT_CONFLICT" in warning_codes
+        assert "PORT_IN_USE" in warning_codes
+        # ``suggested_ports`` is populated even on the failure path so
+        # the frontend can render alternatives in a single round-trip.
+        assert result.suggested_ports[:3] == [25566, 25567, 25568]
+
+    @pytest.mark.asyncio
+    async def test_validate_returns_valid_when_all_checks_pass(
+        self, owner, request_25565
+    ):
+        repo = _FakeServerRepo()
+        service = ServerService(server_repo=repo)
+        service._is_version_supported_db = AsyncMock(return_value=True)
+        service._validate_java_compatibility = AsyncMock()
+
+        result = await service.validate_creation_request(request_25565, db=Mock())
+
+        assert result.valid is True
+        assert result.warnings == []
+        # Suggestions are still computed (allocator returns ports near
+        # the requested one).
+        assert request_25565.port in result.suggested_ports

--- a/tests/unit/servers/routers/test_management.py
+++ b/tests/unit/servers/routers/test_management.py
@@ -48,7 +48,16 @@ class TestServerManagementRouter:
     async def test_create_server_general_exception(
         self, mock_can_create, mock_server_service, admin_user
     ):
-        """Test create server with general exception (lines 69-72)"""
+        """Generic service exceptions now propagate to the global handler.
+
+        Issue #33 removed the catch-all ``except Exception`` from
+        ``create_server`` so structured domain exceptions reach the
+        global handler in :mod:`app.core.error_handlers` unmolested.
+        Anything that escapes the service is the bare ``Exception``
+        type — assert it bubbles up rather than being re-wrapped as a
+        500 ``HTTPException`` (the global handler does the mapping
+        now).
+        """
         from app.servers.routers.management import create_server
         from app.servers.schemas import ServerCreateRequest
 
@@ -66,7 +75,7 @@ class TestServerManagementRouter:
             max_players=20,
         )
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(Exception, match="Database error"):
             await create_server(
                 request=request,
                 background_tasks=BackgroundTasks(),
@@ -74,9 +83,6 @@ class TestServerManagementRouter:
                 db=Mock(),
                 server_service=mock_server_service,
             )
-
-        assert exc_info.value.status_code == 500
-        assert "Failed to create server" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
     @patch("app.servers.routers.management.server_service")
@@ -208,13 +214,19 @@ class TestServerManagementRouter:
     async def test_create_server_conflict_exception_passthrough(
         self, mock_can_create, mock_server_service, admin_user
     ):
-        """Test create server with ConflictException passthrough (lines 67-68)"""
-        from app.core.exceptions import ConflictException
+        """Domain conflict exceptions propagate to the global handler.
+
+        Issue #33 removed the catch-all wrapper from the router; the
+        ``ServerNameConflictError`` is now mapped to HTTP 409 by
+        :mod:`app.core.error_handlers` rather than by an inline router
+        ``except``. Assert the exception bubbles unmolested.
+        """
+        from app.servers.domain.exceptions import ServerNameConflictError
         from app.servers.routers.management import create_server
         from app.servers.schemas import ServerCreateRequest
 
-        # Mock server service to raise ConflictException
-        conflict_exception = ConflictException("Port already in use")
+        # Mock server service to raise the structured domain error
+        conflict_exception = ServerNameConflictError("test-server")
         mock_server_service.create_server = AsyncMock(side_effect=conflict_exception)
 
         request = ServerCreateRequest(
@@ -227,14 +239,86 @@ class TestServerManagementRouter:
             max_players=20,
         )
 
-        # ConflictException should be re-raised as-is
-        with pytest.raises(ConflictException):
+        with pytest.raises(ServerNameConflictError):
             await create_server(
                 request=request,
                 background_tasks=BackgroundTasks(),
                 current_user=admin_user,
                 db=Mock(),
                 server_service=mock_server_service,
+            )
+
+    # ---- Issue #33: /validate endpoint --------------------------------
+
+    @pytest.mark.asyncio
+    @patch(
+        "app.servers.application.authorization.AuthorizationService.can_create_server",
+        return_value=True,
+    )
+    async def test_validate_server_creation_passes_through_to_service(
+        self, mock_can_create, admin_user
+    ):
+        """``/validate`` delegates to ``server_service.validate_creation_request``."""
+        from app.servers.routers.management import validate_server_creation
+        from app.servers.schemas import (
+            ServerCreateRequest,
+            ValidateServerCreationResponse,
+        )
+
+        mock_service = Mock()
+        expected = ValidateServerCreationResponse(
+            valid=True, warnings=[], suggested_ports=[25565, 25566, 25567]
+        )
+        mock_service.validate_creation_request = AsyncMock(return_value=expected)
+
+        request = ServerCreateRequest(
+            name="test-server",
+            minecraft_version="1.20.1",
+            server_type=ServerType.vanilla,
+            port=25565,
+            max_memory=1024,
+            max_players=20,
+        )
+
+        result = await validate_server_creation(
+            request=request,
+            current_user=admin_user,
+            db=Mock(),
+            server_service=mock_service,
+        )
+
+        assert result is expected
+        mock_service.validate_creation_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch(
+        "app.servers.application.authorization.AuthorizationService.can_create_server",
+        return_value=False,
+    )
+    async def test_validate_server_creation_authorization_denied(
+        self, mock_can_create, admin_user
+    ):
+        """``/validate`` enforces the same ``can_create_server`` gate as ``POST``."""
+        from app.servers.domain.exceptions import ServerAccessError
+        from app.servers.routers.management import validate_server_creation
+        from app.servers.schemas import ServerCreateRequest
+
+        mock_service = Mock()
+        request = ServerCreateRequest(
+            name="x",
+            minecraft_version="1.20.1",
+            server_type=ServerType.vanilla,
+            port=25565,
+            max_memory=1024,
+            max_players=20,
+        )
+
+        with pytest.raises(ServerAccessError):
+            await validate_server_creation(
+                request=request,
+                current_user=admin_user,
+                db=Mock(),
+                server_service=mock_service,
             )
 
     @pytest.mark.asyncio

--- a/tests/unit/servers/test_service.py
+++ b/tests/unit/servers/test_service.py
@@ -210,7 +210,16 @@ class TestServerService:
     async def test_create_server_unsupported_version(
         self, server_service, mock_request, mock_user, mock_db
     ):
-        """Test server creation with unsupported version (database validation)"""
+        """Server creation with an unsupported version raises a structured error.
+
+        Issue #33 replaced the generic ``InvalidRequestException`` with
+        :class:`UnsupportedMinecraftVersionError` so the global handler
+        can render an actionable ``SERVER_UNSUPPORTED_VERSION`` 400
+        response. The message still names the offending version + type
+        so existing UI strings continue to match.
+        """
+        from app.servers.domain.exceptions import UnsupportedMinecraftVersionError
+
         # Mock validation to pass initial checks
         server_service.validation_service.validate_server_uniqueness = AsyncMock()
 
@@ -223,10 +232,12 @@ class TestServerService:
             # Mock the database version validation method to return False
             server_service._is_version_supported_db = AsyncMock(return_value=False)
 
-            with pytest.raises(InvalidRequestException) as exc_info:
+            with pytest.raises(UnsupportedMinecraftVersionError) as exc_info:
                 await server_service.create_server(mock_request, mock_user, mock_db)
 
-            assert "Version 1.20.1 is not supported for vanilla" in str(exc_info.value)
+            assert exc_info.value.error_code == "SERVER_UNSUPPORTED_VERSION"
+            assert exc_info.value.version == "1.20.1"
+            assert exc_info.value.server_type == "vanilla"
 
     @pytest.mark.asyncio
     async def test_get_server_success(self, server_service, mock_db):

--- a/tests/unit/servers/test_simplified_sync.py
+++ b/tests/unit/servers/test_simplified_sync.py
@@ -79,10 +79,12 @@ class TestBidirectionalSync:
             f.write("server-port=25599\n")
             f.write("max-players=20\n")
 
-        success, description, updated = (
-            await simplified_sync_service.perform_simplified_sync(
-                test_server, properties_path, repo
-            )
+        (
+            success,
+            description,
+            updated,
+        ) = await simplified_sync_service.perform_simplified_sync(
+            test_server, properties_path, repo
         )
 
         assert success is True
@@ -105,10 +107,12 @@ class TestBidirectionalSync:
             f.write("max-players=20\n")
             f.write("motd=A Minecraft Server\n")
 
-        success, description, updated = (
-            await simplified_sync_service.perform_simplified_sync(
-                test_server, properties_path, repo
-            )
+        (
+            success,
+            description,
+            updated,
+        ) = await simplified_sync_service.perform_simplified_sync(
+            test_server, properties_path, repo
         )
 
         assert success is True
@@ -122,10 +126,12 @@ class TestBidirectionalSync:
         """No sync needed when ports already match (simplified logic)."""
         properties_path = Path(test_server.directory_path) / "server.properties"
 
-        success, description, updated = (
-            await simplified_sync_service.perform_simplified_sync(
-                test_server, properties_path, repo
-            )
+        (
+            success,
+            description,
+            updated,
+        ) = await simplified_sync_service.perform_simplified_sync(
+            test_server, properties_path, repo
         )
 
         assert success is True
@@ -143,10 +149,12 @@ class TestBidirectionalSync:
             f.write("max-players=20\n")
             f.write("motd=Manually Edited Server\n")
 
-        success, description, updated = (
-            await simplified_sync_service.perform_simplified_sync(
-                test_server, properties_path, repo
-            )
+        (
+            success,
+            description,
+            updated,
+        ) = await simplified_sync_service.perform_simplified_sync(
+            test_server, properties_path, repo
         )
 
         assert success is True
@@ -177,10 +185,12 @@ class TestBidirectionalSync:
         synced_entity = await repo.get(test_server.id)
         assert synced_entity is not None
 
-        success, description, updated = (
-            await simplified_sync_service.perform_simplified_sync(
-                synced_entity, properties_path, repo
-            )
+        (
+            success,
+            description,
+            updated,
+        ) = await simplified_sync_service.perform_simplified_sync(
+            synced_entity, properties_path, repo
         )
         assert success is True
         assert "No sync needed" in description


### PR DESCRIPTION
## Summary
- Add **7 new domain exceptions** with `error_code` + `extra_details()` so server-creation failures surface structured, actionable details (suggested ports, supported versions, required Java, etc.) instead of an opaque 500.
- Add a **pre-flight port check** to `create_server` (no more waiting until start time to discover port collisions) plus a `port_allocator` helper that returns `suggested_ports`.
- Add **`POST /api/v1/servers/validate`** — runs the same preflight pipeline in collect mode and returns 200 with `valid=false` + a list of warnings, so the frontend can render inline UI before commit.

## Architecture
`ErrorResponse.from_exception` is extended to read an optional `extra_details()` method on each `ServerError` subclass. Each exception owns:

- `error_code` (stable machine-readable string)
- `http_status` (mapping to HTTP code via `error_handlers.py`)
- `extra_details()` (suggested_ports, supported_versions, required_java_version, etc.)

This keeps controllers thin (just `raise`), avoids leaking internal stack traces, and lets the frontend act on `details` without string parsing.

## Endpoints

| Method | Path                          | Status on success | Notes |
|--------|-------------------------------|-------------------|-------|
| POST   | `/api/v1/servers`             | 201               | Now runs preflight; can return 400/409/500/502 with structured `details` |
| POST   | `/api/v1/servers/validate`    | 200               | Always 200; `valid=false` carries warnings (collect mode) |

### Error codes on `POST /api/v1/servers`

| HTTP | error_code                       | Trigger |
|------|----------------------------------|---------|
| 400  | `SERVER_UNSUPPORTED_VERSION`     | Minecraft version not in supported list |
| 400  | `SERVER_JAVA_INCOMPATIBLE`       | Required Java major not available on host |
| 409  | `SERVER_NAME_CONFLICT`           | Name already used |
| 409  | `SERVER_PORT_CONFLICT`           | DB-level port collision (preflight); response includes `suggested_ports` |
| 500  | `SERVER_DIRECTORY_FAILED`        | Filesystem create / permission failure |
| 500  | `SERVER_CREATION_ROLLBACK_FAILED`| Rollback after partial failure failed |
| 502  | `SERVER_JAR_DOWNLOAD_FAILED`     | Upstream JAR download / integrity failure |

## Files changed
- `app/servers/domain/exceptions.py` — 7 new exception classes with `extra_details()`
- `app/servers/application/service.py` — preflight in `create_server`, new `validate_creation_request`
- `app/servers/application/port_allocator.py` *(new)* — `find_available_ports`
- `app/servers/routers/management.py` — wire `POST /validate`
- `app/servers/routers/import_export.py` — replace inline dup-port loop with `port_allocator`
- `app/servers/schemas.py` — `ValidateServerCreationResponse` + warning schema
- `app/core/error_handlers.py` — surface `extra_details()` in `ErrorResponse`
- Tests: 4 modified + 1 new (`tests/unit/servers/application/test_creation_preflight.py`)

## Test plan
- [x] `uv run pytest tests/unit/servers -m "not slow"` — 329 passed, 1 skipped
- [x] `uv run pytest tests/unit -m "not slow"` — 1461 passed, 5 skipped
- [x] `uv run ruff check app/ tests/` — no new errors vs baseline (29 pre-existing, none in changed files)
- [x] `uv run ruff format --check app/ tests/` — changed files clean (2 unrelated files pre-existing reformats)
- [ ] CI on push (`ci.yaml`) full suite incl. `slow`
- [ ] Manual smoke: hit `POST /api/v1/servers` with a duplicate port -> expect 409 + `suggested_ports` in `details`
- [ ] Manual smoke: hit `POST /api/v1/servers/validate` with several issues -> expect 200 + collected warnings

## Out of scope
- Socket-level port availability check at create time. The DB-level check catches the most common failure (two servers configured on the same port); the existing socket bind check at start time is kept as the authoritative live-port verifier and is not duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>