### PR TITLE
refactor(audit): migrate auth/users/files callsites to AuditWriter DI

### DIFF
--- a/app/audit/api/dependencies.py
+++ b/app/audit/api/dependencies.py
@@ -1,11 +1,13 @@
 """FastAPI dependencies wiring the audit Ports to their adapters."""
 
-from fastapi import Depends
+from fastapi import Depends, Request
 from sqlalchemy.orm import Session
 
-from app.audit.adapters.repository import SqlAlchemyAuditRepository
+from app.audit.adapters.repository import SqlAlchemyAuditRepository, SqlAlchemyAuditWriter
 from app.audit.application.query_service import AuditQueryService
+from app.audit.domain.ports import AuditWriter
 from app.core.database import get_db
+from app.middleware.audit_middleware import get_audit_tracker
 from app.users.adapters.read_port import SqlAlchemyUserReadPort
 from app.users.domain.ports import UserReadPort
 
@@ -23,3 +25,17 @@ def get_user_read_port(db: Session = Depends(get_db)) -> UserReadPort:
     user exists without taking a dependency on the users ORM model.
     """
     return SqlAlchemyUserReadPort(db)
+
+
+def get_audit_writer(request: Request) -> AuditWriter:
+    """Return an `AuditWriter` bound to the request-scoped audit tracker.
+
+    Tracker-mode wins when present (typical FastAPI flow). Falls back
+    to the direct-write path otherwise. See `SqlAlchemyAuditWriter` for
+    the transaction-isolation rationale.
+
+    Shared cross-domain factory used by the auth/users/files routers
+    (#386) — mirrors the groups-domain factory in
+    `app.groups.api.dependencies.get_audit_writer`.
+    """
+    return SqlAlchemyAuditWriter(tracker=get_audit_tracker(request))

--- a/app/auth/api/router.py
+++ b/app/auth/api/router.py
@@ -12,7 +12,10 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel
 
-from app.audit.service import AuditService
+from app.audit.api.dependencies import get_audit_writer
+from app.audit.application.legacy_facade import _extract_ip_address
+from app.audit.domain.entities import AuditEventCommand
+from app.audit.domain.ports import AuditWriter
 from app.auth.api.dependencies import get_auth_service, get_brute_force_service
 from app.auth.application.brute_force_service import BruteForceService, LockoutStatus
 from app.auth.application.service import AuthService
@@ -24,6 +27,77 @@ from app.users.application.password_policy import get_password_policy
 from app.users.application.service import UserService
 
 router = APIRouter()
+
+
+def _record_authentication_event(
+    audit: AuditWriter,
+    request: Request,
+    *,
+    action: str,
+    user_id: Optional[int] = None,
+    details: Optional[dict] = None,
+    success: bool = True,
+) -> None:
+    """Mirror :class:`AuditService.log_authentication_event` byte-identically.
+
+    Preserves the action-string format
+    ``f"auth_{action}_{'success' if success else 'failure'}"``, the
+    ``user_agent``/``success`` details prefix, ``resource_type``, and
+    the IP-extraction helper used by the legacy facade.
+    """
+    audit_details = {
+        "user_agent": request.headers.get("User-Agent", "Unknown"),
+        "success": success,
+        **(details or {}),
+    }
+    audit.record(
+        AuditEventCommand(
+            action=f"auth_{action}_{'success' if success else 'failure'}",
+            resource_type="authentication",
+            user_id=user_id,
+            details=audit_details,
+            ip_address=_extract_ip_address(request),
+        )
+    )
+
+
+def _record_security_event(
+    audit: AuditWriter,
+    request: Request,
+    *,
+    event_type: str,
+    severity: str,
+    details: Optional[dict] = None,
+    user_id: Optional[int] = None,
+) -> None:
+    """Mirror :class:`AuditService.log_security_event` byte-identically.
+
+    Preserves the ``f"security_{event_type}"`` action, the
+    ``resource_type="security"`` field, and the standard details
+    payload (``event_type``, ``severity``, ``request_path``,
+    ``user_agent``). Falls back to the request-scoped
+    ``user_id_context`` (via ``get_current_user_id``) when ``user_id``
+    is not supplied, matching the legacy facade.
+    """
+    from app.middleware.audit_middleware import get_current_user_id
+
+    effective_user_id = user_id if user_id is not None else get_current_user_id()
+    audit_details = {
+        "event_type": event_type,
+        "severity": severity,
+        "request_path": str(request.url.path),
+        "user_agent": request.headers.get("User-Agent", "Unknown"),
+        **(details or {}),
+    }
+    audit.record(
+        AuditEventCommand(
+            action=f"security_{event_type}",
+            resource_type="security",
+            user_id=effective_user_id,
+            details=audit_details,
+            ip_address=_extract_ip_address(request),
+        )
+    )
 
 
 class RefreshTokenRequest(BaseModel):
@@ -130,6 +204,7 @@ async def login(
     user_service: UserService = Depends(get_user_service),
     auth_service: AuthService = Depends(get_auth_service),
     brute_force: BruteForceService = Depends(get_brute_force_service),
+    audit: AuditWriter = Depends(get_audit_writer),
 ):
     ip_address = _extract_ip(request)
     user_agent = request.headers.get("User-Agent")
@@ -139,8 +214,9 @@ async def login(
     lockout = await brute_force.check_lockout(username, ip_address)
     if lockout.locked:
         await _artificial_delay()
-        AuditService.log_authentication_event(
-            request=request,
+        _record_authentication_event(
+            audit,
+            request,
             action="login",
             details={
                 "username": username,
@@ -174,9 +250,10 @@ async def login(
             )
             db.commit()
             await _artificial_delay()
-            _audit_lockout_trigger(request, username, triggered)
-            AuditService.log_authentication_event(
-                request=request,
+            _audit_lockout_trigger(audit, request, username, triggered)
+            _record_authentication_event(
+                audit,
+                request,
                 action="login",
                 details={
                     "username": username,
@@ -206,8 +283,9 @@ async def login(
         if warning:
             response.headers["X-Password-Policy-Warning"] = warning
 
-        AuditService.log_authentication_event(
-            request=request,
+        _record_authentication_event(
+            audit,
+            request,
             action="login",
             user_id=user_entity.id,
             details={
@@ -236,9 +314,10 @@ async def login(
                 failure_reason="authentication_error",
             )
             db.commit()
-            _audit_lockout_trigger(request, username, triggered)
-            AuditService.log_authentication_event(
-                request=request,
+            _audit_lockout_trigger(audit, request, username, triggered)
+            _record_authentication_event(
+                audit,
+                request,
                 action="login",
                 details={
                     "username": username,
@@ -251,6 +330,7 @@ async def login(
 
 
 def _audit_lockout_trigger(
+    audit: AuditWriter,
     request: Request,
     username: str,
     triggered: Optional[LockoutStatus],
@@ -258,8 +338,9 @@ def _audit_lockout_trigger(
     if triggered is None:
         return
     if triggered.reason == "account_locked":
-        AuditService.log_security_event(
-            request=request,
+        _record_security_event(
+            audit,
+            request,
             event_type="account_locked",
             severity="warning",
             details={
@@ -268,8 +349,9 @@ def _audit_lockout_trigger(
             },
         )
     elif triggered.reason == "ip_locked":
-        AuditService.log_security_event(
-            request=request,
+        _record_security_event(
+            audit,
+            request,
             event_type="brute_force_ip_blocked",
             severity="warning",
             details={
@@ -285,11 +367,13 @@ async def refresh_access_token(
     request: Request,
     user_service: UserService = Depends(get_user_service),
     auth_service: AuthService = Depends(get_auth_service),
+    audit: AuditWriter = Depends(get_audit_writer),
 ):
     user_id = await auth_service.verify_refresh_token(token_request.refresh_token)
     if not user_id:
-        AuditService.log_authentication_event(
-            request=request,
+        _record_authentication_event(
+            audit,
+            request,
             action="token_refresh",
             details={"reason": "invalid_refresh_token"},
             success=False,
@@ -301,8 +385,9 @@ async def refresh_access_token(
 
     user = await user_service.get_user_by_id(user_id)
     if user is None or not user.is_active:
-        AuditService.log_authentication_event(
-            request=request,
+        _record_authentication_event(
+            audit,
+            request,
             action="token_refresh",
             user_id=user_id,
             details={"reason": "user_inactive_or_not_found"},
@@ -318,8 +403,9 @@ async def refresh_access_token(
     )
     new_refresh_token = await auth_service.create_refresh_token(user.id)
 
-    AuditService.log_authentication_event(
-        request=request,
+    _record_authentication_event(
+        audit,
+        request,
         action="token_refresh",
         user_id=user.id,
         details={"username": user.username},
@@ -335,12 +421,14 @@ async def logout(
     db: DatabaseSession,
     request: Request,
     auth_service: AuthService = Depends(get_auth_service),
+    audit: AuditWriter = Depends(get_audit_writer),
 ):
     user_id = await auth_service.verify_refresh_token(token_request.refresh_token)
     success = await auth_service.revoke_refresh_token(token_request.refresh_token)
     if not success:
-        AuditService.log_authentication_event(
-            request=request,
+        _record_authentication_event(
+            audit,
+            request,
             action="logout",
             user_id=user_id,
             details={"reason": "invalid_refresh_token"},
@@ -350,8 +438,9 @@ async def logout(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid refresh token"
         )
 
-    AuditService.log_authentication_event(
-        request=request,
+    _record_authentication_event(
+        audit,
+        request,
         action="logout",
         user_id=user_id,
         details={"logout_method": "refresh_token_revocation"},

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -22,6 +22,9 @@ from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.orm import Session
 
+from app.audit.api.dependencies import get_audit_writer
+from app.audit.domain.entities import AuditEventCommand
+from app.audit.domain.ports import AuditWriter
 from app.auth.auth import decode_token
 from app.core.database import get_db
 from app.users import models
@@ -40,6 +43,7 @@ _CREDENTIALS_EXCEPTION = HTTPException(
 
 def _emit_token_revoked_audit(
     *,
+    audit: Optional[AuditWriter],
     request: Optional[Request],
     user: models.User,
     presented_tv: int,
@@ -50,25 +54,35 @@ def _emit_token_revoked_audit(
     (which do not have a ``Request``) silently skip the emit. We also
     swallow any unexpected exception — failing the request because the
     audit sink hiccupped would be worse than the missing log entry.
+
+    Action string, ``resource_type``, ``details`` shape, and IP
+    extraction match the legacy ``AuditService.log_security_event``
+    facade byte-identically (Issue #386 migration).
     """
-    if request is None:
+    if request is None or audit is None:
         return
     try:
-        # Local import to avoid a circular dependency:
-        # `app.audit.application.legacy_facade` imports from
-        # `app.users.adapters` which transitively pulls auth helpers.
-        from app.audit.service import AuditService
+        # Local import to avoid a circular dependency: the legacy
+        # facade transitively pulls auth helpers via its writer wiring.
+        from app.audit.application.legacy_facade import _extract_ip_address
 
-        AuditService.log_security_event(
-            request=request,
-            event_type="token_revoked_post_deactivation",
-            severity="warning",
-            user_id=user.id,
-            details={
-                "username": user.username,
-                "presented_token_version": presented_tv,
-                "current_token_version": user.token_version,
-            },
+        audit_details = {
+            "event_type": "token_revoked_post_deactivation",
+            "severity": "warning",
+            "request_path": str(request.url.path),
+            "user_agent": request.headers.get("User-Agent", "Unknown"),
+            "username": user.username,
+            "presented_token_version": presented_tv,
+            "current_token_version": user.token_version,
+        }
+        audit.record(
+            AuditEventCommand(
+                action="security_token_revoked_post_deactivation",
+                resource_type="security",
+                user_id=user.id,
+                details=audit_details,
+                ip_address=_extract_ip_address(request),
+            )
         )
     except Exception:  # pragma: no cover - audit must never break auth
         logger.exception("Failed to emit token_revoked audit event")
@@ -79,6 +93,7 @@ def _authenticate(
     db: Session,
     *,
     request: Optional[Request] = None,
+    audit: Optional[AuditWriter] = None,
 ) -> models.User:
     """Resolve *token* to a live, non-revoked ``User`` row.
 
@@ -123,7 +138,9 @@ def _authenticate(
 
     current_tv = user.token_version or 0
     if presented_tv != current_tv:
-        _emit_token_revoked_audit(request=request, user=user, presented_tv=presented_tv)
+        _emit_token_revoked_audit(
+            audit=audit, request=request, user=user, presented_tv=presented_tv
+        )
         raise _CREDENTIALS_EXCEPTION
 
     return user
@@ -133,9 +150,10 @@ def get_current_user(
     request: Request,
     token: Annotated[str, Depends(oauth2_scheme)],
     db: Annotated[Session, Depends(get_db)],
+    audit: Annotated[AuditWriter, Depends(get_audit_writer)],
 ) -> models.User:
     """HTTP dependency: resolve the bearer token to a live ``User``."""
-    return _authenticate(token, db, request=request)
+    return _authenticate(token, db, request=request, audit=audit)
 
 
 async def get_current_user_ws(token: str, db: Session) -> models.User:
@@ -146,4 +164,4 @@ async def get_current_user_ws(token: str, db: Session) -> models.User:
     skipped — matching the legacy behaviour of this code path which
     has never written to the audit log.
     """
-    return _authenticate(token, db, request=None)
+    return _authenticate(token, db, request=None, audit=None)

--- a/app/files/router.py
+++ b/app/files/router.py
@@ -16,7 +16,10 @@ from fastapi import (
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
-from app.audit.application.legacy_facade import AuditService
+from app.audit.api.dependencies import get_audit_writer
+from app.audit.application.legacy_facade import _extract_ip_address
+from app.audit.domain.entities import AuditEventCommand
+from app.audit.domain.ports import AuditWriter
 from app.auth.dependencies import get_current_user
 from app.core.database import get_db
 from app.files.api.dependencies import get_file_history_service
@@ -60,26 +63,44 @@ def _duration_ms(start: float) -> int:
 
 
 def _safe_audit(
+    audit: AuditWriter,
     request: Request,
     action: str,
     server_id: int,
     file_path: str,
     details: Optional[Dict[str, Any]] = None,
 ) -> None:
-    """Wrap :class:`AuditService.log_file_event` so a logging failure
-    can never mask the underlying business outcome (Issue #36 Phase 1).
+    """Emit a file-domain audit event so a logging failure can never
+    mask the underlying business outcome (Issue #36 Phase 1).
+
+    Mirrors the legacy ``AuditService.log_file_event`` facade
+    byte-identically (Issue #386): the ``f"file_{action}"`` action
+    string, ``resource_type="file"``, ``resource_id=server_id``, and
+    the standard ``server_id`` / ``file_path`` / ``file_name`` details
+    prefix are all preserved.
 
     Audit emission goes through the request-scoped tracker which is
     flushed by the middleware; raising here would convert a successful
     write into a 500.
     """
     try:
-        AuditService.log_file_event(
-            request=request,
-            action=action,
-            server_id=server_id,
-            file_path=file_path,
-            details=details or {},
+        from app.middleware.audit_middleware import get_current_user_id
+
+        audit_details = {
+            "server_id": server_id,
+            "file_path": file_path,
+            "file_name": file_path.split("/")[-1] if "/" in file_path else file_path,
+            **(details or {}),
+        }
+        audit.record(
+            AuditEventCommand(
+                action=f"file_{action}",
+                resource_type="file",
+                resource_id=server_id,
+                user_id=get_current_user_id(),
+                details=audit_details,
+                ip_address=_extract_ip_address(request),
+            )
         )
     except Exception:  # pragma: no cover - defensive
         logger.exception("audit_log_failed", extra={"action": action})
@@ -186,6 +207,7 @@ async def upload_file(
     extract_if_archive: bool = Form(False),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
+    audit: AuditWriter = Depends(get_audit_writer),
 ):
     """Upload a file to server directory"""
     if not AuthorizationService.can_modify_files(current_user):
@@ -208,6 +230,7 @@ async def upload_file(
         )
     except Exception as exc:
         _safe_audit(
+            audit,
             request,
             "upload_failure",
             server_id,
@@ -221,6 +244,7 @@ async def upload_file(
         raise
 
     _safe_audit(
+        audit,
         request,
         "upload",
         server_id,
@@ -311,6 +335,7 @@ async def create_directory(
     request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
+    audit: AuditWriter = Depends(get_audit_writer),
 ):
     """Create a new directory in server"""
     if not AuthorizationService.can_modify_files(current_user):
@@ -327,6 +352,7 @@ async def create_directory(
         )
     except Exception as exc:
         _safe_audit(
+            audit,
             request,
             "create_directory_failure",
             server_id,
@@ -339,6 +365,7 @@ async def create_directory(
         raise
 
     _safe_audit(
+        audit,
         request,
         "create_directory",
         server_id,
@@ -442,6 +469,7 @@ async def restore_from_version(
     db: Session = Depends(get_db),
     file_history_service: FileHistoryService = Depends(get_file_history_service),
     auth: AuthorizationService = Depends(get_authorization_service),
+    audit: AuditWriter = Depends(get_audit_writer),
 ):
     """Restore file from specific version"""
     # Check permissions (Phase 1: all users can restore files)
@@ -464,6 +492,7 @@ async def restore_from_version(
         )
     except Exception as exc:
         _safe_audit(
+            audit,
             request,
             "restore_version_failure",
             server_id,
@@ -483,6 +512,7 @@ async def restore_from_version(
     file_info = FileInfoResponse(**files[0]) if files else None
 
     _safe_audit(
+        audit,
         request,
         "restore_version",
         server_id,
@@ -515,6 +545,7 @@ async def delete_file_version(
     db: Session = Depends(get_db),
     file_history_service: FileHistoryService = Depends(get_file_history_service),
     auth: AuthorizationService = Depends(get_authorization_service),
+    audit: AuditWriter = Depends(get_audit_writer),
 ):
     """Delete specific version (admin only)"""
     # Check admin permissions
@@ -532,6 +563,7 @@ async def delete_file_version(
         )
     except Exception as exc:
         _safe_audit(
+            audit,
             request,
             "delete_version_failure",
             server_id,
@@ -545,6 +577,7 @@ async def delete_file_version(
         raise
 
     _safe_audit(
+        audit,
         request,
         "delete_version",
         server_id,
@@ -646,6 +679,7 @@ async def write_file(
     request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
+    audit: AuditWriter = Depends(get_audit_writer),
 ):
     """Write content to a file"""
     if not AuthorizationService.can_modify_files(current_user):
@@ -665,6 +699,7 @@ async def write_file(
         )
     except Exception as exc:
         _safe_audit(
+            audit,
             request,
             "write_failure",
             server_id,
@@ -679,6 +714,7 @@ async def write_file(
         raise
 
     _safe_audit(
+        audit,
         request,
         "write",
         server_id,
@@ -703,6 +739,7 @@ async def delete_file(
     request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
+    audit: AuditWriter = Depends(get_audit_writer),
 ):
     """Delete a file or directory from server"""
     if not AuthorizationService.can_modify_files(current_user):
@@ -718,6 +755,7 @@ async def delete_file(
         )
     except Exception as exc:
         _safe_audit(
+            audit,
             request,
             "delete_failure",
             server_id,
@@ -730,6 +768,7 @@ async def delete_file(
         raise
 
     _safe_audit(
+        audit,
         request,
         "delete",
         server_id,
@@ -751,6 +790,7 @@ async def rename_file(
     request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
+    audit: AuditWriter = Depends(get_audit_writer),
 ):
     """Rename a file or directory"""
     if not AuthorizationService.can_modify_files(current_user):
@@ -767,6 +807,7 @@ async def rename_file(
         )
     except Exception as exc:
         _safe_audit(
+            audit,
             request,
             "rename_failure",
             server_id,
@@ -780,6 +821,7 @@ async def rename_file(
         raise
 
     _safe_audit(
+        audit,
         request,
         "rename",
         server_id,

--- a/app/users/api/router.py
+++ b/app/users/api/router.py
@@ -15,7 +15,10 @@ from typing import Optional, Union
 
 from fastapi import APIRouter, Depends, Query, Request
 
-from app.audit.service import AuditService
+from app.audit.api.dependencies import get_audit_writer
+from app.audit.application.legacy_facade import _extract_ip_address
+from app.audit.domain.entities import AuditEventCommand
+from app.audit.domain.ports import AuditWriter
 from app.auth.api.dependencies import get_auth_service
 from app.auth.application.service import AuthService
 from app.auth.dependencies import get_current_user
@@ -70,6 +73,44 @@ def _to_user_with_token_schema(result: UserWithToken) -> schemas.UserWithToken:
     return schemas.UserWithToken(
         user=_to_schema(result.user),
         access_token=result.access_token,
+    )
+
+
+def _record_user_management_event(
+    audit: AuditWriter,
+    request: Request,
+    *,
+    action: str,
+    target_user_id: int,
+    current_user_id: Optional[int] = None,
+    details: Optional[dict] = None,
+) -> None:
+    """Mirror :class:`AuditService.log_user_management_event` byte-identically.
+
+    Preserves the ``f"user_{action}"`` action, ``resource_type="user"``,
+    ``resource_id=target_user_id``, and the
+    ``target_user_id``/``performed_by`` details prefix. Falls back to
+    the request-scoped ``user_id_context`` (via ``get_current_user_id``)
+    when ``current_user_id`` is not supplied, matching the legacy
+    facade.
+    """
+    from app.middleware.audit_middleware import get_current_user_id
+
+    effective_current_user_id = current_user_id or get_current_user_id()
+    audit_details = {
+        "target_user_id": target_user_id,
+        "performed_by": effective_current_user_id,
+        **(details or {}),
+    }
+    audit.record(
+        AuditEventCommand(
+            action=f"user_{action}",
+            resource_type="user",
+            resource_id=target_user_id,
+            user_id=effective_current_user_id,
+            details=audit_details,
+            ip_address=_extract_ip_address(request),
+        )
     )
 
 
@@ -216,6 +257,7 @@ async def deactivate_user(
     current_user: User = Depends(get_current_user),
     service: UserService = Depends(get_user_service),
     auth_service: AuthService = Depends(get_auth_service),
+    audit: AuditWriter = Depends(get_audit_writer),
 ):
     """Admin-only: deactivate *user_id* and revoke all their refresh tokens.
 
@@ -228,8 +270,9 @@ async def deactivate_user(
     """
     updated = await service.deactivate_user(_to_entity(current_user), user_id)
     revoked_count = await auth_service.revoke_all_refresh_tokens_for(user_id)
-    AuditService.log_user_management_event(
-        request=request,
+    _record_user_management_event(
+        audit,
+        request,
         action="deactivated",
         target_user_id=user_id,
         current_user_id=current_user.id,
@@ -247,6 +290,7 @@ async def reactivate_user(
     request: Request,
     current_user: User = Depends(get_current_user),
     service: UserService = Depends(get_user_service),
+    audit: AuditWriter = Depends(get_audit_writer),
 ):
     """Admin-only: restore ``is_active=True`` for a previously deactivated user.
 
@@ -254,8 +298,9 @@ async def reactivate_user(
     access tokens stay rejected and the user must log in afresh.
     """
     updated = await service.reactivate_user(_to_entity(current_user), user_id)
-    AuditService.log_user_management_event(
-        request=request,
+    _record_user_management_event(
+        audit,
+        request,
         action="reactivated",
         target_user_id=user_id,
         current_user_id=current_user.id,

--- a/tests/integration/files/test_router.py
+++ b/tests/integration/files/test_router.py
@@ -1,14 +1,30 @@
 from datetime import datetime
 from io import BytesIO
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi import HTTPException, status
 
+from app.audit.api.dependencies import get_audit_writer
 from app.core.exceptions import (
     FileOperationException,
 )
+from app.main import app
 from app.types import FileType
 from tests.helpers.auth import auth_headers_for as get_auth_headers
+
+
+@pytest.fixture
+def mock_audit_writer():
+    """Override ``get_audit_writer`` so tests can introspect the
+    :class:`AuditEventCommand` instances passed to ``writer.record``
+    instead of patching the legacy ``AuditService`` static facade
+    (Issue #386 migration).
+    """
+    writer = MagicMock()
+    app.dependency_overrides[get_audit_writer] = lambda: writer
+    yield writer
+    app.dependency_overrides.pop(get_audit_writer, None)
 
 
 class TestFileRouter:
@@ -881,13 +897,18 @@ class TestFileRenameRouter:
 
 
 class TestFileRouterAuditWiring:
-    """Verify ``AuditService.log_file_event`` is invoked from the router
-    for both success and failure paths on the mutating endpoints (#36
-    Phase 1), and that file-domain exceptions surface through the global
-    error handlers with the standard envelope (#35).
+    """Verify the file router emits audit events for both success and
+    failure paths on the mutating endpoints (#36 Phase 1), and that
+    file-domain exceptions surface through the global error handlers
+    with the standard envelope (#35).
+
+    Issue #386: the router now records events via an injected
+    :class:`~app.audit.domain.ports.AuditWriter` rather than calling
+    the static ``AuditService`` facade. Tests override
+    ``get_audit_writer`` with a ``MagicMock`` and assert against the
+    :class:`AuditEventCommand` instance passed to ``writer.record``.
     """
 
-    @patch("app.files.router.AuditService.log_file_event")
     @patch(
         "app.servers.application.authorization.AuthorizationService.check_server_access",
         new_callable=AsyncMock,
@@ -899,7 +920,7 @@ class TestFileRouterAuditWiring:
         mock_write_file,
         mock_can_modify,
         mock_check_access,
-        mock_audit,
+        mock_audit_writer,
         client,
         admin_user,
     ):
@@ -927,17 +948,18 @@ class TestFileRouterAuditWiring:
         )
 
         assert response.status_code == status.HTTP_200_OK
-        mock_audit.assert_called_once()
-        kwargs = mock_audit.call_args.kwargs
-        assert kwargs["action"] == "write"
-        assert kwargs["server_id"] == 1
-        assert kwargs["file_path"] == "server.properties"
-        assert kwargs["details"]["encoding"] == "utf-8"
-        assert kwargs["details"]["backup_created"] is True
-        assert kwargs["details"]["bytes"] == 5
-        assert "duration_ms" in kwargs["details"]
+        mock_audit_writer.record.assert_called_once()
+        command = mock_audit_writer.record.call_args.args[0]
+        assert command.action == "file_write"
+        assert command.resource_type == "file"
+        assert command.resource_id == 1
+        assert command.details["server_id"] == 1
+        assert command.details["file_path"] == "server.properties"
+        assert command.details["encoding"] == "utf-8"
+        assert command.details["backup_created"] is True
+        assert command.details["bytes"] == 5
+        assert "duration_ms" in command.details
 
-    @patch("app.files.router.AuditService.log_file_event")
     @patch(
         "app.servers.application.authorization.AuthorizationService.check_server_access",
         new_callable=AsyncMock,
@@ -949,7 +971,7 @@ class TestFileRouterAuditWiring:
         mock_write_file,
         mock_can_modify,
         mock_check_access,
-        mock_audit,
+        mock_audit_writer,
         client,
         admin_user,
     ):
@@ -978,19 +1000,18 @@ class TestFileRouterAuditWiring:
         assert "SUGGESTED_ACTION" in codes
 
         # Failure audit event was emitted with error_type
-        mock_audit.assert_called_once()
-        kwargs = mock_audit.call_args.kwargs
-        assert kwargs["action"] == "write_failure"
-        assert kwargs["details"]["error_type"] == "FileMissingError"
+        mock_audit_writer.record.assert_called_once()
+        command = mock_audit_writer.record.call_args.args[0]
+        assert command.action == "file_write_failure"
+        assert command.details["error_type"] == "FileMissingError"
 
-    @patch("app.files.router.AuditService.log_file_event")
     @patch("app.servers.application.authorization.AuthorizationService.can_modify_files")
     @patch("app.files.application.management.file_management_service.delete_file")
     def test_delete_file_emits_audit_event_on_success(
         self,
         mock_delete_file,
         mock_can_modify,
-        mock_audit,
+        mock_audit_writer,
         client,
         admin_user,
     ):
@@ -1004,8 +1025,9 @@ class TestFileRouterAuditWiring:
         )
 
         assert response.status_code == status.HTTP_200_OK
-        mock_audit.assert_called_once()
-        assert mock_audit.call_args.kwargs["action"] == "delete"
+        mock_audit_writer.record.assert_called_once()
+        command = mock_audit_writer.record.call_args.args[0]
+        assert command.action == "file_delete"
 
     def test_write_request_size_limit_returns_422(self, client, admin_user):
         """``FileWriteRequest.content`` carries a 50 MiB cap (Issue #35).
@@ -1030,9 +1052,8 @@ class TestIssue341FileRouterContract:
     end-to-end through the FastAPI router.
     """
 
-    @patch("app.files.router.AuditService.log_file_event")
     def test_write_invalid_encoding_returns_422_envelope(
-        self, mock_audit, client, admin_user
+        self, mock_audit_writer, client, admin_user
     ):
         """Unknown encodings are rejected at validation time (#341).
 
@@ -1059,7 +1080,7 @@ class TestIssue341FileRouterContract:
         body = response.json()
         assert body["error"] == "VALIDATION_ERROR"
         # Validation rejection short-circuits the handler so no audit fires.
-        mock_audit.assert_not_called()
+        mock_audit_writer.record.assert_not_called()
 
     @patch(
         "app.servers.application.authorization.AuthorizationService.check_server_access",

--- a/tests/unit/auth/test_token_version.py
+++ b/tests/unit/auth/test_token_version.py
@@ -7,7 +7,7 @@ HTTP flow lives in ``tests/integration/auth/test_router.py``.
 """
 
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi import HTTPException
@@ -52,37 +52,44 @@ class TestTokenVersionAuthentication:
         assert excinfo.value.status_code == 401
 
     def test_tv_mismatch_emits_audit_event(self, db, test_user):
-        """The ``tv`` mismatch path emits a security audit event."""
+        """The ``tv`` mismatch path emits a security audit event.
+
+        Issue #386: ``_authenticate`` now takes an explicit
+        ``AuditWriter`` rather than reaching for the static
+        ``AuditService`` facade. The mock writer captures the
+        ``AuditEventCommand`` and we assert against the same fields the
+        legacy patch checked.
+        """
         token = create_access_token(
             data={"sub": test_user.username, "tv": test_user.token_version}
         )
         test_user.token_version = (test_user.token_version or 0) + 1
         db.commit()
 
-        with patch(
-            "app.audit.application.legacy_facade.AuditService.log_security_event"
-        ) as mock_log:
-            from starlette.requests import Request
+        mock_writer = MagicMock()
+        from starlette.requests import Request
 
-            scope = {
-                "type": "http",
-                "method": "GET",
-                "path": "/api/v1/users/me",
-                "headers": [(b"user-agent", b"pytest")],
-                "query_string": b"",
-                "client": ("127.0.0.1", 0),
-                "server": ("testserver", 80),
-                "scheme": "http",
-                "root_path": "",
-            }
-            request = Request(scope)
-            with pytest.raises(HTTPException):
-                _authenticate(token, db, request=request)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/v1/users/me",
+            "headers": [(b"user-agent", b"pytest")],
+            "query_string": b"",
+            "client": ("127.0.0.1", 0),
+            "server": ("testserver", 80),
+            "scheme": "http",
+            "root_path": "",
+        }
+        request = Request(scope)
+        with pytest.raises(HTTPException):
+            _authenticate(token, db, request=request, audit=mock_writer)
 
-        assert mock_log.called
-        call_kwargs = mock_log.call_args.kwargs
-        assert call_kwargs["event_type"] == "token_revoked_post_deactivation"
-        assert call_kwargs["severity"] == "warning"
+        assert mock_writer.record.called
+        command = mock_writer.record.call_args.args[0]
+        assert command.action == "security_token_revoked_post_deactivation"
+        assert command.resource_type == "security"
+        assert command.details["event_type"] == "token_revoked_post_deactivation"
+        assert command.details["severity"] == "warning"
 
     def test_inactive_user_rejected_even_with_matching_tv(self, db, test_user):
         """Defense-in-depth: ``is_active=False`` blocks auth regardless of tv."""


### PR DESCRIPTION
## Summary

Replaces the `AuditService.log_*` static facade calls in `app/auth/`, `app/users/`, and `app/files/` with `AuditWriter` DI via `Depends(get_audit_writer)`. Completes the per-domain migration to the cross-cutting pattern documented in ARCHITECTURE.md §7.1.

The legacy facade remains in place; it is still used by `app/audit/api/router.py` and `app/servers/routers/control.py` (out of scope for #386).

## Migrated callsites

| Domain | File:Line(s) | Method |
|---|---|---|
| auth | `app/auth/api/router.py:142, 178, 209, 240, 261, 271, 291, 304, 321, 342, 353` | `log_authentication_event` (×9), `log_security_event` (×2) |
| auth | `app/auth/dependencies.py:62` | `log_security_event` |
| users | `app/users/api/router.py:231, 257` | `log_user_management_event` (×2) |
| files | `app/files/router.py:77` | `log_file_event` (`_safe_audit` helper, 7 endpoints) |

A shared `get_audit_writer` factory was added to `app/audit/api/dependencies.py` so the three domains do not duplicate the groups-domain factory.

## Preserved invariants

- **Action strings**: byte-identical to the legacy facade — verified by reading `app/audit/application/legacy_facade.py` and reproducing each format string (`auth_{action}_{'success' if success else 'failure'}`, `user_{action}`, `file_{action}`, `security_{event_type}`).
- **details payload shape**: each domain's helper assembles the same `details` dict (e.g. files prepends `server_id`/`file_path`/`file_name`; auth prepends `user_agent`/`success`; user management prepends `target_user_id`/`performed_by`).
- **resource_type / resource_id**: preserved per call (e.g. `resource_type="file"`/`resource_id=server_id` for files; `resource_type="user"`/`resource_id=target_user_id` for user management).
- **ip_address extraction**: routed through the existing `_extract_ip_address` helper imported from `app.audit.application.legacy_facade`.
- **user_id fallback** (`get_current_user_id()`): preserved where the legacy facade applied it (files `_safe_audit`, auth `_record_security_event`, users `_record_user_management_event`).

All emissions still fire **after** the business commit (no error-semantics shift).

## Test updates

- `tests/integration/files/test_router.py`: 4× `@patch("app.files.router.AuditService.log_file_event")` swapped for a `mock_audit_writer` fixture that overrides the `get_audit_writer` dependency with a `MagicMock`. Assertions now read the `AuditEventCommand` instance passed to `writer.record(...)` (e.g. `command.action == "file_write"` instead of `kwargs["action"] == "write"`).
- `tests/unit/auth/test_token_version.py`: the single `@patch("app.audit.application.legacy_facade.AuditService.log_security_event")` was replaced by passing a `MagicMock` writer directly to `_authenticate(..., audit=mock_writer)`.

## Test plan

- [x] `uv run ruff check app/`
- [x] `uv run ruff format --check app/`
- [x] `uv run pytest tests/unit -m "not slow"` — 1477 passed, 5 skipped
- [x] `uv run pytest tests/unit tests/integration -m "not slow"` — 2013 passed, 10 skipped
- [x] `rg "AuditService\.log_" app/auth/ app/users/ app/files/` returns zero call sites (only docstring references remain)

Resolves #386

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>