### PR TITLE
fix: version group upper bound + jar download_url validation (Resolves #353)

### DIFF
--- a/app/servers/adapters/_legacy_helpers.py
+++ b/app/servers/adapters/_legacy_helpers.py
@@ -36,6 +36,7 @@ from app.core.exceptions import (
 )
 from app.core.security import PathValidator, SecurityError
 from app.servers.application.minecraft_server import minecraft_server_manager
+from app.servers.domain.exceptions import UnsupportedMinecraftVersionError
 from app.servers.models import Server, ServerStatus, ServerType
 from app.servers.schemas import (
     ServerCreateRequest,
@@ -468,6 +469,12 @@ class ServerJarService:
                 db, server_type, minecraft_version
             )
 
+            if not download_url:
+                raise UnsupportedMinecraftVersionError(
+                    version=minecraft_version,
+                    server_type=server_type.value,
+                )
+
             cached_jar_path = await self.cache_manager.get_or_download_jar(
                 server_type, minecraft_version, download_url
             )
@@ -482,6 +489,8 @@ class ServerJarService:
             )
             return server_jar_path
 
+        except UnsupportedMinecraftVersionError:
+            raise
         except Exception as e:
             handle_file_error("get server jar", str(server_dir), e)
 

--- a/app/servers/application/server_properties_generator.py
+++ b/app/servers/application/server_properties_generator.py
@@ -19,7 +19,7 @@ class ServerPropertiesGenerator:
             "1.13-1.15": {"min": "1.13.0", "max": "1.15.99"},
             "1.16-1.18": {"min": "1.16.0", "max": "1.18.99"},
             "1.19-1.20": {"min": "1.19.0", "max": "1.20.99"},
-            "1.21+": {"min": "1.21.0", "max": "9.99.99"},
+            "1.21+": {"min": "1.21.0", "max": "9999.99.99"},
         }
 
     def generate_properties(
@@ -230,8 +230,7 @@ class ServerPropertiesGenerator:
         except Exception as e:
             logger.warning(f"Failed to parse version {minecraft_version}: {e}")
 
-        # Default to latest group if parsing fails
-        return "1.19-1.20"
+        return "1.21+"
 
     def _normalize_user_properties(
         self, user_properties: Dict[str, Any]

--- a/tests/unit/servers/application/test_server_properties_generator.py
+++ b/tests/unit/servers/application/test_server_properties_generator.py
@@ -55,13 +55,20 @@ class TestServerPropertiesGenerator:
         assert generator._get_version_group("1.22.0") == "1.21+"
         assert generator._get_version_group("2.0.0") == "1.21+"
 
+    def test_get_version_group_future_versions(self):
+        """Test version group detection for future versioning schemes (e.g. 26.x)"""
+        generator = ServerPropertiesGenerator()
+
+        assert generator._get_version_group("26.1.2") == "1.21+"
+        assert generator._get_version_group("10.0.0") == "1.21+"
+        assert generator._get_version_group("100.0.0") == "1.21+"
+
     def test_get_version_group_invalid(self):
         """Test version group detection for invalid versions"""
         generator = ServerPropertiesGenerator()
 
-        # Should default to 1.19-1.20 for invalid versions
-        assert generator._get_version_group("invalid") == "1.19-1.20"
-        assert generator._get_version_group("1.x.y") == "1.19-1.20"
+        assert generator._get_version_group("invalid") == "1.21+"
+        assert generator._get_version_group("1.x.y") == "1.21+"
 
     def test_get_base_properties(self, admin_user):
         """Test base properties generation"""

--- a/tests/unit/servers/test_service.py
+++ b/tests/unit/servers/test_service.py
@@ -21,6 +21,7 @@ from app.servers.application.service import (
     ServerSecurityValidator,
     ServerService,
 )
+from app.servers.domain.exceptions import UnsupportedMinecraftVersionError
 from app.servers.models import Server, ServerType
 from app.servers.schemas import ServerCreateRequest, ServerUpdateRequest
 from app.users.domain.value_objects import Role
@@ -537,6 +538,19 @@ class TestServerJarServiceExtended:
                     )
 
                     mock_handle_error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_server_jar_no_download_url(self, jar_service, db):
+        """Test that missing download_url raises UnsupportedMinecraftVersionError"""
+        with patch.object(jar_service, "_is_version_supported_db", return_value=True):
+            with patch.object(jar_service, "_get_download_url_db", return_value=None):
+                with pytest.raises(UnsupportedMinecraftVersionError) as exc_info:
+                    await jar_service.get_server_jar(
+                        ServerType.paper, "1.21.6", Path("/tmp"), db
+                    )
+
+                assert "1.21.6" in str(exc_info.value)
+                assert "paper" in str(exc_info.value)
 
 
 class TestServerFileSystemServiceExtended:


### PR DESCRIPTION
## Summary

- **Properties generator `1.21+` group max**: `9.99.99` → `9999.99.99` to support future versioning schemes (e.g. `26.x`). Aligns with `java_compatibility.py` which already uses `9999.99.99`.
- **Fallback version group**: `"1.19-1.20"` → `"1.21+"` so unknown/unparseable versions get the latest properties instead of stale ones.
- **download_url validation**: Raise `UnsupportedMinecraftVersionError` (HTTP 400) when `download_url` is missing from DB, instead of passing `None` to `JarCacheManager` which causes `TypeError` → `FileOperationException` → `ServerJarDownloadError` (HTTP 502).

UI-side version dropdown filtering (versions mixed across server types) tracked in #357.

## Test plan

- [x] `test_get_version_group_future_versions` — verifies `26.1.2`, `10.0.0`, `100.0.0` map to `"1.21+"`
- [x] `test_get_version_group_invalid` — updated to expect `"1.21+"` fallback
- [x] `test_get_server_jar_no_download_url` — verifies `UnsupportedMinecraftVersionError` raised when `download_url` is `None`
- [x] All 1457 unit tests pass, pre-commit hooks (ruff, format, mypy, pytest smoke) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)