### PR TITLE
feat: Prometheus metrics export for health + business gauges (Resolves #329)

### DIFF
--- a/app/auth/application/brute_force_service.py
+++ b/app/auth/application/brute_force_service.py
@@ -154,6 +154,16 @@ class BruteForceService:
         )
         self._db.add(attempt)
 
+        # Surface the attempt in Prometheus (Issue #329). Import inline
+        # to avoid pulling the health API package into the auth domain
+        # graph at module-import time.
+        try:
+            from app.health.api.metrics import login_attempts_total
+
+            login_attempts_total.labels(result="success" if success else "failure").inc()
+        except Exception:  # noqa: BLE001 — metrics must never break auth
+            logger.debug("Failed to increment login_attempts_total", exc_info=True)
+
         triggered: Optional[LockoutStatus] = None
         if success:
             # Successful login clears any existing username lockout

--- a/app/health/api/metrics.py
+++ b/app/health/api/metrics.py
@@ -1,0 +1,137 @@
+"""Prometheus exposition endpoint (`/metrics`).
+
+Phase 2 of Issue #21 / #329. We export two families of metrics:
+
+1. **Health gauges** — re-projects the per-component results from the
+   existing `HealthCheckService` so dashboards and alerting can use
+   the same probes that drive the k8s readiness probe.
+2. **Business gauges** — counts of servers / pending backups / active
+   account lockouts, refreshed on every scrape via
+   `BusinessMetricsCollector`.
+
+Counters (cumulative) live alongside the gauges so they participate
+in the same `/metrics` page. Currently we ship `mc_login_attempts_total`
+which is incremented from the brute-force service whenever an
+authentication attempt is processed.
+
+The endpoint is intentionally **unauthenticated** — that is the
+Prometheus convention. Network-layer ACLs (k8s `NetworkPolicy`, GCP
+firewall rules, etc.) are expected to gate scraping.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping
+
+from fastapi import APIRouter, Depends, Response
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, generate_latest
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.health.api.dependencies import get_health_check_service
+from app.health.application.metrics_collector import BusinessMetricsCollector
+from app.health.application.service import HealthCheckService
+from app.health.domain.entities import HealthStatus, OverallHealth
+
+metrics_router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Health-derived metrics
+# ---------------------------------------------------------------------------
+#
+# The numeric encoding mirrors the traffic-light convention used in
+# the domain (`HealthStatus`): higher = better. Picking 0/1/2 lets
+# operators write alerting rules like `min_over_time(...) < 2` to
+# catch any non-HEALTHY sample in a window.
+
+_STATUS_VALUE: Mapping[HealthStatus, int] = {
+    HealthStatus.UNHEALTHY: 0,
+    HealthStatus.DEGRADED: 1,
+    HealthStatus.HEALTHY: 2,
+}
+
+health_component_status = Gauge(
+    "mc_health_component_status",
+    (
+        "Per-component health status: 0=unhealthy, 1=degraded, 2=healthy. "
+        "Mirrors the components exposed by /api/v1/health/detail."
+    ),
+    ["component", "critical"],
+)
+
+health_component_latency_seconds = Gauge(
+    "mc_health_component_check_duration_seconds",
+    "Latency of the most recent successful per-component health check, in seconds.",
+    ["component"],
+)
+
+
+# ---------------------------------------------------------------------------
+# Counters (cumulative). These are incremented from the producing
+# domain (e.g. the auth brute-force service) and read by the scrape
+# handler via the default registry.
+# ---------------------------------------------------------------------------
+
+login_attempts_total = Counter(
+    "mc_login_attempts_total",
+    "Authentication attempts grouped by outcome.",
+    ["result"],
+)
+
+
+def _refresh_health_metrics(overall: OverallHealth) -> None:
+    """Project ``OverallHealth`` into the Prometheus gauges."""
+    for component in overall.components:
+        health_component_status.labels(
+            component=component.name,
+            critical=str(component.critical).lower(),
+        ).set(_STATUS_VALUE[component.status])
+
+        if component.latency_ms is not None:
+            health_component_latency_seconds.labels(component=component.name).set(
+                component.latency_ms / 1000.0
+            )
+
+
+def _resolve_backups_directory() -> Path:
+    """Late-bind to avoid importing the backups package at module load."""
+    return Path("backups")
+
+
+@metrics_router.get(
+    "/metrics",
+    include_in_schema=False,
+    response_class=Response,
+)
+async def metrics(
+    service: HealthCheckService = Depends(get_health_check_service),
+    db: Session = Depends(get_db),
+) -> Response:
+    """Render the Prometheus exposition payload.
+
+    Bypasses the health-service TTL cache so each scrape returns a
+    fresh snapshot — Prometheus already controls scrape cadence via
+    its own `scrape_interval`, and we do not want to compound that
+    with an in-process cache that could quietly stale.
+    """
+    overall = await service.readiness(use_cache=False)
+    _refresh_health_metrics(overall)
+
+    collector = BusinessMetricsCollector(
+        db=db,
+        backups_directory=_resolve_backups_directory(),
+    )
+    collector.collect()
+
+    payload = generate_latest()
+    return Response(content=payload, media_type=CONTENT_TYPE_LATEST)
+
+
+__all__ = [
+    "health_component_latency_seconds",
+    "health_component_status",
+    "login_attempts_total",
+    "metrics_router",
+]

--- a/app/health/application/metrics_collector.py
+++ b/app/health/application/metrics_collector.py
@@ -1,0 +1,155 @@
+"""Business-metric collection for the Prometheus `/metrics` endpoint.
+
+The collector is intentionally pull-based: when Prometheus scrapes
+`/metrics` the route calls `BusinessMetricsCollector.collect()` which
+refreshes the relevant Gauges with current values. This keeps DB I/O
+proportional to scrape frequency rather than to request volume.
+
+All queries are deliberately cheap (`COUNT(*)` aggregates only) so
+that scrape latency stays well under the typical 10s Prometheus
+default. No N+1 traversal; the collector touches the DB at most
+three times per scrape.
+
+Filesystem-derived gauges (`mc_backups_pending_total`) are exposed as
+a best-effort count of `*.tar.gz` files in `backups/.pending/` — that
+directory is the source of truth for in-flight backup uploads (see
+`app/backups/application/service.py`). Errors during a scrape are
+logged and swallowed so a transient stat failure cannot poison the
+endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from prometheus_client import Gauge
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.auth.models import AccountLockout
+from app.backups.models import Backup
+from app.core.datetime_utils import utcnow
+from app.servers.domain.value_objects import BackupStatus, ServerStatus
+from app.servers.models import Server
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Gauges (module-level so they share the default REGISTRY)
+# ---------------------------------------------------------------------------
+#
+# Naming convention: `mc_` prefix scopes every metric to this project
+# so operators running multiple exporters in the same Prometheus
+# instance do not collide with stock libraries (e.g. `process_*`,
+# `python_*`).
+
+servers_total = Gauge(
+    "mc_servers_total",
+    "Number of Minecraft servers grouped by lifecycle status.",
+    ["status"],
+)
+
+backups_pending_total = Gauge(
+    "mc_backups_pending_total",
+    (
+        "Backups currently in the `creating` state (in-flight + leftover "
+        "`.pending/*.tar.gz` files awaiting cleanup)."
+    ),
+)
+
+account_lockouts_active = Gauge(
+    "mc_account_lockouts_active",
+    "Active account lockouts (rows where locked_until is in the future).",
+)
+
+
+class BusinessMetricsCollector:
+    """Refresh business-level Prometheus gauges on demand.
+
+    Construction is cheap; instantiation per scrape is fine. The
+    collector deliberately owns no state — gauges live at module
+    scope on the default registry.
+    """
+
+    def __init__(self, db: Session, backups_directory: Path) -> None:
+        self._db = db
+        self._backups_directory = backups_directory
+
+    def collect(self) -> None:
+        """Refresh every business gauge.
+
+        Individual metric collection is wrapped so a partial failure
+        (e.g. the lockouts table missing during a transitional
+        migration) does not blank the entire scrape.
+        """
+        self._collect_server_status_counts()
+        self._collect_pending_backups()
+        self._collect_active_lockouts()
+
+    # ------------------------------------------------------------------
+    # Individual collectors
+    # ------------------------------------------------------------------
+
+    def _collect_server_status_counts(self) -> None:
+        try:
+            rows = (
+                self._db.query(Server.status, func.count(Server.id))
+                .group_by(Server.status)
+                .all()
+            )
+            counts = {status: count for status, count in rows}
+            # Always emit a sample for every known status so Prometheus
+            # range vectors (`rate`, `increase`) do not have to deal
+            # with gauges that disappear between scrapes.
+            for status in ServerStatus:
+                value = counts.get(status, 0)
+                servers_total.labels(status=status.value).set(value)
+        except Exception:  # noqa: BLE001 — see module docstring
+            logger.exception("Failed to collect mc_servers_total")
+
+    def _collect_pending_backups(self) -> None:
+        try:
+            db_pending = (
+                self._db.query(func.count(Backup.id))
+                .filter(Backup.status == BackupStatus.creating)
+                .scalar()
+                or 0
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to query Backup rows for mc_backups_pending_total")
+            db_pending = 0
+
+        fs_pending = 0
+        pending_dir = self._backups_directory / ".pending"
+        try:
+            if pending_dir.exists():
+                fs_pending = sum(1 for _ in pending_dir.glob("*.tar.gz"))
+        except OSError:
+            logger.exception("Failed to list %s for pending backups", pending_dir)
+
+        backups_pending_total.set(db_pending + fs_pending)
+
+    def _collect_active_lockouts(self) -> None:
+        try:
+            now = utcnow()
+            count = (
+                self._db.query(func.count(AccountLockout.id))
+                .filter(AccountLockout.locked_until > now)
+                .scalar()
+                or 0
+            )
+            account_lockouts_active.set(count)
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to collect mc_account_lockouts_active")
+            # Leave the gauge at its previous value so the metric does
+            # not flap to 0 during a transient DB blip.
+
+
+__all__ = [
+    "BusinessMetricsCollector",
+    "account_lockouts_active",
+    "backups_pending_total",
+    "servers_total",
+]

--- a/app/main.py
+++ b/app/main.py
@@ -28,6 +28,7 @@ from app.core.visibility_router import router as visibility_router  # noqa: E402
 from app.files.router import router as files_router  # noqa: E402
 from app.groups.router import router as groups_router  # noqa: E402
 from app.health.api.dependencies import get_health_check_service  # noqa: E402
+from app.health.api.metrics import metrics_router  # noqa: E402
 from app.health.api.router import build_legacy_payload  # noqa: E402
 from app.health.api.router import router as health_router  # noqa: E402
 from app.health.application.service import HealthCheckService  # noqa: E402
@@ -492,24 +493,18 @@ async def health_check_v1(
     )
 
 
-@app.get("/metrics", tags=["monitoring"])
-async def get_metrics():
-    """Get performance metrics and statistics"""
-    from datetime import datetime
-
-    metrics = get_performance_metrics()
-
-    return {
-        "timestamp": datetime.now().isoformat(),
-        "performance": metrics,
-        "service_status": service_status.get_status(),
-        "message": "Performance metrics collected successfully",
-    }
+# NOTE: `/metrics` is now served by `metrics_router` (Issue #329) in
+# Prometheus exposition format. The legacy JSON snapshot remains
+# available at `/api/v1/metrics` for existing dashboards / tooling.
 
 
 @app.get("/api/v1/metrics", tags=["monitoring"])
 async def get_metrics_v1():
-    """Get performance metrics and statistics"""
+    """Legacy JSON performance snapshot.
+
+    Retained for backward compatibility. New consumers should scrape
+    the Prometheus-format `/metrics` endpoint instead.
+    """
     from datetime import datetime
 
     metrics = get_performance_metrics()
@@ -566,3 +561,7 @@ app.include_router(audit_router, tags=["audit"])
 # k8s paths; the admin detail endpoint declares its own
 # ``/api/v1/health/detail`` path on the route.
 app.include_router(health_router)
+
+# Prometheus exposition endpoint (Issue #329). Mounted without a
+# prefix so scrapers can use the canonical `/metrics` path.
+app.include_router(metrics_router)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "fastapi[standard]>=0.115.12,<1.0.0",
     "packaging>=25.0,<27.0.0",
     "passlib>=1.7.4,<2.0.0",
+    "prometheus-client>=0.25.0,<1.0.0",
     "psutil>=7.0.0,<8.0.0",
     "pydantic>=2.11.4,<3.0.0",
     "pydantic-settings>=2.9.1,<3.0.0",

--- a/tests/integration/health/test_metrics_endpoint.py
+++ b/tests/integration/health/test_metrics_endpoint.py
@@ -1,0 +1,147 @@
+"""Integration tests for the Prometheus `/metrics` endpoint (Issue #329).
+
+The endpoint is mounted on the live FastAPI app; we stub the
+`HealthCheckService` so the health gauges have deterministic
+component shapes regardless of the real adapter state.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from prometheus_client import CONTENT_TYPE_LATEST
+
+from app.health.api.dependencies import get_health_check_service
+from app.health.application.service import HealthCheckConfig, HealthCheckService
+from app.health.domain.entities import (
+    ComponentHealth,
+    HealthStatus,
+    OverallHealth,
+    aggregate,
+)
+from app.main import app
+
+
+class _StubService(HealthCheckService):
+    """Bypass real adapters with a pre-computed ``OverallHealth``."""
+
+    def __init__(self, overall: OverallHealth) -> None:
+        super().__init__(
+            checks=[],
+            config=HealthCheckConfig(
+                per_component_timeout_seconds=1.0,
+                global_timeout_seconds=2.0,
+                cache_ttl_seconds=0.0,
+            ),
+        )
+        self._overall = overall
+
+    async def readiness(self, *, use_cache: bool = True) -> OverallHealth:
+        return self._overall
+
+
+def _override(components: list[ComponentHealth]) -> None:
+    overall = OverallHealth(
+        status=aggregate(components),
+        components=components,
+        checked_at=datetime.now(timezone.utc),
+    )
+    app.dependency_overrides[get_health_check_service] = lambda: _StubService(overall)
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    app.dependency_overrides.pop(get_health_check_service, None)
+
+
+def test_metrics_endpoint_returns_prometheus_content_type(client) -> None:
+    _override(
+        [
+            ComponentHealth(
+                name="database",
+                status=HealthStatus.HEALTHY,
+                critical=True,
+                latency_ms=12.5,
+            )
+        ]
+    )
+
+    response = client.get("/metrics")
+
+    assert response.status_code == 200
+    # `CONTENT_TYPE_LATEST` includes encoding / version params; the
+    # endpoint should hand it back verbatim so scrapers do not have
+    # to parse a non-standard content type.
+    assert response.headers["content-type"] == CONTENT_TYPE_LATEST
+
+
+def test_metrics_endpoint_exposes_health_component_gauges(client) -> None:
+    _override(
+        [
+            ComponentHealth(
+                name="database",
+                status=HealthStatus.HEALTHY,
+                critical=True,
+                latency_ms=15.0,
+            ),
+            ComponentHealth(
+                name="backup_scheduler",
+                status=HealthStatus.DEGRADED,
+                critical=False,
+                latency_ms=5.0,
+            ),
+        ]
+    )
+
+    body = client.get("/metrics").text
+
+    # Health status gauge: HEALTHY=2, DEGRADED=1.
+    assert 'mc_health_component_status{component="database",critical="true"} 2.0' in body
+    assert (
+        'mc_health_component_status{component="backup_scheduler",critical="false"} 1.0'
+        in body
+    )
+    # Latency exported in seconds (ms / 1000).
+    assert 'mc_health_component_check_duration_seconds{component="database"}' in body
+    assert "0.015" in body
+
+
+def test_metrics_endpoint_exposes_business_gauges(client) -> None:
+    _override(
+        [
+            ComponentHealth(
+                name="database",
+                status=HealthStatus.HEALTHY,
+                critical=True,
+                latency_ms=1.0,
+            )
+        ]
+    )
+
+    body = client.get("/metrics").text
+
+    # Every business gauge should appear at least once even when the
+    # underlying tables are empty.
+    assert "mc_servers_total" in body
+    assert "mc_backups_pending_total" in body
+    assert "mc_account_lockouts_active" in body
+    # The login counter is registered eagerly via module import.
+    assert "mc_login_attempts_total" in body
+
+
+def test_metrics_endpoint_unauthenticated(client) -> None:
+    """Prometheus scrape convention: no auth required."""
+    _override(
+        [
+            ComponentHealth(
+                name="database",
+                status=HealthStatus.HEALTHY,
+                critical=True,
+            )
+        ]
+    )
+    # No Authorization header at all.
+    response = client.get("/metrics")
+    assert response.status_code == 200

--- a/tests/unit/health/test_metrics_collector.py
+++ b/tests/unit/health/test_metrics_collector.py
@@ -1,0 +1,159 @@
+"""Unit tests for ``BusinessMetricsCollector`` (Issue #329).
+
+These tests bypass the FastAPI stack entirely — the collector takes a
+plain SQLAlchemy session + filesystem path and writes to module-level
+Prometheus gauges. We assert on those gauge samples directly via the
+``_value`` accessor exposed by the prometheus-client SDK.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from app.auth.models import AccountLockout
+from app.backups.models import Backup
+from app.core.datetime_utils import utcnow
+from app.health.application.metrics_collector import (
+    BusinessMetricsCollector,
+    account_lockouts_active,
+    backups_pending_total,
+    servers_total,
+)
+from app.servers.domain.value_objects import BackupStatus, ServerStatus
+from app.servers.models import Server
+
+
+def _gauge_sample(gauge, **labels):
+    """Return the current value for a labelled gauge sample."""
+    if labels:
+        return gauge.labels(**labels)._value.get()
+    return gauge._value.get()
+
+
+def _make_server(name: str, status: ServerStatus, *, owner_id: int) -> Server:
+    return Server(
+        name=name,
+        directory_path=f"servers/{name}",
+        port=25565,
+        max_memory=1024,
+        max_players=20,
+        owner_id=owner_id,
+        status=status,
+        server_type="vanilla",
+        minecraft_version="1.20.1",
+    )
+
+
+@pytest.fixture
+def collector(db, tmp_path: Path) -> BusinessMetricsCollector:
+    return BusinessMetricsCollector(db=db, backups_directory=tmp_path)
+
+
+def test_collect_server_status_counts_emits_zero_for_every_status(
+    collector: BusinessMetricsCollector,
+) -> None:
+    collector.collect()
+    for status in ServerStatus:
+        assert _gauge_sample(servers_total, status=status.value) == 0
+
+
+def test_collect_server_status_counts_groups_by_status(
+    collector: BusinessMetricsCollector,
+    db,
+    admin_user,
+) -> None:
+    db.add_all(
+        [
+            _make_server("running-a", ServerStatus.running, owner_id=admin_user.id),
+            _make_server("running-b", ServerStatus.running, owner_id=admin_user.id),
+            _make_server("stopped-a", ServerStatus.stopped, owner_id=admin_user.id),
+        ]
+    )
+    db.commit()
+
+    collector.collect()
+
+    assert _gauge_sample(servers_total, status="running") == 2
+    assert _gauge_sample(servers_total, status="stopped") == 1
+    assert _gauge_sample(servers_total, status="error") == 0
+
+
+def test_collect_pending_backups_combines_db_and_filesystem(
+    collector: BusinessMetricsCollector,
+    db,
+    admin_user,
+    tmp_path: Path,
+) -> None:
+    server = _make_server("backup-host", ServerStatus.stopped, owner_id=admin_user.id)
+    db.add(server)
+    db.flush()
+    db.add(
+        Backup(
+            server_id=server.id,
+            name="b1",
+            file_path="/tmp/b1.tar.gz",
+            file_size=1,
+            status=BackupStatus.creating,
+        )
+    )
+    db.add(
+        Backup(
+            server_id=server.id,
+            name="b2-done",
+            file_path="/tmp/b2.tar.gz",
+            file_size=1,
+            status=BackupStatus.completed,
+        )
+    )
+    db.commit()
+
+    # Two pending-on-disk archives that have not been promoted yet.
+    pending_dir = tmp_path / ".pending"
+    pending_dir.mkdir()
+    (pending_dir / ".pending-aaa.tar.gz").touch()
+    (pending_dir / ".pending-bbb.tar.gz").touch()
+    # A non-tar file is ignored.
+    (pending_dir / "README").touch()
+
+    collector.collect()
+
+    assert _gauge_sample(backups_pending_total) == 1 + 2  # one DB row + two FS files
+
+
+def test_collect_active_lockouts(
+    collector: BusinessMetricsCollector,
+    db,
+) -> None:
+    now = utcnow()
+    db.add_all(
+        [
+            AccountLockout(
+                username="locked-1",
+                locked_until=now + timedelta(minutes=5),
+                lockout_count=1,
+            ),
+            AccountLockout(
+                username="locked-2",
+                locked_until=now + timedelta(minutes=10),
+                lockout_count=1,
+            ),
+            AccountLockout(
+                username="expired",
+                locked_until=now - timedelta(minutes=1),
+                lockout_count=1,
+            ),
+            AccountLockout(
+                username="never",
+                locked_until=None,
+                lockout_count=0,
+            ),
+        ]
+    )
+    db.commit()
+
+    collector.collect()
+
+    assert _gauge_sample(account_lockouts_active) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.13"
 
 [options]
-exclude-newer = "2026-05-09T06:03:44.878874569Z"
+exclude-newer = "2026-05-16T11:14:20.711728425Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -599,6 +599,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "packaging" },
     { name = "passlib" },
+    { name = "prometheus-client" },
     { name = "psutil" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -628,6 +629,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12,<1.0.0" },
     { name = "packaging", specifier = ">=25.0,<27.0.0" },
     { name = "passlib", specifier = ">=1.7.4,<2.0.0" },
+    { name = "prometheus-client", specifier = ">=0.25.0,<1.0.0" },
     { name = "psutil", specifier = ">=7.0.0,<8.0.0" },
     { name = "pydantic", specifier = ">=2.11.4,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.9.1,<3.0.0" },
@@ -799,6 +801,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424, upload-time = "2025-03-18T21:35:20.987Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707, upload-time = "2025-03-18T21:35:19.343Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `prometheus-client` (0.25.x) and expose a Prometheus exposition `/metrics` endpoint that re-projects per-component `ComponentHealth` results from PR #328 into gauges, plus a few business gauges pulled on every scrape.
- Increment a `mc_login_attempts_total` counter from `BruteForceService.record_attempt` so authentication success/failure rates are scrapable.
- Replace the legacy JSON snapshot at `/metrics` with the Prometheus exposition format; keep the JSON snapshot at `/api/v1/metrics` for backward compatibility.

Resolves #329.

## Metrics exported

| Name | Type | Labels | Description |
|---|---|---|---|
| `mc_health_component_status` | Gauge | `component`, `critical` | 0=unhealthy, 1=degraded, 2=healthy |
| `mc_health_component_check_duration_seconds` | Gauge | `component` | most recent per-check latency (s) |
| `mc_servers_total` | Gauge | `status` | servers grouped by `ServerStatus` (emits every status, including zeros) |
| `mc_backups_pending_total` | Gauge | — | `Backup.status=creating` rows + `backups/.pending/*.tar.gz` artifacts |
| `mc_account_lockouts_active` | Gauge | — | rows where `locked_until > now` |
| `mc_login_attempts_total` | Counter | `result` | success/failure of every auth attempt |

## Architecture

- `app/health/api/metrics.py` — `/metrics` route, Prometheus gauge/counter definitions, health-projection helper.
- `app/health/application/metrics_collector.py` — `BusinessMetricsCollector` runs three lightweight aggregate queries per scrape (no N+1).
- Pull-based: scrape handler bypasses the readiness TTL cache (`use_cache=False`); Prometheus already paces requests via `scrape_interval`.
- `/metrics` is **unauthenticated**, per Prometheus convention. Existing `audit` + `performance_monitoring` middleware already exclude `/metrics` (no change needed).

## Out of scope
- Alerting rules and Grafana dashboards (deployment-side; tracked separately).
- `FilesystemHealthCheck` writability-probe wiring and `ServiceStatus` consolidation noted in PR #328 review — deferred to a separate follow-up to keep this PR focused on exposition format.

## Test plan
- [x] `uv run pytest tests/unit/health tests/integration/health -m "not slow"` (49 passed)
- [x] `uv run pytest tests/unit/auth -m "not slow"` (56 passed, 3 skipped — covers the brute-force counter increment path)
- [x] `uv run ruff check app/` (clean)
- [ ] CI on push (`ci.yaml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)