### PR TITLE
fix: enforce upload size limit + encoding validator + rename conflict 409 (Resolves #341)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -175,6 +175,13 @@ class Settings(BaseSettings):
     DATABASE_RETRY_BACKOFF: float = 0.1
     DATABASE_BATCH_SIZE: int = 100
 
+    # File upload size cap (Issue #341). Enforced by the file upload
+    # service via a streaming/chunked read so the entire payload never
+    # lands in process memory before the limit is checked. Defaults to
+    # 100 MiB; override via the `FILE_MAX_UPLOAD_BYTES` env var. Set to
+    # 0 to disable enforcement (not recommended for production).
+    FILE_MAX_UPLOAD_BYTES: int = 100 * 1024 * 1024  # 100 MiB
+
     # Backup directory housekeeping (Issue #284)
     BACKUPS_PENDING_RETENTION_HOURS: int = 24
     BACKUPS_FAILED_RETENTION_DAYS: int = 30
@@ -400,6 +407,21 @@ class Settings(BaseSettings):
         """Validate DATABASE_BATCH_SIZE is within reasonable limits"""
         if v < 10 or v > 1000:
             raise ValueError("DATABASE_BATCH_SIZE must be between 10 and 1000")
+        return v
+
+    @field_validator("FILE_MAX_UPLOAD_BYTES")
+    @classmethod
+    def validate_file_max_upload_bytes(cls, v: int) -> int:
+        """Validate FILE_MAX_UPLOAD_BYTES is within reasonable bounds.
+
+        0 disables enforcement. Otherwise must be in [1 KiB, 10 GiB].
+        """
+        if v == 0:
+            return v
+        if v < 1024 or v > 10 * 1024 * 1024 * 1024:
+            raise ValueError(
+                "FILE_MAX_UPLOAD_BYTES must be 0 (disabled) or between 1KiB and 10GiB"
+            )
         return v
 
     @field_validator("BACKUPS_PENDING_RETENTION_HOURS")

--- a/app/core/error_handlers.py
+++ b/app/core/error_handlers.py
@@ -43,6 +43,7 @@ from app.core.exceptions import (
     APIException,
     DiskSpaceError,
     FileAccessDeniedError,
+    FileAlreadyExistsError,
     FileMissingError,
     FileOperationException,
     FileTooLargeError,
@@ -617,6 +618,10 @@ def register_exception_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(DiskSpaceError)
     async def _file_disk_space(request: Request, exc: DiskSpaceError):
+        return _api_exception_response(request, exc)
+
+    @app.exception_handler(FileAlreadyExistsError)
+    async def _file_already_exists(request: Request, exc: FileAlreadyExistsError):
         return _api_exception_response(request, exc)
 
     @app.exception_handler(FileOperationException)

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -387,6 +387,52 @@ class InvalidFileTypeError(FileOperationException):
         return details
 
 
+class FileAlreadyExistsError(FileOperationException):
+    """Raised when an operation targets a path that is already occupied.
+
+    Mapped to HTTP 409 (Conflict). Use for rename/move/upload destinations
+    that would clobber an existing file or directory. Carries the
+    conflicting path via :attr:`existing_path` so the frontend can offer
+    an inline resolution (rename, overwrite, delete-then-retry).
+    """
+
+    error_code: ClassVar[str] = "FILE_ALREADY_EXISTS"
+    _http_status: ClassVar[int] = status.HTTP_409_CONFLICT
+    _log_level: ClassVar[str] = "warning"
+
+    def __init__(
+        self,
+        operation: str,
+        file_path: str,
+        reason: str = "Destination already exists",
+        *,
+        existing_path: Optional[str] = None,
+        technical_details: Optional[str] = None,
+    ):
+        self.existing_path = existing_path or file_path
+        super().__init__(
+            operation, file_path, reason, technical_details=technical_details
+        )
+
+    def _suggested_actions(self) -> List[str]:
+        return [
+            "Use a different destination name or path",
+            "Delete the existing file or directory first, then retry",
+        ]
+
+    def extra_details(self) -> List[ErrorDetail]:
+        details = super().extra_details()
+        if self.existing_path:
+            details.append(
+                ErrorDetail(
+                    field="existing_path",
+                    message=self.existing_path,
+                    code="EXISTING_PATH",
+                )
+            )
+        return details
+
+
 class DiskSpaceError(FileOperationException):
     """Raised when a write fails because the device is out of space.
 
@@ -472,9 +518,9 @@ def handle_file_error(operation: str, file_path: str, error: Exception) -> NoRet
 
     Issue #35 introduced :class:`FileMissingError`,
     :class:`FileAccessDeniedError`, :class:`FileTooLargeError`,
-    :class:`InvalidFileTypeError`, and :class:`DiskSpaceError` so the
-    standard error response carries the correct HTTP status and
-    actionable ``suggested_actions``. This helper dispatches on
+    :class:`InvalidFileTypeError`, :class:`DiskSpaceError`, and (under
+    #341) :class:`FileAlreadyExistsError` so the standard error response
+    carries the correct HTTP status and actionable ``suggested_actions``. This helper dispatches on
     ``errno`` and built-in exception type before falling back to the
     generic 500 :class:`FileOperationException`.
 

--- a/app/files/application/management.py
+++ b/app/files/application/management.py
@@ -3,16 +3,19 @@ import shutil
 import zipfile
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated, Any, Dict, List, Optional
+from typing import Annotated, Any, ClassVar, Dict, List, Optional
 
 import aiofiles
 from fastapi import UploadFile
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.core.exceptions import (
     AccessDeniedException,
+    FileAlreadyExistsError,
     FileMissingError,
     FileOperationException,
+    FileTooLargeError,
     InvalidFileTypeError,
     InvalidRequestException,
     ServerNotFoundException,
@@ -475,17 +478,57 @@ class FileOperationService:
             # If file is not within server directory, use the filename
             return file_path.name
 
+    # 64 KiB chunk size matches the default disk page size for most
+    # filesystems and keeps peak per-request memory bounded while
+    # streaming the upload to disk.
+    _UPLOAD_CHUNK_BYTES: ClassVar[int] = 64 * 1024
+
     async def upload_file(self, file: UploadFile, target_path: Path) -> int:
-        """Upload file to target path and return file size"""
+        """Upload file to target path and return file size.
+
+        Reads the upload in fixed-size chunks (#341) so the full payload
+        never materialises in memory. The running total is checked
+        against ``settings.FILE_MAX_UPLOAD_BYTES`` after every chunk and
+        a :class:`FileTooLargeError` is raised the moment the limit is
+        exceeded — any partial output is removed before the exception
+        propagates. ``FILE_MAX_UPLOAD_BYTES = 0`` disables enforcement.
+        """
+        max_bytes = settings.FILE_MAX_UPLOAD_BYTES
+        enforce_limit = max_bytes > 0
         try:
             target_path.parent.mkdir(parents=True, exist_ok=True)
 
-            content = await file.read()
+            total = 0
+            try:
+                async with aiofiles.open(target_path, mode="wb") as f:
+                    while True:
+                        chunk = await file.read(self._UPLOAD_CHUNK_BYTES)
+                        if not chunk:
+                            break
+                        total += len(chunk)
+                        if enforce_limit and total > max_bytes:
+                            raise FileTooLargeError(
+                                "upload",
+                                str(target_path),
+                                size_bytes=total,
+                                max_bytes=max_bytes,
+                            )
+                        await f.write(chunk)
+            except FileTooLargeError:
+                # Best-effort cleanup of any bytes already flushed to
+                # disk so a rejected upload does not leak storage.
+                try:
+                    if target_path.exists():
+                        target_path.unlink()
+                except OSError:
+                    logger.debug(
+                        "Failed to cleanup partial upload at %s",
+                        target_path,
+                        exc_info=True,
+                    )
+                raise
 
-            async with aiofiles.open(target_path, mode="wb") as f:
-                await f.write(content)
-
-            return len(content)
+            return total
 
         except Exception as e:
             handle_file_error("upload", str(target_path), e)
@@ -1144,14 +1187,16 @@ class FileManagementService:
         # Create destination path (same directory, new name)
         destination_path = source_path.parent / new_name
 
-        # Check if destination already exists. Kept as the generic
-        # ``FileOperationException`` (500) for now — adding a dedicated
-        # ``FileAlreadyExistsError`` is tracked under #36 follow-ups.
+        # Check if destination already exists. Routed through the
+        # dedicated :class:`FileAlreadyExistsError` (HTTP 409, #341)
+        # so the client gets a structured envelope with the existing
+        # path and actionable suggestions.
         if destination_path.exists():
-            raise FileOperationException(
+            raise FileAlreadyExistsError(
                 "rename",
                 str(source_path),
                 f"File or directory '{new_name}' already exists",
+                existing_path=str(destination_path.relative_to(server_path)),
             )
 
         # Validate destination path safety

--- a/app/files/schemas.py
+++ b/app/files/schemas.py
@@ -1,7 +1,8 @@
+import codecs
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.types import FileType
 
@@ -53,6 +54,24 @@ class FileWriteRequest(BaseModel):
     )
     encoding: str = Field("utf-8", description="File encoding")
     create_backup: bool = Field(True, description="Create backup before writing")
+
+    @field_validator("encoding")
+    @classmethod
+    def _validate_encoding(cls, v: str) -> str:
+        """Reject unknown codecs up-front (#341).
+
+        Without this guard ``router.write_file`` reached
+        ``payload.content.encode(payload.encoding, ...)`` *before* the
+        try/except guarding the audit emission, so an invalid encoding
+        leaked a bare ``LookupError`` (500) and the failure audit was
+        never recorded. Validating here turns the same input into a
+        clean 422 with the standard envelope.
+        """
+        try:
+            codecs.lookup(v)
+        except LookupError as exc:
+            raise ValueError(f"Unknown encoding: {v!r}") from exc
+        return v
 
 
 class FileWriteResponse(BaseModel):

--- a/tests/integration/files/test_router.py
+++ b/tests/integration/files/test_router.py
@@ -1023,3 +1023,131 @@ class TestFileRouterAuditWiring:
             headers=headers,
         )
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+class TestIssue341FileRouterContract:
+    """Issue #341: enforce upload size, encoding validation, and rename 409s
+    end-to-end through the FastAPI router.
+    """
+
+    @patch("app.files.router.AuditService.log_file_event")
+    def test_write_invalid_encoding_returns_422_envelope(
+        self, mock_audit, client, admin_user
+    ):
+        """Unknown encodings are rejected at validation time (#341).
+
+        Pre-fix the router raised ``LookupError`` from
+        ``str.encode(payload.encoding, ...)`` *before* ``_safe_audit``
+        was wired up, leaking a 500 with no envelope. The
+        ``@field_validator`` on :class:`FileWriteRequest.encoding` turns
+        the same input into a clean 422 with the standard ``details``
+        payload, and the failure audit is skipped because the request
+        never reaches the handler body.
+        """
+        headers = get_auth_headers(admin_user.username)
+        response = client.put(
+            "/api/v1/files/servers/1/files/server.properties",
+            json={
+                "content": "hi",
+                "encoding": "definitely-not-a-codec",
+                "create_backup": False,
+            },
+            headers=headers,
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        body = response.json()
+        assert body["error"] == "VALIDATION_ERROR"
+        # Validation rejection short-circuits the handler so no audit fires.
+        mock_audit.assert_not_called()
+
+    @patch(
+        "app.servers.application.authorization.AuthorizationService.check_server_access",
+        new_callable=AsyncMock,
+    )
+    @patch("app.servers.application.authorization.AuthorizationService.can_modify_files")
+    @patch("app.files.application.management.file_management_service.upload_file")
+    def test_upload_too_large_returns_413_envelope(
+        self,
+        mock_upload_file,
+        mock_can_modify,
+        mock_check_access,
+        client,
+        admin_user,
+    ):
+        """``FileTooLargeError`` from the service surfaces as a 413
+        with ``FILE_TOO_LARGE`` + size metadata in the envelope.
+        """
+        from app.core.exceptions import FileTooLargeError
+
+        mock_check_access.return_value = None
+        mock_can_modify.return_value = True
+        mock_upload_file.side_effect = FileTooLargeError(
+            "upload",
+            "huge.bin",
+            size_bytes=200_000_000,
+            max_bytes=100 * 1024 * 1024,
+        )
+
+        test_file = BytesIO(b"payload")
+        test_file.name = "huge.bin"
+
+        headers = get_auth_headers(admin_user.username)
+        response = client.post(
+            "/api/v1/files/servers/1/files/upload",
+            files={"file": ("huge.bin", test_file, "application/octet-stream")},
+            data={"destination_path": ""},
+            headers=headers,
+        )
+
+        assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+        body = response.json()
+        assert body["error"] == "FILE_TOO_LARGE"
+        codes = {d["code"]: d["message"] for d in body.get("details") or []}
+        assert codes.get("FILE_SIZE_BYTES") == "200000000"
+        assert codes.get("FILE_MAX_BYTES") == str(100 * 1024 * 1024)
+
+    @patch(
+        "app.servers.application.authorization.AuthorizationService.check_server_access",
+        new_callable=AsyncMock,
+    )
+    @patch("app.servers.application.authorization.AuthorizationService.can_modify_files")
+    @patch("app.files.application.management.file_management_service.rename_file")
+    def test_rename_destination_exists_returns_409_envelope(
+        self,
+        mock_rename_file,
+        mock_can_modify,
+        mock_check_access,
+        client,
+        admin_user,
+    ):
+        """Rename onto an existing path surfaces as ``FILE_ALREADY_EXISTS`` 409."""
+        from app.core.exceptions import FileAlreadyExistsError
+
+        mock_check_access.return_value = None
+        mock_can_modify.return_value = True
+        mock_rename_file.side_effect = FileAlreadyExistsError(
+            "rename",
+            "/srv/src.txt",
+            existing_path="dst.txt",
+        )
+
+        headers = get_auth_headers(admin_user.username)
+        response = client.patch(
+            "/api/v1/files/servers/1/files/src.txt/rename",
+            json={"new_name": "dst.txt"},
+            headers=headers,
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        body = response.json()
+        assert body["error"] == "FILE_ALREADY_EXISTS"
+        # The existing path is round-tripped to the client so the UI can
+        # suggest a resolution without an extra round-trip.
+        details = {d["code"]: d["message"] for d in body.get("details") or []}
+        assert details.get("EXISTING_PATH") == "dst.txt"
+        assert any(
+            "different destination" in d["message"]
+            for d in body.get("details") or []
+            if d.get("code") == "SUGGESTED_ACTION"
+        )

--- a/tests/unit/core/test_exceptions.py
+++ b/tests/unit/core/test_exceptions.py
@@ -474,6 +474,32 @@ class TestFileOperationExceptionTaxonomy:
         assert exc.status_code == status.HTTP_507_INSUFFICIENT_STORAGE
         assert exc.error_code == "DISK_SPACE_INSUFFICIENT"
 
+    def test_file_already_exists_error_status_and_code(self):
+        """Issue #341: dedicated 409 conflict for rename/move collisions."""
+        from app.core.exceptions import FileAlreadyExistsError
+
+        exc = FileAlreadyExistsError(
+            "rename",
+            "/srv/src.txt",
+            existing_path="dst.txt",
+        )
+        assert exc.status_code == status.HTTP_409_CONFLICT
+        assert exc.error_code == "FILE_ALREADY_EXISTS"
+        assert isinstance(exc, FileOperationException)
+        details = {d.code: d.message for d in exc.extra_details()}
+        assert details["EXISTING_PATH"] == "dst.txt"
+        # At least one of the two suggested actions reaches the envelope.
+        suggested = [
+            d.message for d in exc.extra_details() if d.code == "SUGGESTED_ACTION"
+        ]
+        assert any("different destination" in s for s in suggested)
+
+    def test_file_already_exists_error_defaults_existing_path_to_file_path(self):
+        from app.core.exceptions import FileAlreadyExistsError
+
+        exc = FileAlreadyExistsError("upload", "/srv/foo.txt")
+        assert exc.existing_path == "/srv/foo.txt"
+
 
 class TestHandleFileErrorErrnoDispatch:
     """Coverage for the errno-aware dispatch added to ``handle_file_error``

--- a/tests/unit/files/application/test_management.py
+++ b/tests/unit/files/application/test_management.py
@@ -58,7 +58,9 @@ class TestFileManagementService:
         self, mock_exists, mock_server, mock_db
     ):
         """Test get_server_files when server directory doesn't exist"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
         mock_exists.return_value = False
 
         with pytest.raises(FileOperationException):
@@ -70,7 +72,9 @@ class TestFileManagementService:
         self, mock_exists, mock_server, mock_db
     ):
         """Test get_server_files with path traversal attempt"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
         mock_exists.side_effect = [True, True]  # server_path and target_path exist
 
         with patch("pathlib.Path.resolve") as mock_resolve:
@@ -92,7 +96,9 @@ class TestFileManagementService:
         self, mock_iterdir, mock_is_dir, mock_exists, mock_server, mock_db
     ):
         """Test successful directory listing"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
         mock_exists.return_value = True
         mock_is_dir.return_value = True
 
@@ -133,7 +139,9 @@ class TestFileManagementService:
     @pytest.mark.asyncio
     async def test_read_file_path_traversal(self, mock_server, mock_db):
         """Test read_file with path traversal attempt"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
 
         with patch("pathlib.Path.resolve") as mock_resolve:
             mock_resolve.side_effect = [
@@ -150,7 +158,9 @@ class TestFileManagementService:
     @patch("pathlib.Path.exists")
     async def test_read_file_not_found(self, mock_exists, mock_server, mock_db):
         """Test read_file when file doesn't exist"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
         mock_exists.return_value = False
 
         with pytest.raises(FileOperationException):
@@ -165,7 +175,9 @@ class TestFileManagementService:
         self, mock_is_dir, mock_exists, mock_server, mock_db
     ):
         """Test read_file when target is a directory"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
         mock_exists.return_value = True
         mock_is_dir.return_value = True
 
@@ -188,7 +200,9 @@ class TestFileManagementService:
         self, mock_safe_read, mock_is_dir, mock_exists, mock_server, mock_db
     ):
         """Test successful file read"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
         mock_exists.return_value = True
         mock_is_dir.return_value = False
 
@@ -222,7 +236,9 @@ class TestFileManagementService:
         self, mock_safe_read, mock_is_dir, mock_exists, mock_server, mock_db
     ):
         """Test read_file with unicode decode error"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
         mock_exists.return_value = True
         mock_is_dir.return_value = False
 
@@ -261,7 +277,9 @@ class TestFileManagementService:
         self, mock_resolve, mock_server, mock_user, mock_db
     ):
         """Test write_file with path traversal attempt"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
         mock_resolve.side_effect = [
             Path("/etc/passwd"),  # target_path.resolve()
             Path("/servers/test_server"),  # server_path.resolve()
@@ -279,7 +297,9 @@ class TestFileManagementService:
     @pytest.mark.asyncio
     async def test_write_file_restricted_non_admin(self, mock_server, mock_user, mock_db):
         """Test write_file restricted file by non-admin user"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
 
         with patch("pathlib.Path.resolve") as mock_resolve:
             mock_resolve.side_effect = [
@@ -303,7 +323,9 @@ class TestFileManagementService:
         self, mock_aiofiles_open, mock_exists, mock_server, mock_user, mock_db
     ):
         """Test successful file write"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
         mock_exists.return_value = False
 
         mock_file = AsyncMock()
@@ -354,7 +376,9 @@ class TestFileManagementService:
         self, mock_exists, mock_server, mock_user, mock_db
     ):
         """Test delete_file when file doesn't exist"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
         mock_exists.return_value = False
 
         with pytest.raises(FileOperationException):
@@ -376,7 +400,9 @@ class TestFileManagementService:
         mock_db,
     ):
         """Test successful file deletion"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
         mock_exists.return_value = True
         mock_is_file.return_value = True
 
@@ -406,7 +432,9 @@ class TestFileManagementService:
         self, mock_rmtree, mock_is_dir, mock_exists, mock_server, mock_admin_user, mock_db
     ):
         """Test successful directory deletion"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
         mock_exists.return_value = True
         mock_is_dir.return_value = True
 
@@ -447,11 +475,15 @@ class TestFileManagementService:
         self, mock_aiofiles_open, mock_server, mock_user, mock_db
     ):
         """Test successful file upload"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
 
         mock_file = Mock(spec=UploadFile)
         mock_file.filename = "test.txt"
-        mock_file.read = AsyncMock(return_value=b"file content")
+        # Chunked upload (#341): first read returns the payload, the
+        # next signals EOF so the streaming loop terminates.
+        mock_file.read = AsyncMock(side_effect=[b"file content", b""])
 
         mock_aio_file = AsyncMock()
         mock_aiofiles_open.return_value.__aenter__.return_value = mock_aio_file
@@ -503,7 +535,9 @@ class TestFileManagementService:
         self, mock_is_dir, mock_exists, mock_server, mock_db
     ):
         """Test successful file download"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
         mock_exists.return_value = True
         mock_is_dir.return_value = False
 
@@ -534,7 +568,9 @@ class TestFileManagementService:
     @pytest.mark.asyncio
     async def test_create_directory_success(self, mock_server, mock_db):
         """Test successful directory creation"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
 
         with patch("pathlib.Path.resolve") as mock_resolve:
             mock_resolve.side_effect = [
@@ -571,7 +607,9 @@ class TestFileManagementService:
         self, mock_rglob, mock_exists, mock_server, mock_db
     ):
         """Test successful file search"""
