### PR TITLE
chore(deps): bump starlette floor to latest patch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pydantic-settings>=2.9.1,<3.0.0",
     "python-jose>=3.5.0,<4.0.0",
     "SQLAlchemy>=2.0.41,<3.0.0",
-    "starlette>=0.47.2,<1.1.0",
+    "starlette>=0.47.3,<1.1.0",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.13"
 
 [options]
-exclude-newer = "2026-05-16T11:14:20.711728425Z"
+exclude-newer = "2026-05-19T18:27:17.041452206Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -635,7 +635,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.9.1,<3.0.0" },
     { name = "python-jose", specifier = ">=3.5.0,<4.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.41,<3.0.0" },
-    { name = "starlette", specifier = ">=0.47.2,<1.1.0" },
+    { name = "starlette", specifier = ">=0.47.3,<1.1.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1211,14 +1211,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.47.2"
+version = "0.47.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/57/d062573f391d062710d4088fa1369428c38d51460ab6fedff920efef932e/starlette-0.47.2.tar.gz", hash = "sha256:6ae9aa5db235e4846decc1e7b79c4f346adf41e9777aebeb49dfd09bbd7023d8", size = 2583948, upload-time = "2025-07-20T17:31:58.522Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/b9/cc3017f9a9c9b6e27c5106cc10cc7904653c3eec0729793aec10479dd669/starlette-0.47.3.tar.gz", hash = "sha256:6bc94f839cc176c4858894f1f8908f0ab79dfec1a6b8402f6da9be26ebea52e9", size = 2584144, upload-time = "2025-08-24T13:36:42.122Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/1f/b876b1f83aef204198a42dc101613fefccb32258e5428b5f9259677864b4/starlette-0.47.2-py3-none-any.whl", hash = "sha256:c5847e96134e5c5371ee9fac6fdf1a67336d5815e09eb2a01fdb57a351ef915b", size = 72984, upload-time = "2025-07-20T17:31:56.738Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fd/901cfa59aaa5b30a99e16876f11abe38b59a1a2c51ffb3d7142bb6089069/starlette-0.47.3-py3-none-any.whl", hash = "sha256:89c0778ca62a76b826101e7c709e70680a1699ca7da6b44d38eb0a7e61fe4b51", size = 72991, upload-time = "2025-08-24T13:36:40.887Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps `starlette` floor in `pyproject.toml` from `>=0.47.2` to `>=0.47.3` — the latest version available within the 7-day `tool.uv.exclude-newer` supply-chain cooldown window. No `0.48.x` release was eligible at this time.

**Version change:** `0.47.2` -> `0.47.3` (patch bump)

## Files changed

- `pyproject.toml` — floor `>=0.47.2` -> `>=0.47.3`
- `uv.lock` — regenerated via `uv lock --upgrade-package starlette`

No code or behavior changes. Existing middleware (audit, performance monitoring) continues to work against the `BaseHTTPMiddleware` API.

## Why not a minor bump?

The task spec preferred a minor bump to `0.48.x` if available, but `uv lock --upgrade-package starlette --dry-run` resolved only to `0.47.3` under the active `exclude-newer = "7 days"` cooldown. We bump the floor to `0.47.3` to ratchet the freshness floor without touching the ceiling (`<1.1.0`); a follow-up PR can pick up `0.48.x` once it ages into cooldown.

## Test plan

- [x] `just lint` -> All checks passed
- [x] `uv run pytest tests/unit -m "not slow"` -> 1477 passed, 5 skipped
- [x] `uv run pytest tests/unit tests/integration -m "not slow"` -> 2013 passed, 10 skipped
- [ ] `just test` (full suite incl. slow) -> not run locally; no JRE on PATH (see CLAUDE.md Rule 6 op-note 5). Will rely on CI.
- [x] `filterwarnings = ["error::DeprecationWarning", ...]` safety net: no new deprecation errors observed

## Notes

Part of #164 (B-4 major-version re-validation series, PR-1/4). Refs #164.

Do not auto-close #164 on merge — there are 3 follow-up PRs (FastAPI / SQLAlchemy / Pydantic) in the same series.