### PR TITLE
perf: migrate groups pagination from in-memory slicing to SQL LIMIT/OFFSET (Resolves #365)

### DIFF
--- a/app/groups/adapters/repository.py
+++ b/app/groups/adapters/repository.py
@@ -29,6 +29,7 @@ from app.groups.domain.entities import (
     AttachServerGroupCommand,
     CreateGroupCommand,
     GroupEntity,
+    GroupListPage,
     GroupListSpec,
     ServerGroupEntity,
     UpdateGroupCommand,
@@ -108,12 +109,21 @@ class SqlAlchemyGroupRepository:
         )
         return _group_to_entity(row) if row else None
 
-    async def list(self, spec: GroupListSpec) -> List[GroupEntity]:
+    async def list(self, spec: GroupListSpec) -> GroupListPage:
         # Phase 1 visibility: all authenticated users see all groups.
         query = self.db.query(Group)
         if spec.type is not None:
             query = query.filter(Group.type == spec.type)
-        return [_group_to_entity(r) for r in query.all()]
+
+        total = query.count()
+        rows = query.offset((spec.page - 1) * spec.size).limit(spec.size).all()
+
+        return GroupListPage(
+            entities=[_group_to_entity(r) for r in rows],
+            total=total,
+            page=spec.page,
+            size=spec.size,
+        )
 
     # ===================
     # Writes

--- a/app/groups/application/service.py
+++ b/app/groups/application/service.py
@@ -23,6 +23,7 @@ from app.groups.domain.entities import (
     AttachServerGroupCommand,
     CreateGroupCommand,
     GroupEntity,
+    GroupListPage,
     GroupListSpec,
     UpdateGroupCommand,
 )
@@ -139,9 +140,11 @@ class GroupService:
         self,
         actor_id: int,
         group_type: Optional[GroupType] = None,
-    ) -> List[GroupEntity]:
+        page: int = 1,
+        size: int = 50,
+    ) -> GroupListPage:
         """List groups visible to the viewer (Phase 1 = all groups)."""
-        spec = GroupListSpec(type=group_type)
+        spec = GroupListSpec(type=group_type, page=page, size=size)
         async with self._uow as uow:
             return await uow.groups.list(spec)
 

--- a/app/groups/domain/entities.py
+++ b/app/groups/domain/entities.py
@@ -77,6 +77,18 @@ class GroupListSpec:
     """
 
     type: Optional[GroupType] = None
+    page: int = 1
+    size: int = 50
+
+
+@dataclass(frozen=True)
+class GroupListPage:
+    """Read result for `GroupRepository.list`."""
+
+    entities: List[GroupEntity]
+    total: int
+    page: int
+    size: int
 
 
 @dataclass(frozen=True)

--- a/app/groups/domain/ports.py
+++ b/app/groups/domain/ports.py
@@ -25,6 +25,7 @@ from app.groups.domain.entities import (
     AttachServerGroupCommand,
     CreateGroupCommand,
     GroupEntity,
+    GroupListPage,
     GroupListSpec,
     ServerGroupEntity,
     UpdateGroupCommand,
@@ -57,7 +58,7 @@ class GroupRepository(Protocol):
         self, owner_id: int, name: str
     ) -> Optional[GroupEntity]: ...
 
-    async def list(self, spec: GroupListSpec) -> List[GroupEntity]: ...
+    async def list(self, spec: GroupListSpec) -> GroupListPage: ...
 
     # ----- Writes -----
 

--- a/app/groups/router.py
+++ b/app/groups/router.py
@@ -109,26 +109,26 @@ async def list_groups(
 ):
     """List groups visible to the current user (Phase 1 = all groups).
 
