### PR TITLE
perf: replace model_validate with model_construct for trusted entity conversions

### DIFF
--- a/app/files/router.py
+++ b/app/files/router.py
@@ -373,7 +373,22 @@ async def get_file_edit_history(
     return FileHistoryListResponse(
         file_path=file_path,
         total_versions=len(history),
-        history=[FileHistoryRecord.model_validate(entity) for entity in history],
+        history=[
+            FileHistoryRecord.model_construct(
+                id=entity.id,
+                server_id=entity.server_id,
+                file_path=entity.file_path,
+                version_number=entity.version_number,
+                backup_file_path=entity.backup_file_path,
+                file_size=entity.file_size,
+                content_hash=entity.content_hash,
+                editor_user_id=entity.editor_user_id,
+                editor_username=entity.editor_username,
+                created_at=entity.created_at,
+                description=entity.description,
+            )
+            for entity in history
+        ],
     )
 
 

--- a/app/users/api/router.py
+++ b/app/users/api/router.py
@@ -56,15 +56,13 @@ def _to_entity(user: User) -> UserEntity:
 
 def _to_schema(entity: UserEntity) -> schemas.User:
     """Adapt a `UserEntity` to the Pydantic response schema."""
-    return schemas.User.model_validate(
-        {
-            "id": entity.id,
-            "username": entity.username,
-            "email": entity.email,
-            "role": entity.role,
-            "is_active": entity.is_active,
-            "is_approved": entity.is_approved,
-        }
+    return schemas.User.model_construct(
+        id=entity.id,
+        username=entity.username,
+        email=entity.email,
+        role=entity.role,
+        is_active=entity.is_active,
+        is_approved=entity.is_approved,
     )
 
 


### PR DESCRIPTION
## Summary
- Replace `model_validate()` with `model_construct()` in two router files where the source data comes from trusted domain entities, skipping unnecessary Pydantic re-validation
- `app/files/router.py`: `FileHistoryRecord` conversion from `FileHistoryEntity` (all 11 fields explicitly mapped)
- `app/users/api/router.py`: `User` schema conversion from `UserEntity` (all 6 response fields explicitly mapped)

Resolves #368

## Test plan
- [x] All 126 file + user unit tests pass (`uv run pytest tests/unit/files/ tests/unit/users/ -v -x`)
- [x] Full unit smoke suite passes (`pytest tests/unit -m "not slow"`) via pre-commit hook
- [x] Integration smoke suite passes via pre-push hook
- [x] Ruff lint + format clean
- [x] MyPy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)