### PR TITLE
perf: remove unused memory_start + add TTL cache to MemoryTracker (Resolves #359)

### DIFF
--- a/app/middleware/performance_monitoring.py
+++ b/app/middleware/performance_monitoring.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 # Context variables for tracking metrics per request
 request_start_time: ContextVar[float] = ContextVar("request_start_time")
 database_queries: ContextVar[List[Dict]] = ContextVar("database_queries", default=[])
-memory_usage_start: ContextVar[float] = ContextVar("memory_usage_start")
 
 
 class DatabaseQueryTracker:
@@ -52,25 +51,41 @@ class DatabaseQueryTracker:
 
 
 class MemoryTracker:
-    """Helper class to track memory usage"""
+    """Helper class to track memory usage with interval-based caching."""
 
-    @staticmethod
-    def get_memory_usage() -> Dict:
-        """Get current memory usage information"""
+    _cache: Dict = {}
+    _cache_time: float = 0.0
+    _cache_ttl: float = 5.0  # seconds
+
+    @classmethod
+    def get_memory_usage(cls) -> Dict:
+        """Get current memory usage, cached for up to 5 seconds."""
+        now = time.time()
+        if now - cls._cache_time < cls._cache_ttl and cls._cache:
+            return cls._cache
         try:
             process = psutil.Process()
             memory_info = process.memory_info()
             memory_percent = process.memory_percent()
-
-            return {
-                "rss_mb": round(memory_info.rss / 1024 / 1024, 2),  # Resident set size
-                "vms_mb": round(memory_info.vms / 1024 / 1024, 2),  # Virtual memory size
+            cls._cache = {
+                "rss_mb": round(memory_info.rss / 1024 / 1024, 2),
+                "vms_mb": round(memory_info.vms / 1024 / 1024, 2),
                 "percent": round(memory_percent, 2),
-                "available_mb": round(psutil.virtual_memory().available / 1024 / 1024, 2),
+                "available_mb": round(
+                    psutil.virtual_memory().available / 1024 / 1024,
+                    2,
+                ),
             }
+            cls._cache_time = now
+            return cls._cache
         except Exception as e:
             logger.warning(f"Failed to get memory usage: {e}")
-            return {"rss_mb": 0, "vms_mb": 0, "percent": 0, "available_mb": 0}
+            return {
+                "rss_mb": 0,
+                "vms_mb": 0,
+                "percent": 0,
+                "available_mb": 0,
+            }
 
 
 class PerformanceMetrics:
@@ -225,9 +240,6 @@ class PerformanceMonitoringMiddleware(BaseHTTPMiddleware):
 
         db_tracker = DatabaseQueryTracker()
         database_queries.set([])
-
-        memory_start = MemoryTracker.get_memory_usage()
-        memory_usage_start.set(memory_start.get("percent", 0))
 
         # Process the request
         try:

--- a/tests/infrastructure/core/test_performance_monitoring.py
+++ b/tests/infrastructure/core/test_performance_monitoring.py
@@ -59,6 +59,15 @@ class TestDatabaseQueryTracker:
 
 
 class TestMemoryTracker:
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self):
+        """Reset MemoryTracker cache before each test."""
+        MemoryTracker._cache = {}
+        MemoryTracker._cache_time = 0.0
+        yield
+        MemoryTracker._cache = {}
+        MemoryTracker._cache_time = 0.0
+
     def test_get_memory_usage(self):
         """Test memory usage tracking"""
         memory_info = MemoryTracker.get_memory_usage()
@@ -74,6 +83,22 @@ class TestMemoryTracker:
         assert memory_info["vms_mb"] >= 0
         assert 0 <= memory_info["percent"] <= 100
         assert memory_info["available_mb"] >= 0
+
+    def test_cache_returns_same_result_within_ttl(self):
+        """Test that repeated calls within TTL return cached result."""
+        first = MemoryTracker.get_memory_usage()
+        second = MemoryTracker.get_memory_usage()
+        # Within 5 s the exact same dict object should be returned
+        assert first is second
+
+    def test_cache_expires_after_ttl(self):
+        """Test that the cache refreshes after TTL expires."""
+        first = MemoryTracker.get_memory_usage()
+        # Manually expire the cache
+        MemoryTracker._cache_time -= MemoryTracker._cache_ttl + 1
+        second = MemoryTracker.get_memory_usage()
+        # New dict object, though values may be similar
+        assert first is not second
 
 
 class TestPerformanceMetrics:


### PR DESCRIPTION
## Summary
- per-request の psutil 呼び出しを最適化: 2回/request → 最大 1回/5秒
- 未使用の `memory_start` 呼び出しを完全除去（取得後にdelta計算なし）
- `MemoryTracker` に5秒TTLキャッシュを追加

## Changes
- `app/middleware/performance_monitoring.py`:
  - `memory_usage_start` ContextVar を削除（未使用）
  - dispatch() から `memory_start = MemoryTracker.get_memory_usage()` を除去
  - `MemoryTracker` を `@staticmethod` → `@classmethod` + クラスレベルキャッシュに変更
- `tests/infrastructure/core/test_performance_monitoring.py`:
  - `_reset_cache` autouse fixture 追加
  - キャッシュヒット/期限切れテスト追加

## Test plan
- [x] 全15件の performance monitoring テスト通過
- [x] pre-commit/pre-push hooks 通過
- [x] キャッシュ動作: `first is second` (同一オブジェクト) でヒット確認

Resolves #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)