### PR TITLE
feat: optional port + auto-assign + port discovery endpoints (Resolves #31, Resolves #32)

### DIFF
--- a/app/core/error_handlers.py
+++ b/app/core/error_handlers.py
@@ -60,6 +60,7 @@ from app.groups.domain.exceptions import (
 from app.servers.domain.exceptions import (
     InvalidServerStateError,
     JavaCompatibilityError,
+    NoAvailablePortError,
     ServerAccessError,
     ServerAlreadyExistsError,
     ServerCreationRollbackError,
@@ -236,6 +237,16 @@ def register_exception_handlers(app: FastAPI) -> None:
             status_code=status.HTTP_409_CONFLICT,
             default_message="Port already in use by another server",
             fallback_code="SERVER_PORT_CONFLICT",
+        )
+
+    @app.exception_handler(NoAvailablePortError)
+    async def _server_no_port_available(request: Request, exc: NoAvailablePortError):
+        return _domain_response(
+            request,
+            exc,
+            status_code=status.HTTP_409_CONFLICT,
+            default_message="No available port in the searched range",
+            fallback_code="SERVER_NO_PORT_AVAILABLE",
         )
 
     @app.exception_handler(UnsupportedMinecraftVersionError)

--- a/app/servers/application/service.py
+++ b/app/servers/application/service.py
@@ -89,6 +89,7 @@ from app.servers.domain.entities import (
 )
 from app.servers.domain.exceptions import (
     JavaCompatibilityError,
+    NoAvailablePortError,
     ServerCreationRollbackError,
     ServerJarDownloadError,
     ServerNameConflictError,
@@ -129,6 +130,13 @@ __all__ = [
     "ServerDatabaseService",
     "ServerService",
 ]
+
+# Default starting port for the auto-assign path (Issue #32). The
+# Minecraft community convention is 25565; we walk upward from there
+# when ``ServerCreateRequest.port`` is omitted. Hardcoded — see the
+# delivery plan: making this configurable adds knobs without a known
+# caller and complicates the discovery endpoint contract.
+DEFAULT_PORT_START = 25565
 
 
 # ---------------------------------------------------------------------------
@@ -632,6 +640,34 @@ class ServerService:
         ServerSecurityValidator.validate_server_name(request.name)
         ServerSecurityValidator.validate_memory_value(request.max_memory)
 
+        # ---- Auto-assign port (Issue #32) ----
+        # When ``port`` is omitted, walk from ``DEFAULT_PORT_START`` to
+        # find the first free port. Done **before** the conflict check
+        # below so the conflict path always sees a concrete integer.
+        # The discovery only consults the database (active-status
+        # servers) — see ``port_allocator.find_available_ports``.
+        if request.port is None:
+            if self._server_repo is None:
+                # Legacy fallback (no DI). Best-effort: default to the
+                # historical 25565 and let downstream logic surface a
+                # conflict if needed. The repo-less path is exercised
+                # only by unit tests that mock ``database_service``.
+                request.port = DEFAULT_PORT_START
+            else:
+                picks = await find_available_ports(
+                    self._server_repo, DEFAULT_PORT_START, count=1
+                )
+                if not picks:
+                    raise NoAvailablePortError(start_port=DEFAULT_PORT_START)
+                request.port = picks[0]
+                logger.info(
+                    "server_create_port_auto_assigned",
+                    extra={
+                        "server_name": request.name,
+                        "assigned_port": request.port,
+                    },
+                )
+
         # ---- Port pre-flight ----
         logger.info(
             "server_create_step",
@@ -743,11 +779,17 @@ class ServerService:
         # Always provide at least one alternative port suggestion when
         # the repo is wired — useful both for the conflict path and for
         # frontends that want to show "free ports near your choice"
-        # affordances independent of any failure.
+        # affordances independent of any failure. When the request omits
+        # ``port`` entirely (Issue #32 auto-assign), the
+        # ``_validate_creation_preconditions`` call above has already
+        # populated ``request.port`` with the auto-assigned value; fall
+        # back to the default start port if validation aborted before
+        # that step ran.
         suggested_ports: List[int] = []
         if self._server_repo is not None:
+            start = request.port if request.port is not None else DEFAULT_PORT_START
             suggested_ports = await find_available_ports(
-                self._server_repo, start_port=request.port, count=3
+                self._server_repo, start_port=start, count=3
             )
 
         return ValidateServerCreationResponse(

--- a/app/servers/domain/exceptions.py
+++ b/app/servers/domain/exceptions.py
@@ -351,6 +351,51 @@ class ServerDirectoryCreationError(ServerError):
         ]
 
 
+class NoAvailablePortError(ServerError):
+    """Raised when no free port can be located in the search range (Issue #32).
+
+    The auto-assignment path (``ServerCreateRequest.port`` omitted) and the
+    ``GET /api/v1/servers/ports/available`` discovery endpoint both walk
+    the port range starting at a configured ``start_port`` and stop at
+    ``range_end``. When every candidate is held by an active server the
+    application surfaces this exception so the caller receives a
+    structured 409 instead of an opaque 500.
+    """
+
+    error_code: ClassVar[str] = "SERVER_NO_PORT_AVAILABLE"
+
+    def __init__(
+        self,
+        start_port: int,
+        range_end: int = 65535,
+    ) -> None:
+        self.start_port = start_port
+        self.range_end = range_end
+        super().__init__(
+            f"No available port found in range {start_port}-{range_end}. "
+            "All candidate ports are currently in use by active servers."
+        )
+
+    def extra_details(self) -> List[ErrorDetail]:
+        return [
+            ErrorDetail(
+                field="port",
+                message=(
+                    f"No available port in range {self.start_port}-{self.range_end}"
+                ),
+                code="NO_AVAILABLE_PORT",
+            ),
+            ErrorDetail(
+                field=None,
+                message=(
+                    "Stop an existing active server or widen the search range "
+                    "to free up a port."
+                ),
+                code="RESOLUTION_STEP",
+            ),
+        ]
+
+
 class ServerCreationRollbackError(ServerError):
     """Raised when cleanup after a failed server creation itself fails.
 
@@ -401,6 +446,7 @@ __all__ = [
     "ServerJarDownloadError",
     "ServerDirectoryCreationError",
     "ServerCreationRollbackError",
+    "NoAvailablePortError",
     # Legacy re-exports
     "ServerNotFoundException",
     "ServerAccessDeniedException",

--- a/app/servers/routers/__init__.py
+++ b/app/servers/routers/__init__.py
@@ -16,6 +16,8 @@ from fastapi import APIRouter, status
 
 # Import route functions directly rather than routers to avoid conflicts
 from app.servers.schemas import (
+    AvailablePortsResponse,
+    PortAvailabilityResponse,
     ServerListResponse,
     ServerLogsResponse,
     ServerResponse,
@@ -33,9 +35,11 @@ from .control import (
 )
 from .import_export import export_server, import_server
 from .management import (
+    check_port,
     create_server,
     delete_server,
     get_server,
+    list_available_ports,
     list_servers,
     update_server,
 )
@@ -58,6 +62,24 @@ router.add_api_route(
     status_code=status.HTTP_201_CREATED,
 )
 router.add_api_route("", list_servers, methods=["GET"], response_model=ServerListResponse)
+
+# Port discovery endpoints (Issue #32). Registered BEFORE the
+# ``/{server_id}`` routes so FastAPI's path matcher does not attempt
+# to coerce the literal segment ``ports`` into the ``server_id``
+# integer path parameter.
+router.add_api_route(
+    "/ports/available",
+    list_available_ports,
+    methods=["GET"],
+    response_model=AvailablePortsResponse,
+)
+router.add_api_route(
+    "/ports/check/{port}",
+    check_port,
+    methods=["GET"],
+    response_model=PortAvailabilityResponse,
+)
+
 router.add_api_route(
     "/{server_id}", get_server, methods=["GET"], response_model=ServerResponse
 )

--- a/app/servers/routers/management.py
+++ b/app/servers/routers/management.py
@@ -5,6 +5,7 @@ from fastapi import (
     BackgroundTasks,
     Depends,
     HTTPException,
+    Path,
     Query,
     status,
 )
@@ -18,19 +19,31 @@ from app.backups.domain.exceptions import (
 from app.core.database import get_db
 from app.servers.api.dependencies import (
     get_authorization_service,
+    get_server_repository,
     get_server_service,
 )
 from app.servers.application.authorization import AuthorizationService
 from app.servers.application.minecraft_server import minecraft_server_manager
+from app.servers.application.port_allocator import (
+    find_available_ports,
+    port_holder,
+)
 from app.servers.application.service import (
     ServerService,
 )
 from app.servers.application.service import (
     _server_service_legacy as server_service,  # legacy module-level alias (still referenced by older unit tests)
 )
-from app.servers.domain.exceptions import ServerAccessError, ServerNotFoundError
+from app.servers.domain.exceptions import (
+    NoAvailablePortError,
+    ServerAccessError,
+    ServerNotFoundError,
+)
+from app.servers.domain.ports import ServerRepository
 from app.servers.models import ServerStatus
 from app.servers.schemas import (
+    AvailablePortsResponse,
+    PortAvailabilityResponse,
     ServerCreateRequest,
     ServerListResponse,
     ServerResponse,
@@ -114,6 +127,85 @@ async def validate_server_creation(
         raise ServerAccessError("Insufficient permissions to validate server creation")
 
     return await server_service.validate_creation_request(request, db)
+
+
+@router.get(
+    "/ports/available",
+    response_model=AvailablePortsResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def list_available_ports(
+    start: int = Query(
+        25565,
+        ge=1024,
+        le=65535,
+        description="Starting port for the search (inclusive). Default 25565.",
+    ),
+    count: int = Query(
+        1,
+        ge=1,
+        le=50,
+        description=(
+            "Number of free ports to return (clamped to 50 to bound the "
+            "scan and mitigate DoS via large ranges)."
+        ),
+    ),
+    current_user: User = Depends(get_current_user),
+    server_repo: ServerRepository = Depends(get_server_repository),
+):
+    """Discover free ports for server creation (Issue #32).
+
+    Walks the registered-port range from ``start`` upward and returns
+    up to ``count`` ports that are not currently held by an active
+    server (``starting`` / ``running``). Stopped servers do not block
+    re-use, matching the contract enforced by the create-server path.
+
+    Authorization mirrors create — the ``can_create_server`` gate is
+    enforced so unauthenticated/unauthorized callers cannot enumerate
+    the port allocation table. Raises :class:`NoAvailablePortError`
+    (409) when the search finds zero free ports.
+    """
+    if not AuthorizationService.can_create_server(current_user):
+        raise ServerAccessError("Insufficient permissions to discover server ports")
+
+    ports = await find_available_ports(server_repo, start, count=count)
+    if not ports:
+        raise NoAvailablePortError(start_port=start)
+    return AvailablePortsResponse(ports=ports, start_port=start)
+
+
+@router.get(
+    "/ports/check/{port}",
+    response_model=PortAvailabilityResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def check_port(
+    port: int = Path(
+        ...,
+        ge=1024,
+        le=65535,
+        description="The port to query (registered range only, 1024-65535).",
+    ),
+    current_user: User = Depends(get_current_user),
+    server_repo: ServerRepository = Depends(get_server_repository),
+):
+    """Check whether a specific port is currently held (Issue #32).
+
+    Returns the active server holding the port (if any) so frontends
+    can render inline feedback before the user submits the create
+    form. Holder disclosure mirrors the create-server pre-flight
+    behaviour (gated by ``can_create_server``) — non-creator callers
+    cannot enumerate other users' ports.
+    """
+    if not AuthorizationService.can_create_server(current_user):
+        raise ServerAccessError("Insufficient permissions to check server ports")
+
+    holder = await port_holder(server_repo, port)
+    return PortAvailabilityResponse(
+        port=port,
+        available=holder is None,
+        holder=holder,
+    )
 
 
 @router.get("", response_model=ServerListResponse)

--- a/app/servers/schemas.py
+++ b/app/servers/schemas.py
@@ -103,7 +103,16 @@ class ServerCreateRequest(BaseModel):
     server_type: ServerType = Field(
         ..., description="Server type: vanilla, forge, or paper"
     )
-    port: int = Field(25565, ge=1024, le=65535, description="Server port")
+    port: Optional[int] = Field(
+        None,
+        ge=1024,
+        le=65535,
+        description=(
+            "Server port. Omit to auto-assign the next available port "
+            "starting at 25565 (Issue #32). When provided, must be a "
+            "registered (non well-known) port in the range 1024-65535."
+        ),
+    )
     max_memory: int = Field(1024, ge=512, le=16384, description="Maximum memory in MB")
     max_players: int = Field(20, ge=1, le=100, description="Maximum number of players")
     template_id: Optional[int] = Field(
@@ -409,3 +418,55 @@ class ValidateServerCreationResponse(BaseModel):
 from app.core.error_schemas import ErrorDetail  # noqa: E402
 
 ValidateServerCreationResponse.model_rebuild()
+
+
+class AvailablePortsResponse(BaseModel):
+    """Response payload for ``GET /api/v1/servers/ports/available`` (Issue #32).
+
+    Returns up to ``count`` (clamped to 50) free ports starting from
+    ``start_port``. The walk ignores ports held by servers in a
+    ``stopped`` state — those are considered re-usable because they are
+    not currently bound.
+    """
+
+    ports: List[int] = Field(
+        ...,
+        description=(
+            "Free ports discovered, in ascending order. Empty when every "
+            "port from ``start_port`` to 65535 is currently held."
+        ),
+    )
+    start_port: int = Field(
+        ...,
+        description=(
+            "The starting port the search began at. Mirrors the request "
+            "query parameter so clients can correlate a paginated walk."
+        ),
+    )
+
+
+class PortAvailabilityResponse(BaseModel):
+    """Response payload for ``GET /api/v1/servers/ports/check/{port}`` (Issue #32).
+
+    Returns whether the requested ``port`` is currently held by an
+    active server (``starting`` / ``running``). The ``holder`` field is
+    populated only when ``available`` is False; it carries the same
+    information surfaced by ``ServerPortConflictError`` so the frontend
+    can render a consistent message.
+    """
+
+    port: int = Field(..., description="The port that was queried.")
+    available: bool = Field(
+        ...,
+        description=(
+            "True when no active server currently holds the port. "
+            "Stopped servers do not count as holders."
+        ),
+    )
+    holder: Optional[str] = Field(
+        None,
+        description=(
+            "Name of the active server currently holding the port. "
+            "``None`` when ``available`` is True."
+        ),
+    )

--- a/tests/integration/servers/test_port_discovery_endpoints.py
+++ b/tests/integration/servers/test_port_discovery_endpoints.py
@@ -1,0 +1,171 @@
+"""Integration tests for the port-discovery endpoints (Issue #32).
+
+These exercise:
+  * ``GET /api/v1/servers/ports/available`` — bulk discovery with count clamping
+    and the ``NoAvailablePortError`` path.
+  * ``GET /api/v1/servers/ports/check/{port}`` — individual port checks for
+    available / held-by-active-server / held-by-stopped-server cases.
+
+Stopped servers do not block re-use — that contract matches the
+existing :mod:`tests.integration.servers.test_port_conflicts` suite.
+"""
+
+from __future__ import annotations
+
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from app.servers.models import ServerStatus, ServerType
+from tests.helpers.servers import make_server
+
+
+class TestListAvailablePorts:
+    def test_returns_requested_count_starting_at_default(
+        self, client: TestClient, admin_headers
+    ):
+        """No active servers → first ``count`` ports from ``start`` are free."""
+        response = client.get(
+            "/api/v1/servers/ports/available",
+            headers=admin_headers,
+            params={"start": 25565, "count": 3},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["start_port"] == 25565
+        assert body["ports"] == [25565, 25566, 25567]
+
+    def test_skips_active_ports(self, client: TestClient, admin_headers, db, admin_user):
+        """Ports held by active servers are skipped, stopped are reusable."""
+        # Active (starting) — blocks reuse
+        make_server(
+            db,
+            admin_user,
+            name="Active Server",
+            port=25565,
+            status=ServerStatus.starting,
+            directory_path="./servers/active_server",
+            minecraft_version="1.21.6",
+            server_type=ServerType.vanilla,
+        )
+        # Stopped — does NOT block reuse
+        make_server(
+            db,
+            admin_user,
+            name="Stopped Server",
+            port=25566,
+            status=ServerStatus.stopped,
+            directory_path="./servers/stopped_server",
+            minecraft_version="1.21.6",
+            server_type=ServerType.vanilla,
+        )
+
+        response = client.get(
+            "/api/v1/servers/ports/available",
+            headers=admin_headers,
+            params={"start": 25565, "count": 3},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        # 25565 is skipped (active); 25566 is allowed (stopped); then 25567/25568.
+        assert body["ports"] == [25566, 25567, 25568]
+
+    def test_count_above_50_rejected_by_validation(
+        self, client: TestClient, admin_headers
+    ):
+        """``count`` is clamped at 50 by the Pydantic ``Query(le=50)`` constraint."""
+        response = client.get(
+            "/api/v1/servers/ports/available",
+            headers=admin_headers,
+            params={"start": 25565, "count": 51},
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        body = response.json()
+        # Standard error envelope from the global validation handler.
+        assert body["error"] == "VALIDATION_ERROR"
+
+    def test_count_50_accepted_returns_up_to_50(self, client: TestClient, admin_headers):
+        """``count=50`` is the upper bound and returns exactly that many ports."""
+        response = client.get(
+            "/api/v1/servers/ports/available",
+            headers=admin_headers,
+            params={"start": 25565, "count": 50},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert len(body["ports"]) == 50
+        assert body["ports"][0] == 25565
+        assert body["ports"][-1] == 25614
+
+    def test_unauthenticated_returns_401(self, client: TestClient):
+        """No bearer token → 401 (FastAPI's auth dependency)."""
+        response = client.get("/api/v1/servers/ports/available")
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+
+class TestCheckPort:
+    def test_port_available_when_no_holder(self, client: TestClient, admin_headers):
+        response = client.get("/api/v1/servers/ports/check/25565", headers=admin_headers)
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body == {"port": 25565, "available": True, "holder": None}
+
+    def test_port_unavailable_when_active_server_holds(
+        self, client: TestClient, admin_headers, db, admin_user
+    ):
+        make_server(
+            db,
+            admin_user,
+            name="Live Server",
+            port=25599,
+            status=ServerStatus.running,
+            directory_path="./servers/live_server",
+            minecraft_version="1.21.6",
+            server_type=ServerType.vanilla,
+        )
+
+        response = client.get("/api/v1/servers/ports/check/25599", headers=admin_headers)
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["port"] == 25599
+        assert body["available"] is False
+        assert body["holder"] == "Live Server"
+
+    def test_stopped_server_does_not_block(
+        self, client: TestClient, admin_headers, db, admin_user
+    ):
+        """Stopped servers don't count as port holders — port is still available."""
+        make_server(
+            db,
+            admin_user,
+            name="Sleeping",
+            port=25600,
+            status=ServerStatus.stopped,
+            directory_path="./servers/sleeping",
+            minecraft_version="1.21.6",
+            server_type=ServerType.vanilla,
+        )
+
+        response = client.get("/api/v1/servers/ports/check/25600", headers=admin_headers)
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["available"] is True
+        assert body["holder"] is None
+
+    def test_port_below_1024_rejected(self, client: TestClient, admin_headers):
+        """Well-known ports below 1024 are rejected by the path constraint."""
+        response = client.get("/api/v1/servers/ports/check/80", headers=admin_headers)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_unauthenticated_returns_401(self, client: TestClient):
+        response = client.get("/api/v1/servers/ports/check/25565")
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )

--- a/tests/unit/core/test_error_handlers.py
+++ b/tests/unit/core/test_error_handlers.py
@@ -33,6 +33,7 @@ from app.groups.domain.exceptions import (
 from app.middleware.audit_middleware import AuditMiddleware
 from app.servers.domain.exceptions import (
     JavaCompatibilityError,
+    NoAvailablePortError,
     ServerAccessError,
     ServerJarDownloadError,
     ServerNameConflictError,
@@ -124,6 +125,10 @@ def _build_app() -> FastAPI:
             reason="network",
             retry_hint="Check internet connectivity",
         )
+
+    @app.get("/raise-server-no-port-available")
+    def _server_no_port_available():
+        raise NoAvailablePortError(start_port=25565)
 
     @app.get("/raise-legacy-not-found")
     def _legacy_nf():
@@ -250,6 +255,21 @@ class TestServerCreationActionableErrors:
             d.get("message") for d in details if d.get("code") == "JAVA_AVAILABLE"
         ]
         assert "17" in available
+
+    def test_server_no_port_available_returns_409_with_resolution_hint(self):
+        """Issue #32: ``NoAvailablePortError`` surfaces as 409 with structured details."""
+        r = _client().get("/raise-server-no-port-available")
+        assert r.status_code == 409
+        body = r.json()
+        assert body["error"] == "SERVER_NO_PORT_AVAILABLE"
+        details = body.get("details") or []
+        # First detail pinpoints the exhausted range; second carries the
+        # resolution hint (stop a server or widen the range).
+        assert any(
+            d.get("field") == "port" and d.get("code") == "NO_AVAILABLE_PORT"
+            for d in details
+        )
+        assert any(d.get("code") == "RESOLUTION_STEP" for d in details)
 
     def test_server_jar_download_failed_returns_502_with_retry_hint(self):
         r = _client().get("/raise-server-jar-download-failed")

--- a/tests/unit/servers/application/test_creation_preflight.py
+++ b/tests/unit/servers/application/test_creation_preflight.py
@@ -17,6 +17,7 @@ from app.servers.application.service import ServerService
 from app.servers.domain.entities import ServerEntity
 from app.servers.domain.exceptions import (
     JavaCompatibilityError,
+    NoAvailablePortError,
     ServerNameConflictError,
     ServerPortConflictError,
     UnsupportedMinecraftVersionError,
@@ -238,3 +239,144 @@ class TestValidateCreationRequest:
         # Suggestions are still computed (allocator returns ports near
         # the requested one).
         assert request_25565.port in result.suggested_ports
+
+
+class _RangedFakeRepo:
+    """Repo stand-in that reports a configurable set of active ports.
+
+    Used to exercise the Issue #32 auto-assign path where the request
+    omits ``port`` and the service must walk the candidate range
+    starting at ``DEFAULT_PORT_START``.
+    """
+
+    def __init__(self, *, active_ports: set[int]) -> None:
+        self._active_ports = set(active_ports)
+
+    async def get_by_name(self, name: str, *, include_deleted: bool = False):
+        return None
+
+    async def list_by_port(
+        self,
+        port,
+        *,
+        statuses=None,
+        exclude_id=None,
+        include_deleted: bool = False,
+    ) -> List[ServerEntity]:
+        if port is None:
+            return [
+                _entity(id_=p, name=f"server-{p}", port=p, status=ServerStatus.running)
+                for p in sorted(self._active_ports)
+            ]
+        if port in self._active_ports:
+            return [
+                _entity(
+                    id_=port,
+                    name=f"server-{port}",
+                    port=port,
+                    status=ServerStatus.running,
+                )
+            ]
+        return []
+
+
+class TestAutoAssignPort:
+    """Issue #32: auto-assign port when ``ServerCreateRequest.port`` is omitted."""
+
+    def _request_without_port(self) -> ServerCreateRequest:
+        return ServerCreateRequest(
+            name="auto-port-server",
+            description=None,
+            minecraft_version="1.21.6",
+            server_type=ServerType.vanilla,
+            # port omitted on purpose — exercises the auto-assign path.
+            max_memory=1024,
+            max_players=20,
+        )
+
+    @pytest.mark.asyncio
+    async def test_port_none_picks_default_start_when_free(self, owner):
+        """When 25565 is free, the auto-assign path picks it."""
+        repo = _RangedFakeRepo(active_ports=set())
+        service = ServerService(server_repo=repo)
+        service._is_version_supported_db = AsyncMock(return_value=True)
+        service._validate_java_compatibility = AsyncMock()
+        # Short-circuit the filesystem + persistence path; we only care
+        # that the pre-flight populated ``request.port`` before the call
+        # would have reached the JAR/persist stages.
+        service._validate_creation_preconditions = (
+            service._validate_creation_preconditions
+        )
+
+        request = self._request_without_port()
+        await service._validate_creation_preconditions(request, db=Mock())
+
+        assert request.port == 25565
+
+    @pytest.mark.asyncio
+    async def test_port_none_hops_to_next_free_when_default_busy(self, owner):
+        """25565 is held by an active server → picks 25566 next."""
+        repo = _RangedFakeRepo(active_ports={25565})
+        service = ServerService(server_repo=repo)
+        service._is_version_supported_db = AsyncMock(return_value=True)
+        service._validate_java_compatibility = AsyncMock()
+
+        request = self._request_without_port()
+        await service._validate_creation_preconditions(request, db=Mock())
+
+        assert request.port == 25566
+
+    @pytest.mark.asyncio
+    async def test_port_none_raises_when_no_port_available(self, owner):
+        """Exhausted range → ``NoAvailablePortError`` (Issue #32)."""
+
+        class _ExhaustedRepo:
+            """Returns 'in-use' for every probe so allocator finds nothing.
+
+            ``find_available_ports`` walks the range starting at the
+            requested port and consults ``list_by_port(port=None)`` once
+            to build the held-port set. Returning an entity for every
+            port in the range simulates total exhaustion.
+            """
+
+            async def get_by_name(self, name, *, include_deleted=False):
+                return None
+
+            async def list_by_port(
+                self,
+                port,
+                *,
+                statuses=None,
+                exclude_id=None,
+                include_deleted=False,
+            ):
+                if port is None:
+                    # Report every port in 25565..65535 as taken by an
+                    # active server so the allocator returns []. Using a
+                    # generator-like ``range`` produces ~40000 entities
+                    # which is fine for an in-memory test.
+                    return [
+                        _entity(
+                            id_=p,
+                            name=f"s-{p}",
+                            port=p,
+                            status=ServerStatus.running,
+                        )
+                        for p in range(25565, 65536)
+                    ]
+                return []
+
+        repo = _ExhaustedRepo()
+        service = ServerService(server_repo=repo)
+        service._is_version_supported_db = AsyncMock(return_value=True)
+        service._validate_java_compatibility = AsyncMock()
+
+        request = self._request_without_port()
+        with pytest.raises(NoAvailablePortError) as exc:
+            await service._validate_creation_preconditions(request, db=Mock())
+
+        assert exc.value.error_code == "SERVER_NO_PORT_AVAILABLE"
+        assert exc.value.start_port == 25565
+        details = exc.value.extra_details()
+        assert any(d.code == "NO_AVAILABLE_PORT" for d in details)
+        assert any(d.code == "RESOLUTION_STEP" for d in details)


### PR DESCRIPTION
## Summary

- Makes ``ServerCreateRequest.port`` Optional with auto-assignment starting at 25565 when omitted (Issue #32).
- Adds two new discovery endpoints:
  - `GET /api/v1/servers/ports/available?start=25565&count=N` — returns up to `count` (≤50) free ports.
  - `GET /api/v1/servers/ports/check/{port}` — returns whether a port is held and by which active server.
- Introduces `NoAvailablePortError` (`SERVER_NO_PORT_AVAILABLE`, HTTP 409) for the exhausted-range case.

Together these close #31 (port range flexibility — registered ports remain enforced via the existing `ge=1024, le=65535` validator) and #32 (automatic port discovery + assignment).

## Design notes

- **Search range**: hardcoded `start=25565`, with `count` clamped at 50 in `Query(le=50)` to bound the scan cost / DoS exposure.
- **`auto_assign_port` flag**: intentionally not introduced — `port=None` already expresses the intent without adding a second knob.
- **Holder disclosure**: `ports/check/{port}` returns the active server's name when held; authorization mirrors `can_create_server`, matching the create-server pre-flight contract.

## Already shipped in #334 (Issue #33)

PR #334 landed the foundational machinery this PR builds on:

- `ServerPortConflictError` (409, `SERVER_PORT_CONFLICT`) with `suggested_ports`.
- `app/servers/application/port_allocator.py` exposing `find_available_ports` + `port_holder`.
- `POST /api/v1/servers/validate` returning `suggested_ports` for both the success and failure shapes.

## Compatibility

`port` becomes optional in the API schema, but existing clients that always supply a value continue to work unchanged. No database migrations.

## Test plan

- [x] `tests/unit/servers/application/test_creation_preflight.py` — auto-assign picks 25565 when free, hops to 25566 when held, raises `NoAvailablePortError` when exhausted.
- [x] `tests/unit/core/test_error_handlers.py` — `NoAvailablePortError` maps to 409 with `SERVER_NO_PORT_AVAILABLE` + structured details.
- [x] `tests/integration/servers/test_port_discovery_endpoints.py` — end-to-end coverage of both new endpoints: happy path, active-server skipping, `count` clamp at 50 (`Query(le=50)` → 422 for 51), well-known port rejection (`<1024` → 422), unauthenticated 401.
- [x] Existing `tests/integration/servers/test_port_conflicts.py` unaffected.
- [x] `uv run ruff check` / `uv run ruff format --check` clean on touched files.
- [x] Pre-commit + pre-push (unit + integration smoke, excludes slow) pass.

Resolves #31
Resolves #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)