### PR TITLE
perf: cache parsed Settings properties with functools.cached_property (Resolves #367)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,6 +17,7 @@ See ``docs/CONFIGURATION.md`` for the full reference and load order.
 
 from __future__ import annotations
 
+import functools
 import os
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional
@@ -622,7 +623,7 @@ class Settings(BaseSettings):
     # Properties
     # ------------------------------------------------------------------
 
-    @property
+    @functools.cached_property
     def cors_origins_list(self) -> List[str]:
         """Parse CORS origins from comma-separated string"""
         if not self.CORS_ORIGINS:
@@ -631,7 +632,7 @@ class Settings(BaseSettings):
             origin.strip() for origin in self.CORS_ORIGINS.split(",") if origin.strip()
         ]
 
-    @property
+    @functools.cached_property
     def trusted_proxies_list(self) -> List[str]:
         """Parse TRUSTED_PROXIES from a comma-separated string.
 
@@ -664,7 +665,7 @@ class Settings(BaseSettings):
         """Check if running in staging environment"""
         return self.ENVIRONMENT == Environment.STAGING
 
-    @property
+    @functools.cached_property
     def java_discovery_paths_list(self) -> List[str]:
         """Parse Java discovery paths from comma-separated string"""
         if not self.JAVA_DISCOVERY_PATHS:

--- a/tests/unit/auth/test_extract_ip.py
+++ b/tests/unit/auth/test_extract_ip.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from app.auth.api.router import _extract_ip
-from app.core.config import settings
+from app.core.config import Settings, settings
 
 
 def _make_request(*, client_host: str | None, headers: dict[str, str]):
@@ -31,6 +31,7 @@ class TestProxyTrustDisabledByDefault:
     def test_xff_is_ignored_when_trust_disabled(self, monkeypatch):
         monkeypatch.setattr(settings, "TRUST_PROXY_HEADERS", False)
         monkeypatch.setattr(settings, "TRUSTED_PROXIES", "10.0.0.1")
+        monkeypatch.setattr(settings, "trusted_proxies_list", ["10.0.0.1"])
         req = _make_request(
             client_host="203.0.113.5",
             headers={"X-Forwarded-For": "1.2.3.4, 9.9.9.9"},
@@ -55,6 +56,7 @@ class TestProxyTrustEnabledRequiresTrustedPeer:
     def test_xff_trusted_when_peer_is_trusted_proxy(self, monkeypatch):
         monkeypatch.setattr(settings, "TRUST_PROXY_HEADERS", True)
         monkeypatch.setattr(settings, "TRUSTED_PROXIES", "10.0.0.1,127.0.0.1")
+        monkeypatch.setattr(settings, "trusted_proxies_list", ["10.0.0.1", "127.0.0.1"])
         req = _make_request(
             client_host="10.0.0.1",
             headers={"X-Forwarded-For": "1.2.3.4, 9.9.9.9"},
@@ -65,6 +67,7 @@ class TestProxyTrustEnabledRequiresTrustedPeer:
         """An attacker hitting the API directly cannot spoof IP."""
         monkeypatch.setattr(settings, "TRUST_PROXY_HEADERS", True)
         monkeypatch.setattr(settings, "TRUSTED_PROXIES", "10.0.0.1")
+        monkeypatch.setattr(settings, "trusted_proxies_list", ["10.0.0.1"])
         req = _make_request(
             client_host="203.0.113.5",  # NOT in TRUSTED_PROXIES
             headers={"X-Forwarded-For": "1.2.3.4"},
@@ -75,6 +78,7 @@ class TestProxyTrustEnabledRequiresTrustedPeer:
     def test_real_ip_fallback_when_xff_absent(self, monkeypatch):
         monkeypatch.setattr(settings, "TRUST_PROXY_HEADERS", True)
         monkeypatch.setattr(settings, "TRUSTED_PROXIES", "10.0.0.1")
+        monkeypatch.setattr(settings, "trusted_proxies_list", ["10.0.0.1"])
         req = _make_request(
             client_host="10.0.0.1",
             headers={"X-Real-IP": "1.2.3.4"},
@@ -85,6 +89,7 @@ class TestProxyTrustEnabledRequiresTrustedPeer:
         """Safe-by-default even when TRUST_PROXY_HEADERS=true."""
         monkeypatch.setattr(settings, "TRUST_PROXY_HEADERS", True)
         monkeypatch.setattr(settings, "TRUSTED_PROXIES", "")
+        monkeypatch.setattr(settings, "trusted_proxies_list", [])
         req = _make_request(
             client_host="10.0.0.1",
             headers={"X-Forwarded-For": "1.2.3.4"},
@@ -95,6 +100,7 @@ class TestProxyTrustEnabledRequiresTrustedPeer:
         """Multi-hop XFF returns the original client (leftmost)."""
         monkeypatch.setattr(settings, "TRUST_PROXY_HEADERS", True)
         monkeypatch.setattr(settings, "TRUSTED_PROXIES", "10.0.0.1")
+        monkeypatch.setattr(settings, "trusted_proxies_list", ["10.0.0.1"])
         req = _make_request(
             client_host="10.0.0.1",
             headers={"X-Forwarded-For": "  1.2.3.4 , 5.6.7.8 , 10.0.0.1 "},
@@ -105,10 +111,18 @@ class TestProxyTrustEnabledRequiresTrustedPeer:
 class TestTrustedProxiesListParse:
     """Pure config helper covering whitespace handling."""
 
-    def test_list_strips_whitespace_and_skips_empty(self, monkeypatch):
-        monkeypatch.setattr(settings, "TRUSTED_PROXIES", "  10.0.0.1 ,, 127.0.0.1 ,")
-        assert settings.trusted_proxies_list == ["10.0.0.1", "127.0.0.1"]
+    def test_list_strips_whitespace_and_skips_empty(self):
+        s = Settings(
+            SECRET_KEY="this-is-a-very-secure-secret-key-with-sufficient-length",
+            DATABASE_URL="sqlite:///test.db",
+            TRUSTED_PROXIES="  10.0.0.1 ,, 127.0.0.1 ,",
+        )
+        assert s.trusted_proxies_list == ["10.0.0.1", "127.0.0.1"]
 
-    def test_list_empty_when_unset(self, monkeypatch):
-        monkeypatch.setattr(settings, "TRUSTED_PROXIES", "")
-        assert settings.trusted_proxies_list == []
+    def test_list_empty_when_unset(self):
+        s = Settings(
+            SECRET_KEY="this-is-a-very-secure-secret-key-with-sufficient-length",
+            DATABASE_URL="sqlite:///test.db",
+            TRUSTED_PROXIES="",
+        )
+        assert s.trusted_proxies_list == []


### PR DESCRIPTION
## Summary
- `@property` → `@functools.cached_property` に変更し、Settings のカンマ区切り文字列パースを初回アクセス時のみ実行するようにキャッシュ化
- `trusted_proxies_list` は認証リクエストごとに呼ばれるホットパスであり、per-request のパースオーバーヘッドを排除
- テストの monkeypatch パターンを `cached_property` 互換に修正

## Changes
- `app/core/config.py`: `import functools` 追加、3プロパティのデコレータ変更
  - `cors_origins_list`
  - `trusted_proxies_list`
  - `java_discovery_paths_list`
- `tests/unit/auth/test_extract_ip.py`: シングルトン monkeypatch に `trusted_proxies_list` のコンパニオン patch 追加、`TestTrustedProxiesListParse` を fresh Settings インスタンスに移行

## Test plan
- [x] `uv run pytest tests/unit/core/test_config.py tests/unit/auth/test_extract_ip.py -v` — 全テスト通過
- [x] pre-commit hooks (ruff, mypy, pytest smoke) 通過
- [x] pre-push hooks 通過

Resolves #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)