### PR TITLE
fix: avoid importlib.reload(app.core.config) in concurrency tests

### DIFF
--- a/tests/unit/core/test_concurrency.py
+++ b/tests/unit/core/test_concurrency.py
@@ -95,11 +95,13 @@ class TestSemaphoreRegistry:
         monkeypatch.setenv("MAX_CONCURRENT_WEBSOCKETS", "50")
         monkeypatch.setenv("FILE_IO_SEMAPHORE_LIMIT", "8")
 
-        import importlib
+        # Rebuild the module-level `settings` from the patched env without
+        # reloading the module — `importlib.reload(app.core.config)` would
+        # replace the `Settings` class object too, breaking `isinstance`
+        # checks in tests that imported the original class.
+        from app.core import config as config_module
 
-        import app.core.config
-
-        importlib.reload(app.core.config)
+        monkeypatch.setattr(config_module, "settings", config_module.Settings())
 
         registry = SemaphoreRegistry()
         registry.initialize()
@@ -116,11 +118,9 @@ class TestSemaphoreRegistry:
         monkeypatch.setenv("SECRET_KEY", "a" * 32)
         monkeypatch.setenv("DATABASE_URL", "sqlite:///./test.db")
 
-        import importlib
+        from app.core import config as config_module
 
-        import app.core.config
-
-        importlib.reload(app.core.config)
+        monkeypatch.setattr(config_module, "settings", config_module.Settings())
 
         registry = SemaphoreRegistry()
         registry.initialize()


### PR DESCRIPTION
## Summary
- Fixes CI failure on master (`tests/unit/core/test_config.py::TestSettingsGlobalInstance::test_global_settings_exists`) caused by test pollution from `tests/unit/core/test_concurrency.py`.
- `importlib.reload(app.core.config)` replaced the `Settings` class object on the module; other test modules that bound `Settings` at import time then failed `isinstance(settings, Settings)`.
- Swap the reload for `monkeypatch.setattr(config_module, "settings", config_module.Settings())`, which rebuilds the module-level instance from the patched env without changing the class identity.

Resolves #384.

## Repro (before fix)
```
uv run pytest tests/unit/core/test_concurrency.py tests/unit/core/test_config.py -n 0
```

The order matters: when `test_concurrency.py` runs first on a worker, the reload happens and the later `test_config.py` assertion fails. CI hit this on the master run [#26450072259](https://github.com/mmiura-2351/mc-server-dashboard-api/actions/runs/26450072259).

## Test plan
- [x] `uv run pytest tests/unit/core/test_concurrency.py tests/unit/core/test_config.py -n 0` — passes
- [x] `just test` — 2137 passed, 10 skipped locally
- [x] `uv run ruff check tests/unit/core/test_concurrency.py` — clean
- [x] `uv run ruff format tests/unit/core/test_concurrency.py --check` — clean
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)