### PR TITLE
perf: replace NOT IN subquery with LEFT JOIN + IS NULL in visibility repository

### DIFF
--- a/app/core/visibility/adapters/repository.py
+++ b/app/core/visibility/adapters/repository.py
@@ -19,7 +19,7 @@ application layer to know the legacy column names. See
 
 from typing import Dict, List, Optional
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func
 from sqlalchemy.orm import Session
 
 from app.core.visibility.domain.entities import (
@@ -188,17 +188,33 @@ class SqlAlchemyVisibilityRepository:
     # ----- Migration helpers (cross-domain reads kept in adapter) -----
 
     async def list_missing_server_ids(self) -> List[int]:
-        existing = select(ResourceVisibility.resource_id).where(
-            ResourceVisibility.resource_type == ResourceType.SERVER
+        rows = (
+            self._db.query(Server.id)
+            .outerjoin(
+                ResourceVisibility,
+                and_(
+                    Server.id == ResourceVisibility.resource_id,
+                    ResourceVisibility.resource_type == ResourceType.SERVER,
+                ),
+            )
+            .filter(ResourceVisibility.id.is_(None))
+            .all()
         )
-        rows = self._db.query(Server.id).filter(~Server.id.in_(existing)).all()
         return [row.id for row in rows]
 
     async def list_missing_group_ids(self) -> List[int]:
-        existing = select(ResourceVisibility.resource_id).where(
-            ResourceVisibility.resource_type == ResourceType.GROUP
+        rows = (
+            self._db.query(Group.id)
+            .outerjoin(
+                ResourceVisibility,
+                and_(
+                    Group.id == ResourceVisibility.resource_id,
+                    ResourceVisibility.resource_type == ResourceType.GROUP,
+                ),
+            )
+            .filter(ResourceVisibility.id.is_(None))
+            .all()
         )
-        rows = self._db.query(Group.id).filter(~Group.id.in_(existing)).all()
         return [row.id for row in rows]
 
     async def add_many_public(


### PR DESCRIPTION
## Summary
- Replaced `NOT IN (subquery)` with `LEFT JOIN + IS NULL` (anti-join) in `list_missing_server_ids()` and `list_missing_group_ids()` methods
- Removed unused `select` import and added `and_` import from SQLAlchemy
- This optimization avoids the correlated subquery and lets the database planner use a more efficient hash/merge anti-join

Resolves #371

## Test plan
- [x] Integration tests for `list_missing_server_ids` and `list_missing_group_ids` pass (`tests/integration/core/visibility/test_visibility_repository.py -k missing`)
- [x] All 20 visibility integration tests pass
- [x] Full unit smoke suite passes (1456 passed, 5 skipped)
- [x] Ruff lint and format pass
- [x] mypy type checking passes
- [x] Pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)