### PR TITLE
fix(files): sanitize upload filename to block path traversal

### DIFF
--- a/app/files/application/management.py
+++ b/app/files/application/management.py
@@ -308,15 +308,21 @@ class FileManagementService:
 
         self.validation_service.validate_path_safety(server_path, target_dir)
 
-        # Upload file
-        target_file = target_dir / file.filename
+        # Strip any directory components from the attacker-controlled
+        # ``Content-Disposition`` filename, then re-validate the resolved
+        # path so traversal sequences (e.g. ``../../other-server/ops.json``)
+        # cannot escape ``server_path``.
+        safe_name = Path(file.filename).name
+        target_file = target_dir / safe_name
+        self.validation_service.validate_path_safety(server_path, target_file)
+
         await self.operation_service.upload_file(file, target_file)
 
         # Get file info for response
         file_info = await self.info_service.get_file_info(target_file, server_path)
 
         result = {
-            "message": f"File '{file.filename}' uploaded successfully",
+            "message": f"File '{safe_name}' uploaded successfully",
             "file": file_info,
             "extracted_files": [],
         }
@@ -333,7 +339,7 @@ class FileManagementService:
 
             # Update message to reflect extraction
             result["message"] = (
-                f"Archive '{file.filename}' uploaded and extracted successfully"
+                f"Archive '{safe_name}' uploaded and extracted successfully"
             )
 
         return result

--- a/app/files/application/management.py
+++ b/app/files/application/management.py
@@ -308,11 +308,20 @@ class FileManagementService:
 
         self.validation_service.validate_path_safety(server_path, target_dir)
 
+        # ``UploadFile.filename`` is ``Optional[str]``; reject missing/empty
+        # names explicitly so ``Path(None)`` doesn't surface as a TypeError.
+        # ``Path("..").name`` and ``Path(".").name`` both resolve to ``""``,
+        # so the empty check below also covers bare-traversal inputs.
+        if not file.filename:
+            raise InvalidRequestException("Filename is required for file upload")
+
         # Strip any directory components from the attacker-controlled
         # ``Content-Disposition`` filename, then re-validate the resolved
         # path so traversal sequences (e.g. ``../../other-server/ops.json``)
         # cannot escape ``server_path``.
         safe_name = Path(file.filename).name
+        if not safe_name:
+            raise InvalidRequestException("Invalid filename for file upload")
         target_file = target_dir / safe_name
         self.validation_service.validate_path_safety(server_path, target_file)
 

--- a/app/files/application/management.py
+++ b/app/files/application/management.py
@@ -310,8 +310,8 @@ class FileManagementService:
 
         # ``UploadFile.filename`` is ``Optional[str]``; reject missing/empty
         # names explicitly so ``Path(None)`` doesn't surface as a TypeError.
-        # ``Path("..").name`` and ``Path(".").name`` both resolve to ``""``,
-        # so the empty check below also covers bare-traversal inputs.
+        # ``Path(".").name`` resolves to ``""``; ``Path("..").name`` resolves
+        # to ``".."`` which is caught by the downstream ``validate_path_safety``.
         if not file.filename:
             raise InvalidRequestException("Filename is required for file upload")
 

--- a/tests/unit/files/application/test_management.py
+++ b/tests/unit/files/application/test_management.py
@@ -7,6 +7,7 @@ from fastapi import UploadFile
 from app.core.exceptions import (
     AccessDeniedException,
     FileOperationException,
+    InvalidRequestException,
     ServerNotFoundException,
 )
 from app.files.application.management import file_management_service
@@ -519,6 +520,29 @@ class TestFileManagementService:
             assert result["file"]["name"] == "test.txt"
             assert result["extracted_files"] == []
             mock_aio_file.write.assert_called_once_with(b"file content")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_name", [None, "", "."])
