### PR TITLE
perf: replace COUNT loops with GROUP BY aggregation in server statistics (Resolves #362)

### DIFF
--- a/app/servers/adapters/_legacy_helpers.py
+++ b/app/servers/adapters/_legacy_helpers.py
@@ -352,15 +352,19 @@ def get_server_statistics_legacy(user: User, db: Session) -> Dict[str, Any]:
             query = query.filter(Server.owner_id == user.id)
         total_servers = query.count()
 
-        status_counts: Dict[str, int] = {}
-        for status_value in ServerStatus:
-            count = query.filter(Server.status == status_value).count()
+        status_counts: Dict[str, int] = {s.value: 0 for s in ServerStatus}
+        status_query = query.with_entities(
+            Server.status, func.count(Server.id).label("count")
+        ).group_by(Server.status)
+        for status_value, count in status_query:
             status_counts[status_value.value] = count
 
-        type_counts: Dict[str, int] = {}
-        for server_type_value in ServerType:
-            count = query.filter(Server.server_type == server_type_value).count()
-            type_counts[server_type_value.value] = count
+        type_counts: Dict[str, int] = {t.value: 0 for t in ServerType}
+        type_query = query.with_entities(
+            Server.server_type, func.count(Server.id).label("count")
+        ).group_by(Server.server_type)
+        for type_value, count in type_query:
+            type_counts[type_value.value] = count
 
         version_query = query.with_entities(
             Server.minecraft_version, func.count(Server.id).label("count")

--- a/tests/unit/servers/application/test_server_service.py
+++ b/tests/unit/servers/application/test_server_service.py
@@ -307,17 +307,41 @@ class TestServerService:
     # Test get_server_statistics
     def test_get_server_statistics_admin(self, service, admin_user, mock_db_session):
         """Test server statistics for admin user"""
-        # Mock query chain
+        # Mock query chain — with_entities().group_by() is called three
+        # times: status, type, and version.  The first two are iterated
+        # directly; the third uses .all().  We use side_effect to return
+        # a fresh iterable mock for each call.
         mock_db_session.count.return_value = 5
         mock_db_session.with_entities.return_value = mock_db_session
-        mock_db_session.group_by.return_value = mock_db_session
-        mock_db_session.all.return_value = [("1.19.0", 3), ("1.18.0", 2)]
+
+        status_result = Mock()
+        status_result.__iter__ = Mock(
+            return_value=iter([(ServerStatus.running, 3), (ServerStatus.stopped, 2)])
+        )
+
+        type_result = Mock()
+        type_result.__iter__ = Mock(
+            return_value=iter([(ServerType.vanilla, 4), (ServerType.paper, 1)])
+        )
+
+        version_result = Mock()
+        version_result.all.return_value = [("1.19.0", 3), ("1.18.0", 2)]
+
+        mock_db_session.group_by.side_effect = [
+            status_result,
+            type_result,
+            version_result,
+        ]
 
         result = service.get_server_statistics(admin_user, db=mock_db_session)
 
         assert result["total_servers"] == 5
         assert "status_distribution" in result
+        assert result["status_distribution"]["running"] == 3
+        assert result["status_distribution"]["stopped"] == 2
         assert "type_distribution" in result
+        assert result["type_distribution"]["vanilla"] == 4
+        assert result["type_distribution"]["paper"] == 1
         assert "version_distribution" in result
         assert result["version_distribution"]["1.19.0"] == 3
         assert "last_updated" in result
@@ -328,8 +352,21 @@ class TestServerService:
         """Test server statistics for regular user with filtering"""
         mock_db_session.count.return_value = 2
         mock_db_session.with_entities.return_value = mock_db_session
-        mock_db_session.group_by.return_value = mock_db_session
-        mock_db_session.all.return_value = [("1.19.0", 2)]
+
+        status_result = Mock()
+        status_result.__iter__ = Mock(return_value=iter([(ServerStatus.running, 2)]))
+
+        type_result = Mock()
+        type_result.__iter__ = Mock(return_value=iter([(ServerType.vanilla, 2)]))
+
+        version_result = Mock()
+        version_result.all.return_value = [("1.19.0", 2)]
+
+        mock_db_session.group_by.side_effect = [
+            status_result,
+            type_result,
+            version_result,
+        ]
 
         result = service.get_server_statistics(regular_user, db=mock_db_session)
 


### PR DESCRIPTION
## Summary
- サーバー統計取得の COUNT ループ (status 5回 + type 3回 = 8クエリ) を GROUP BY 集約クエリ 2本に置換
- 既存の version_query と同じパターンに統一
- 全 enum 値をゼロ初期化 dict で事前定義し、出力フォーマットを完全保持

## Changes
- `app/servers/adapters/_legacy_helpers.py`: 2つのループを GROUP BY クエリに置換
- `tests/unit/servers/application/test_server_service.py`: mock chain を `side_effect` パターンに更新、分布値の具体的なアサーション追加

## Test plan
- [x] `uv run pytest tests/unit/servers/application/test_server_service.py -v -k statistics` — 全テスト通過
- [x] unit smoke (1457 passed, 5 skipped)
- [x] pre-commit hooks 通過

Resolves #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)