### PR TITLE
perf: add HTTP Cache-Control headers to read-only list endpoints (Resolves #364)

### DIFF
--- a/app/files/router.py
+++ b/app/files/router.py
@@ -10,6 +10,7 @@ from fastapi import (
     HTTPException,
     Query,
     Request,
+    Response,
     UploadFile,
 )
 from fastapi.responses import FileResponse
@@ -89,6 +90,7 @@ def _safe_audit(
     "/servers/{server_id}/files/{file_path:path}/read", response_model=FileReadResponse
 )
 async def read_file(
+    response: Response,
     server_id: int,
     file_path: str,
     encoding: str = "utf-8",
@@ -98,6 +100,7 @@ async def read_file(
     auth: AuthorizationService = Depends(get_authorization_service),
 ):
     """Read content of a text file or image"""
+    response.headers["Cache-Control"] = "private, max-age=30"
     # Check server access
     await auth.check_server_access(server_id, current_user)
 
@@ -591,6 +594,7 @@ async def get_server_file_history_stats(
 @router.get("/servers/{server_id}/files", response_model=FileListResponse)
 @router.get("/servers/{server_id}/files/{path:path}", response_model=FileListResponse)
 async def list_server_files(
+    response: Response,
     server_id: int,
     path: str = "",
     file_type: Optional[FileType] = None,
@@ -607,6 +611,7 @@ async def list_server_files(
     file exception has a structured handler that emits the standard
     error envelope.
     """
+    response.headers["Cache-Control"] = "private, max-age=30"
     # Check server access
     await auth.check_server_access(server_id, current_user)
 

--- a/app/groups/router.py
+++ b/app/groups/router.py
@@ -9,7 +9,7 @@ application layer never imports FastAPI.
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
 from app.auth.dependencies import get_current_user
 from app.groups.api.dependencies import get_group_service
@@ -101,6 +101,7 @@ async def create_group(
 
 @router.get("", response_model=GroupListResponse)
 async def list_groups(
+    response: Response,
     group_type: Optional[GroupType] = Query(None, description="Filter by group type"),
     page: int = Query(1, ge=1, description="Page number"),
     size: int = Query(50, ge=1, le=100, description="Page size"),
@@ -113,6 +114,7 @@ async def list_groups(
     ``total`` reflects the full filtered count so legacy clients keep
     working.
     """
+    response.headers["Cache-Control"] = "private, max-age=60"
     try:
         from app.core.pagination import build_pagination_meta
 
@@ -138,11 +140,13 @@ async def list_groups(
 
 @router.get("/{group_id}", response_model=GroupResponse)
 async def get_group(
+    response: Response,
     group_id: int,
     current_user: User = Depends(get_current_user),
     group_service: _ApplicationGroupService = Depends(get_group_service),
 ):
     """Get group details by id."""
+    response.headers["Cache-Control"] = "private, max-age=60"
     try:
         entity = await group_service.get_group(
             actor_id=current_user.id, group_id=group_id

--- a/app/servers/routers/management.py
+++ b/app/servers/routers/management.py
@@ -7,6 +7,7 @@ from fastapi import (
     HTTPException,
     Path,
     Query,
+    Response,
     status,
 )
 from sqlalchemy.orm import Session
@@ -209,6 +210,7 @@ async def check_port(
 
 @router.get("", response_model=ServerListResponse)
 async def list_servers(
+    response: Response,
     page: int = Query(1, ge=1, description="Page number"),
     size: int = Query(50, ge=1, le=100, description="Page size"),
     current_user: User = Depends(get_current_user),
@@ -220,6 +222,7 @@ async def list_servers(
 
     Returns a paginated list of all servers. All authenticated users can see all servers.
     """
+    response.headers["Cache-Control"] = "private, max-age=10"
     try:
         # All users can see all servers
         owner_id = None

--- a/app/versions/api/router.py
+++ b/app/versions/api/router.py
@@ -7,7 +7,7 @@ shape for the entire codebase per `docs/ARCHITECTURE.md` §4.4.
 
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
 from app.auth.dependencies import get_current_user
 from app.servers.models import ServerType
@@ -58,9 +58,11 @@ def _to_response(entity: MinecraftVersionEntity) -> MinecraftVersionResponse:
     summary="Get all supported versions (fast database query)",
 )
 async def get_supported_versions(
+    response: Response,
     server_type: Optional[ServerType] = Query(None, description="Filter by server type"),
     service: VersionUpdateService = Depends(get_version_service),
 ) -> List[MinecraftVersionResponse]:
+    response.headers["Cache-Control"] = "public, max-age=3600"
     try:
         if server_type:
             entities = await service.get_supported_versions(server_type)
@@ -150,8 +152,10 @@ async def get_scheduler_status(
     summary="Get version statistics",
 )
 async def get_version_stats(
+    response: Response,
     service: VersionUpdateService = Depends(get_version_service),
 ) -> VersionStatsResponse:
+    response.headers["Cache-Control"] = "public, max-age=300"
     try:
         stats = await service.get_version_stats()
         return VersionStatsResponse(
@@ -172,9 +176,11 @@ async def get_version_stats(
     summary="Get versions for specific server type",
 )
 async def get_versions_by_server_type(
+    response: Response,
     server_type: ServerType,
     service: VersionUpdateService = Depends(get_version_service),
 ) -> List[MinecraftVersionResponse]:
+    response.headers["Cache-Control"] = "public, max-age=3600"
     try:
         entities = await service.get_supported_versions(server_type)
         return [_to_response(e) for e in entities]
@@ -191,10 +197,12 @@ async def get_versions_by_server_type(
     summary="Get specific version details",
 )
 async def get_specific_version(
+    response: Response,
     server_type: ServerType,
     version: str,
     service: VersionUpdateService = Depends(get_version_service),
 ) -> MinecraftVersionResponse:
+    response.headers["Cache-Control"] = "public, max-age=3600"
     try:
         entity = await service.get_version(server_type, version)
         if entity is None:

--- a/tests/unit/servers/routers/test_management.py
+++ b/tests/unit/servers/routers/test_management.py
@@ -12,7 +12,7 @@ patched on the class rather than on a mock instance.
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from fastapi import BackgroundTasks, HTTPException
+from fastapi import BackgroundTasks, HTTPException, Response
 
 from app.servers.application.authorization import AuthorizationService
 from app.servers.models import ServerType
@@ -97,6 +97,7 @@ class TestServerManagementRouter:
 
         with pytest.raises(HTTPException) as exc_info:
             await list_servers(
+                response=Response(),
                 page=1,
                 size=10,
                 current_user=admin_user,
@@ -169,6 +170,7 @@ class TestServerManagementRouter:
 
         # Test admin access (should see all servers - owner_id=None)
         await list_servers(
+            response=Response(),
             page=1,
             size=10,
             current_user=admin_user,
@@ -186,6 +188,7 @@ class TestServerManagementRouter:
 
         # Test regular user access (should also see all servers - owner_id=None)
         await list_servers(
+            response=Response(),
             page=1,
             size=10,
             current_user=test_user,


### PR DESCRIPTION
## Summary
- 9つの読み取り専用GETエンドポイントに Cache-Control ヘッダーを追加
- レスポンスボディは一切変更なし（純粋にヘッダー追加のみ）

## Cache-Control 設定

| エンドポイント | Cache-Control | 根拠 |
|---|---|---|
| `/versions/supported`, `/versions/{type}`, `/versions/{type}/{ver}` | `public, max-age=3600` | バージョンデータは6h TTLキャッシュ |
| `/versions/stats` | `public, max-age=300` | 統計は5分で十分 |
| `/groups`, `/groups/{id}` | `private, max-age=60` | ユーザー固有データ |
| `/servers` | `private, max-age=10` | リアルタイム性が重要 |
| `/files/read`, `/files/list` | `private, max-age=30` | 編集中はWSで通知 |

## Test plan
- [x] unit smoke 1457 passed
- [x] pre-commit/pre-push hooks 通過
- [x] テスト修正: `response=Response()` パラメータ追加のみ

Resolves #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)