-    Issue #76 (Phase 1): adds ``page`` / ``size`` query parameters and
-    the canonical ``pagination`` response block. ``total`` continues to
-    reflect the full filtered count so legacy clients keep working.
-    The slice is computed in-memory — switching to a SQL-side
-    ``LIMIT/OFFSET`` is tracked as part of the broader pagination
-    migration follow-up.
+    Pagination is handled SQL-side via LIMIT/OFFSET (Issue #365).
+    ``total`` reflects the full filtered count so legacy clients keep
+    working.
     """
     try:
         from app.core.pagination import build_pagination_meta
 
-        entities = await group_service.list_groups(
-            actor_id=current_user.id, group_type=group_type
+        result = await group_service.list_groups(
+            actor_id=current_user.id,
+            group_type=group_type,
+            page=page,
+            size=size,
         )
-        total = len(entities)
-        start = (page - 1) * size
-        end = start + size
-        sliced = entities[start:end]
-        responses = [_entity_to_response(e) for e in sliced]
-        pagination = build_pagination_meta(total=total, page=page, size=size)
-        return GroupListResponse(groups=responses, total=total, pagination=pagination)
+        responses = [_entity_to_response(e) for e in result.entities]
+        pagination = build_pagination_meta(
+            total=result.total, page=result.page, size=result.size
+        )
+        return GroupListResponse(
+            groups=responses, total=result.total, pagination=pagination
+        )
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/tests/integration/groups/test_group_repository.py
+++ b/tests/integration/groups/test_group_repository.py
@@ -80,11 +80,28 @@ class TestGroupRepositoryReads:
         _seed_group(db, admin_user.id, name="o", type=GroupType.op)
         _seed_group(db, admin_user.id, name="w", type=GroupType.whitelist)
 
-        op_only = await repository.list(GroupListSpec(type=GroupType.op))
-        assert [e.name for e in op_only] == ["o"]
+        op_page = await repository.list(GroupListSpec(type=GroupType.op))
+        assert [e.name for e in op_page.entities] == ["o"]
+        assert op_page.total == 1
 
-        all_ = await repository.list(GroupListSpec())
-        assert {e.name for e in all_} == {"o", "w"}
+        all_page = await repository.list(GroupListSpec())
+        assert {e.name for e in all_page.entities} == {"o", "w"}
+        assert all_page.total == 2
+
+    @pytest.mark.asyncio
+    async def test_list_paginates_with_offset_limit(self, repository, db, admin_user):
+        for i in range(5):
+            _seed_group(db, admin_user.id, name=f"g{i}", type=GroupType.op)
+
+        page1 = await repository.list(GroupListSpec(page=1, size=2))
+        assert len(page1.entities) == 2
+        assert page1.total == 5
+        assert page1.page == 1
+        assert page1.size == 2
+
+        page3 = await repository.list(GroupListSpec(page=3, size=2))
+        assert len(page3.entities) == 1
+        assert page3.total == 5
 
 
 # ----- Writes -----

--- a/tests/integration/groups/test_groups_router.py
+++ b/tests/integration/groups/test_groups_router.py
@@ -17,6 +17,7 @@ from app.groups.domain.entities import (
     AttachedGroupView,
     AttachedServerView,
     GroupEntity,
+    GroupListPage,
 )
 from app.groups.domain.exceptions import (
     GroupAccessError,
@@ -87,10 +88,17 @@ class _FakeGroupService:
         self._maybe_raise("create_group")
         return self.entity
 
-    async def list_groups(self, **kwargs) -> List[GroupEntity]:
+    async def list_groups(self, **kwargs) -> GroupListPage:
         self.calls.append(("list_groups", kwargs))
         self._maybe_raise("list_groups")
-        return self.list_entities
+        page = kwargs.get("page", 1)
+        size = kwargs.get("size", 50)
+        return GroupListPage(
+            entities=self.list_entities,
+            total=len(self.list_entities),
+            page=page,
+            size=size,
+        )
 
     async def get_group(self, **kwargs) -> GroupEntity:
         self.calls.append(("get_group", kwargs))

--- a/tests/unit/groups/fakes.py
+++ b/tests/unit/groups/fakes.py
@@ -23,6 +23,7 @@ from app.groups.domain.entities import (
     AttachServerGroupCommand,
     CreateGroupCommand,
     GroupEntity,
+    GroupListPage,
     GroupListSpec,
     ServerGroupEntity,
     UpdateGroupCommand,
@@ -55,11 +56,20 @@ class FakeGroupRepository:
                 return entity
         return None
 
-    async def list(self, spec: GroupListSpec) -> List[GroupEntity]:
+    async def list(self, spec: GroupListSpec) -> GroupListPage:
         rows = list(self._records.values())
         if spec.type is not None:
             rows = [r for r in rows if r.type == spec.type]
-        return rows
+        total = len(rows)
+        start = (spec.page - 1) * spec.size
+        end = start + spec.size
+        sliced = rows[start:end]
+        return GroupListPage(
+            entities=sliced,
+            total=total,
+            page=spec.page,
+            size=spec.size,
+        )
 
     # ----- Writes -----
 

--- a/tests/unit/groups/test_service_with_fake.py
+++ b/tests/unit/groups/test_service_with_fake.py
@@ -196,8 +196,9 @@ async def test_list_groups_passthrough_no_filter(
     group_repo.seed(
         make_group_entity(id=2, owner_id=99, name="b", type=GroupType.whitelist)
     )
-    out = await service.list_groups(actor_id=1)
-    assert {e.id for e in out} == {1, 2}
+    page = await service.list_groups(actor_id=1)
+    assert {e.id for e in page.entities} == {1, 2}
+    assert page.total == 2
 
 
 @pytest.mark.asyncio
@@ -208,8 +209,9 @@ async def test_list_groups_filter_by_type(
     group_repo.seed(
         make_group_entity(id=2, owner_id=1, name="b", type=GroupType.whitelist)
     )
-    out = await service.list_groups(actor_id=1, group_type=GroupType.op)
-    assert {e.id for e in out} == {1}
+    page = await service.list_groups(actor_id=1, group_type=GroupType.op)
+    assert {e.id for e in page.entities} == {1}
+    assert page.total == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Replaced in-memory Python slicing (`entities[start:end]`) with SQL-side `LIMIT/OFFSET` for the groups list endpoint, following the same pattern already used in backups and servers domains.
- Added `page`/`size` fields to `GroupListSpec` and introduced a new `GroupListPage` dataclass to carry paginated results with total count.
- Updated the `GroupRepository` port, SQLAlchemy adapter, `GroupService`, router, and all fakes/tests to use the new return type.

## Changes
- `app/groups/domain/entities.py` — Added `page`/`size` to `GroupListSpec`, added `GroupListPage` dataclass
- `app/groups/domain/ports.py` — `GroupRepository.list()` now returns `GroupListPage`
- `app/groups/adapters/repository.py` — SQL-side `COUNT` + `OFFSET/LIMIT` in `SqlAlchemyGroupRepository.list()`
- `app/groups/application/service.py` — `list_groups()` accepts `page`/`size`, returns `GroupListPage`
- `app/groups/router.py` — Removed in-memory slicing; uses `GroupListPage` directly
- `tests/unit/groups/fakes.py` — `FakeGroupRepository.list()` returns `GroupListPage` with in-memory pagination
- `tests/unit/groups/test_service_with_fake.py` — Updated assertions for `GroupListPage` return type
- `tests/integration/groups/test_group_repository.py` — Updated assertions + added `test_list_paginates_with_offset_limit`
- `tests/integration/groups/test_groups_router.py` — Router fake returns `GroupListPage`

## Test plan
- [x] All 187 group unit + integration tests pass
- [x] Full unit smoke (1457 passed, 5 skipped)
- [x] Lint and format checks pass
- [x] Pre-commit hooks pass (ruff, ruff format, pytest, mypy)
- [x] Pre-push hooks pass (unit + integration smoke)
- [x] New integration test verifies SQL-side OFFSET/LIMIT pagination correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)