+    async def test_upload_file_rejects_missing_or_empty_filename(
+        self, mock_server, mock_db, tmp_path, bad_name
+    ):
+        """``UploadFile.filename`` is ``Optional[str]``; reject missing or
+        directory-only inputs (``Path(".").name == ""``) before they reach
+        ``Path(None)`` (TypeError) or land on ``target_dir`` itself."""
+        server_dir = tmp_path / "test_server"
+        server_dir.mkdir()
+        mock_server.directory_path = str(server_dir)
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
+
+        mock_file = Mock(spec=UploadFile)
+        mock_file.filename = bad_name
+
+        with pytest.raises(InvalidRequestException):
+            await file_management_service.upload_file(
+                server_id=1, file=mock_file, db=mock_db
+            )
 
     @pytest.mark.asyncio
     async def test_upload_file_strips_traversal_in_filename(

--- a/tests/unit/files/application/test_management.py
+++ b/tests/unit/files/application/test_management.py
@@ -492,10 +492,12 @@ class TestFileManagementService:
             mock_resolve.side_effect = [
                 Path("/servers/test_server"),  # target_dir.resolve()
                 Path("/servers/test_server"),  # server_path.resolve()
+                Path("/servers/test_server/test.txt"),  # target_file.resolve()
+                Path("/servers/test_server"),  # server_path.resolve() (2nd check)
             ]
 
             # Mock all file system operations
-            with patch("pathlib.Path.mkdir") as mock_mkdir:
+            with patch("pathlib.Path.mkdir"):
                 with patch("pathlib.Path.stat") as mock_stat:
                     mock_stat.return_value.st_size = 12  # len(b"file content")
                     mock_stat.return_value.st_mtime = 1640995200
@@ -517,6 +519,46 @@ class TestFileManagementService:
             assert result["file"]["name"] == "test.txt"
             assert result["extracted_files"] == []
             mock_aio_file.write.assert_called_once_with(b"file content")
+
+    @pytest.mark.asyncio
+    async def test_upload_file_strips_traversal_in_filename(
+        self, mock_server, mock_db, tmp_path
+    ):
+        """Regression for #400: traversal sequences in ``file.filename`` must
+        not escape the server directory."""
+        server_dir = tmp_path / "test_server"
+        server_dir.mkdir()
+        mock_server.directory_path = str(server_dir)
+        mock_db.query.return_value.filter.return_value.one_or_none.return_value = (
+            mock_server
+        )
+
+        mock_file = Mock(spec=UploadFile)
+        mock_file.filename = "../../evil.txt"
+
+        captured: dict = {}
+
+        async def _capture_upload(upload, target_path):
+            captured["target"] = target_path
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_bytes(b"x")
+            return 1
+
+        with patch.object(
+            file_management_service.operation_service,
+            "upload_file",
+            side_effect=_capture_upload,
+        ):
+            result = await file_management_service.upload_file(
+                server_id=1, file=mock_file, db=mock_db
+            )
+
+        # File was written inside server_dir (basename only), not outside.
+        assert captured["target"].parent.resolve() == server_dir.resolve()
+        assert captured["target"].name == "evil.txt"
+        assert not (tmp_path / "evil.txt").exists()
+        assert result["file"]["name"] == "evil.txt"
+        assert "evil.txt" in result["message"]
 
     @pytest.mark.asyncio
     async def test_download_file_server_not_found(self, mock_db):

--- a/tests/unit/files/application/test_management.py
+++ b/tests/unit/files/application/test_management.py
@@ -522,13 +522,22 @@ class TestFileManagementService:
             mock_aio_file.write.assert_called_once_with(b"file content")
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("bad_name", [None, "", "."])
+    @pytest.mark.parametrize(
+        ("bad_name", "expected_exc"),
+        [
+            (None, InvalidRequestException),
+            ("", InvalidRequestException),
+            (".", InvalidRequestException),
+            ("..", AccessDeniedException),
+        ],
+    )
     async def test_upload_file_rejects_missing_or_empty_filename(
-        self, mock_server, mock_db, tmp_path, bad_name
+        self, mock_server, mock_db, tmp_path, bad_name, expected_exc
     ):
         """``UploadFile.filename`` is ``Optional[str]``; reject missing or
         directory-only inputs (``Path(".").name == ""``) before they reach
-        ``Path(None)`` (TypeError) or land on ``target_dir`` itself."""
+        ``Path(None)`` (TypeError) or land on ``target_dir`` itself.
+        ``".."`` passes the empty check but is caught by ``validate_path_safety``."""
         server_dir = tmp_path / "test_server"
         server_dir.mkdir()
         mock_server.directory_path = str(server_dir)
@@ -539,7 +548,7 @@ class TestFileManagementService:
         mock_file = Mock(spec=UploadFile)
         mock_file.filename = bad_name
 
-        with pytest.raises(InvalidRequestException):
+        with pytest.raises(expected_exc):
             await file_management_service.upload_file(
                 server_id=1, file=mock_file, db=mock_db
             )


### PR DESCRIPTION
## Summary

Fixes the HIGH severity path traversal vulnerability in the file upload endpoint reported in #400.

`FileManagementService.upload_file` joined the attacker-controlled `Content-Disposition` filename directly onto the validated `target_dir`, so a filename like `../../other-server/ops.json` resolved outside the server boundary. An authenticated operator/admin could overwrite arbitrary files reachable by the process — other servers' configs, `server.jar`, or application directories — because `FileOperationService.upload_file` also creates intermediate dirs via `mkdir(parents=True, exist_ok=True)`.

## Changes

- `app/files/application/management.py`: Strip directory components with `Path(file.filename).name` before composing `target_file`, then re-run `validate_path_safety` on the resolved target path as defence-in-depth. Use the sanitized name in the response message so it reflects what was actually written.
- `tests/unit/files/application/test_management.py`:
  - New regression `test_upload_file_strips_traversal_in_filename` uploads `../../evil.txt` against a real `tmp_path` server dir and asserts the file lands inside the server directory under its basename only.
  - Updated the existing `test_upload_file_success` `Path.resolve` `side_effect` to cover the additional validation call.

## Test plan

- [x] `uv run pytest tests/unit/files -m "not slow"` — 80 passed
- [x] `uv run pytest tests/unit -m "not slow"` — 1478 passed, 5 skipped
- [x] `uv run ruff check` / `ruff format` on the changed files — clean
- [x] Pre-commit + pre-push hooks — passed

Resolves #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)