-        mock_db.query.return_value.filter.return_value.one_or_none.return_value = mock_server
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
         mock_exists.return_value = True
 
         mock_file = Mock()
@@ -752,3 +790,117 @@ class TestFileManagementService:
             assert not service._is_restricted_file(Path(filename)), (
                 f"Non-restricted file {filename} should not be protected"
             )
+
+
+class TestUploadFileOperation:
+    """Issue #341: upload_file streams the payload and rejects oversize uploads."""
+
+    @pytest.mark.asyncio
+    async def test_upload_file_streams_chunked_reads(self, tmp_path):
+        """upload_file consumes the file with bounded ``read(N)`` calls."""
+        from app.files.application.management import FileOperationService
+
+        service = FileOperationService(backup_service=Mock())
+        target = tmp_path / "uploaded.bin"
+
+        payload = b"abcdef" * 1000  # 6 KiB — fits in a single 64 KiB chunk
+        chunks = [payload, b""]
+        mock_file = Mock(spec=UploadFile)
+        mock_file.read = AsyncMock(side_effect=chunks)
+
+        written = await service.upload_file(mock_file, target)
+
+        assert written == len(payload)
+        assert target.read_bytes() == payload
+        # First call requested at most CHUNK_BYTES; second call drains EOF.
+        assert mock_file.read.call_args_list[0].args[0] == service._UPLOAD_CHUNK_BYTES
+
+    @pytest.mark.asyncio
+    async def test_upload_file_rejects_oversize(self, tmp_path, monkeypatch):
+        """Exceeding ``FILE_MAX_UPLOAD_BYTES`` raises ``FileTooLargeError``."""
+        from app.core.exceptions import FileTooLargeError
+        from app.files.application.management import FileOperationService, settings
+
+        monkeypatch.setattr(settings, "FILE_MAX_UPLOAD_BYTES", 128)
+
+        service = FileOperationService(backup_service=Mock())
+        target = tmp_path / "huge.bin"
+
+        # 64 KiB chunk * 3 => 192 KiB, well over the 128-byte cap.
+        oversize = b"x" * (64 * 1024)
+        mock_file = Mock(spec=UploadFile)
+        mock_file.read = AsyncMock(side_effect=[oversize, oversize, b""])
+
+        with pytest.raises(FileTooLargeError) as excinfo:
+            await service.upload_file(mock_file, target)
+
+        # The error carries the running size + configured cap and the
+        # partial output is cleaned up so storage isn't leaked.
+        assert excinfo.value.size_bytes is not None
+        assert excinfo.value.size_bytes > 128
+        assert excinfo.value.max_bytes == 128
+        assert not target.exists()
+
+    @pytest.mark.asyncio
+    async def test_upload_file_limit_zero_disables_enforcement(
+        self, tmp_path, monkeypatch
+    ):
+        """``FILE_MAX_UPLOAD_BYTES = 0`` allows arbitrarily large uploads."""
+        from app.files.application.management import FileOperationService, settings
+
+        monkeypatch.setattr(settings, "FILE_MAX_UPLOAD_BYTES", 0)
+
+        service = FileOperationService(backup_service=Mock())
+        target = tmp_path / "unbounded.bin"
+        big = b"y" * (64 * 1024)
+        mock_file = Mock(spec=UploadFile)
+        mock_file.read = AsyncMock(side_effect=[big, big, b""])
+
+        written = await service.upload_file(mock_file, target)
+        assert written == 2 * len(big)
+        assert target.stat().st_size == 2 * len(big)
+
+
+class TestRenameFileAlreadyExists:
+    """Issue #341: rename surfaces 409 ``FileAlreadyExistsError`` on conflict."""
+
+    @pytest.mark.asyncio
+    async def test_rename_conflict_raises_file_already_exists(self, tmp_path):
+        from app.core.exceptions import FileAlreadyExistsError
+        from app.files.application.management import file_management_service
+
+        # Stage a real server directory with both the source and the
+        # conflicting destination already present.
+        server_dir = tmp_path / "srv"
+        server_dir.mkdir()
+        (server_dir / "src.txt").write_text("hello")
+        (server_dir / "dst.txt").write_text("collision")
+
+        server = Mock(spec=Server)
+        server.id = 1
+        server.directory_path = str(server_dir)
+
+        mock_db = Mock()
+        user = Mock(spec=User)
+        user.id = 1
+        user.username = "operator"
+        user.role = Role.admin
+
+        with patch.object(
+            file_management_service.validation_service,
+            "validate_server_exists",
+            new=AsyncMock(return_value=server),
+        ):
+            with pytest.raises(FileAlreadyExistsError) as excinfo:
+                await file_management_service.rename_file(
+                    server_id=1,
+                    file_path="src.txt",
+                    new_name="dst.txt",
+                    db=mock_db,
+                    user=user,
+                )
+
+        # The error envelope carries the conflicting path so the UI can
+        # offer "rename to" / "delete first" without an extra round-trip.
+        assert excinfo.value.existing_path == "dst.txt"
+        assert excinfo.value.status_code == 409


