### PR TITLE
perf: explicitly configure SQLAlchemy connection pool settings (Resolves #369)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,13 @@ DATABASE_MAX_RETRIES=3
 DATABASE_RETRY_BACKOFF=0.1
 DATABASE_BATCH_SIZE=100
 
+# Database connection pool configuration (Issue #369)
+# pool_size and max_overflow only apply to non-SQLite backends.
+# DB_POOL_SIZE=5
+# DB_MAX_OVERFLOW=10
+# DB_POOL_RECYCLE=3600
+# DB_POOL_PRE_PING=true
+
 # Backup directory housekeeping (Issue #284)
 # Periodic sweep of stale artifacts left in `backups/.pending/` and
 # `backups/.failed/` by interrupted atomic-rename operations.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -176,6 +176,15 @@ class Settings(BaseSettings):
     DATABASE_RETRY_BACKOFF: float = 0.1
     DATABASE_BATCH_SIZE: int = 100
 
+    # Database connection pool configuration (Issue #369)
+    # These are passed to SQLAlchemy's create_engine(); pool_size and
+    # max_overflow are only applied for non-SQLite backends (SQLite uses
+    # a single-connection pool by default).
+    DB_POOL_SIZE: int = 5
+    DB_MAX_OVERFLOW: int = 10
+    DB_POOL_RECYCLE: int = 3600
+    DB_POOL_PRE_PING: bool = True
+
     # File upload size cap (Issue #341). Enforced by the file upload
     # service via a streaming/chunked read so the entire payload never
     # lands in process memory before the limit is checked. Defaults to
@@ -408,6 +417,30 @@ class Settings(BaseSettings):
         """Validate DATABASE_BATCH_SIZE is within reasonable limits"""
         if v < 10 or v > 1000:
             raise ValueError("DATABASE_BATCH_SIZE must be between 10 and 1000")
+        return v
+
+    @field_validator("DB_POOL_SIZE")
+    @classmethod
+    def validate_db_pool_size(cls, v: int) -> int:
+        """Validate DB_POOL_SIZE is within reasonable limits."""
+        if v < 1 or v > 100:
+            raise ValueError("DB_POOL_SIZE must be between 1 and 100")
+        return v
+
+    @field_validator("DB_MAX_OVERFLOW")
+    @classmethod
+    def validate_db_max_overflow(cls, v: int) -> int:
+        """Validate DB_MAX_OVERFLOW is within reasonable limits."""
+        if v < 0 or v > 100:
+            raise ValueError("DB_MAX_OVERFLOW must be between 0 and 100")
+        return v
+
+    @field_validator("DB_POOL_RECYCLE")
+    @classmethod
+    def validate_db_pool_recycle(cls, v: int) -> int:
+        """Validate DB_POOL_RECYCLE is within reasonable limits."""
+        if v < -1 or v > 86400:
+            raise ValueError("DB_POOL_RECYCLE must be between -1 and 86400 seconds")
         return v
 
     @field_validator("FILE_MAX_UPLOAD_BYTES")

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -1,13 +1,32 @@
+from typing import Any, Dict
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 
 from app.core.config import settings
 
-# SQLite database URL (relative path file)
+# Database URL from settings
 DATABASE_URL = settings.DATABASE_URL
 
-# connect_args is necessary for SQLite (to avoid thread constraints)
-engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+# Build engine kwargs with explicit connection pool configuration
+# (Issue #369). SQLite needs `check_same_thread=False` but does not
+# support pool_size / max_overflow (it uses QueuePool(pool_size=5) by
+# default, which is fine). Non-SQLite backends get full pool tuning.
+engine_kwargs: Dict[str, Any] = {
+    "connect_args": {"check_same_thread": False},
+}
+
+if not DATABASE_URL.startswith("sqlite"):
+    # Remove SQLite-specific connect_args for other backends
+    engine_kwargs.pop("connect_args")
+    engine_kwargs["pool_size"] = settings.DB_POOL_SIZE
+    engine_kwargs["max_overflow"] = settings.DB_MAX_OVERFLOW
+    engine_kwargs["pool_recycle"] = settings.DB_POOL_RECYCLE
+
+# pool_pre_ping is supported by all backends (including SQLite)
+engine_kwargs["pool_pre_ping"] = settings.DB_POOL_PRE_PING
+
+engine = create_engine(DATABASE_URL, **engine_kwargs)
 
 # Set up database query monitoring
 try:


### PR DESCRIPTION
## Summary
- Add `DB_POOL_SIZE`, `DB_MAX_OVERFLOW`, `DB_POOL_RECYCLE`, and `DB_POOL_PRE_PING` settings to the `Settings` class with sensible defaults
- Update `database.py` engine creation to branch on SQLite vs non-SQLite backends: SQLite keeps `check_same_thread=False` with `pool_pre_ping` only; non-SQLite backends get full pool tuning (`pool_size`, `max_overflow`, `pool_recycle`, `pool_pre_ping`)
- Add field validators for the new pool settings with reasonable bounds
- Update `.env.example` with commented-out defaults for discoverability

## Test plan
- [x] All 1457 unit tests pass (no regressions)
- [x] Ruff lint and format checks pass
- [x] MyPy type checking passes
- [x] Pre-commit and pre-push hooks pass
- [ ] Verify `pool_pre_ping=True` enables connection liveness checks in dev environment
- [ ] Verify non-SQLite backends (PostgreSQL) receive full pool configuration when `DATABASE_URL` is changed

Resolves #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)