### PR TITLE
chore: add direnv integration + Nix usage in README (Resolves #173, Resolves #174)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+# direnv-flake hook for automatic devShell activation.
+# Requires nix-direnv: https://github.com/nix-community/nix-direnv
+#
+# After installing direnv + nix-direnv, run `direnv allow` once in this
+# directory; entering the repo will then auto-load the Nix devShell.
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ coverage.json
 
 # Test screenshots
 /screenshots/
+
+# direnv / nix-direnv (Issue #173)
+# `.envrc` itself is committed (loads the Nix devShell); local overrides
+# and the direnv cache directory must not be.
+.envrc.local
+.direnv/

--- a/README.md
+++ b/README.md
@@ -79,6 +79,44 @@ A comprehensive FastAPI-based backend system for managing multiple Minecraft ser
 
 The API will be available at `http://localhost:8000` with interactive documentation at `/docs`.
 
+### Optional: Nix-based development environment
+
+For a fully reproducible system-level toolchain (Python 3.13, `uv`,
+JDK 21, `just`, `pre-commit`, `git`), the repository ships a minimal
+[`flake.nix`](./flake.nix). This is **strictly opt-in** — the standard
+`uv sync` workflow above continues to work without any of the steps
+below, so non-Nix contributors are unaffected.
+
+**Prerequisites**: install [Nix](https://nixos.org/download) with
+flakes enabled (the [Determinate Systems installer](https://zero-to-nix.com/start/install)
+enables flakes by default).
+
+**Manual entry** — enter the devShell on demand:
+
+```bash
+nix develop
+uv sync --group dev
+uv run pre-commit install --hook-type pre-commit --hook-type pre-push
+```
+
+**Automatic with direnv** (recommended) — `cd` into the repo and the
+devShell loads itself; `cd` out and it unloads:
+
+```bash
+# one-time install of direnv + nix-direnv, then in this directory:
+direnv allow
+```
+
+`.envrc` (committed) contains `use flake`, which delegates activation
+to [`nix-direnv`](https://github.com/nix-community/nix-direnv). Place
+host-specific overrides in `.envrc.local` (gitignored).
+
+**Relationship to the standard workflow**: Nix manages the *system*
+toolchain (interpreter, JDK, CLI utilities); `uv` continues to manage
+Python *dependencies* inside `.venv`. The two layers are independent,
+so you can adopt or drop Nix without touching `pyproject.toml` /
+`uv.lock`.
+
 ## Documentation
 
 ### 📚 Core Documentation


### PR DESCRIPTION
## Summary

Combined follow-up to PR #324 (Issue #172, `flake.nix` devShell). Adds the two remaining D-track chores in a single docs-leaning PR:

- **#173 (.envrc / direnv)**: ship `.envrc` containing `use flake` so direnv (via [nix-direnv](https://github.com/nix-community/nix-direnv)) auto-loads the Nix devShell on `cd`. `.gitignore` now excludes `.envrc.local` (host-specific overrides) and `.direnv/` (direnv cache).
- **#174 (README Nix section)**: add an explicitly opt-in "Optional: Nix-based development environment" subsection under Quick Start covering Nix prerequisites, `nix develop` manual entry, `direnv allow` automatic activation, and the separation between the Nix system layer and the existing `uv`-managed Python layer.

## Non-breaking guarantee

Non-Nix contributors are unaffected. The standard `uv sync --group dev` workflow continues to work without direnv or Nix installed — the new sections in README explicitly call this out.

## Verification

- pre-commit ran cleanly on the changed files (`.envrc`, `.gitignore`, `README.md`); all hooks that gate on relevant filetypes either Passed or Skipped (no Python/YAML/JSON/TOML touched).
- Nix is **not** installed in the agent environment, so end-to-end `direnv allow` activation could not be exercised here. Reviewer/maintainer please confirm on a Nix host:

## Test plan

- [ ] On a host with Nix + direnv + nix-direnv installed, run `direnv allow` in the repo root and confirm the devShell auto-loads (python 3.13, uv, java 21 visible).
- [ ] `cd` out of the repo and confirm the devShell unloads.
- [ ] On a host **without** Nix, confirm `uv sync --group dev` + `uv run fastapi dev` still work without touching `.envrc`.
- [ ] Skim the new README subsection for tone/structure consistency with the rest of Quick Start.

Resolves #173
Resolves #174