### PR DESCRIPTION
## Summary
Three #35/#36 follow-up fixes for the file-operation contract:

1. **Upload size enforcement (`FileTooLargeError`, HTTP 413)** — `FileOperationService.upload_file` now streams the payload in 64 KiB chunks instead of `await file.read()`, so a malicious or accidental oversize upload never lands fully in process memory. A new `Settings.FILE_MAX_UPLOAD_BYTES` (default 100 MiB, `0` disables) is checked after every chunk; partial output is unlinked before the 413 propagates.
2. **Encoding pre-validation on `FileWriteRequest` (HTTP 422)** — `router.write_file` computed `content.encode(payload.encoding, ...)` *outside* the try/except wrapping `_safe_audit`, so an unknown codec leaked a bare `LookupError` (500) and the failure-audit event was never emitted. Added a Pydantic `@field_validator` that runs `codecs.lookup(v)`, turning the same input into a clean 422 with the standard envelope before the handler body runs.
3. **Rename conflict (`FileAlreadyExistsError`, HTTP 409)** — `rename_file` previously raised a generic `FileOperationException` (500) when the destination existed. New `FileAlreadyExistsError(FileOperationException)` subclass carries `existing_path` + actionable suggestions and is wired through the global exception handler registry.

## Files touched
- `app/core/exceptions.py` — `FileAlreadyExistsError`
- `app/core/error_handlers.py` — register the new handler
- `app/core/config.py` — `FILE_MAX_UPLOAD_BYTES` setting + validator
- `app/files/application/management.py` — chunked upload + new exception in `rename_file`
- `app/files/schemas.py` — `@field_validator` on `FileWriteRequest.encoding`

## Test plan
- [x] Unit: `tests/unit/core/test_exceptions.py::TestFileOperationExceptionTaxonomy` (new 409 subclass)
- [x] Unit: `tests/unit/files/application/test_management.py::TestUploadFileOperation` (chunked happy-path, oversize rejection with partial cleanup, zero-limit bypass)
- [x] Unit: `tests/unit/files/application/test_management.py::TestRenameFileAlreadyExists`
- [x] Integration: `tests/integration/files/test_router.py::TestIssue341FileRouterContract` (413, 422 no-audit, 409 with `EXISTING_PATH`)
- [x] All 510 unit tests pass (`tests/unit -m "not slow"`)
- [x] All 62 `tests/integration/files` tests pass
- [x] `ruff check` + `ruff format --check` clean for modified files

Resolves #341.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>