### PR TITLE
ci(tagpr): disable uv cache to fix release-tag run failure

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -24,7 +24,11 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
-          enable-cache: true
+          # Cache disabled: tagpr only runs `uv lock` (via .tagpr's
+          # postVersionCommand) when opening/refreshing the release PR.
+          # On the release-tagging push no uv command runs, leaving the
+          # cache dir empty and breaking the post-step cache save.
+          enable-cache: false
           python-version: "3.13.12"
 
       - name: Run tagpr


### PR DESCRIPTION
## Summary
- `tagpr` workflow の `Post Set up uv` (キャッシュ保存) ステップが失敗していた (例: [run 26543216024](https://github.com/mmiura-2351/mc-server-dashboard-api/actions/runs/26543216024))。
- 原因: `.tagpr` の `postVersionCommand = "uv lock"` はリリース PR を作成/更新する push でのみ走り、リリースタグ付け push では何も `uv` コマンドが走らない。結果として `setup-uv@v5` のキャッシュ対象ディレクトリ `/home/runner/work/_temp/setup-uv-cache` が生成されず、post-step が `Cache path ... does not exist on disk` で落ちる。
- 修正: `enable-cache: false` に変更。workflow は ~15s で完了するためキャッシュの恩恵はほぼ無し。

## Test plan
- [ ] master へマージ後、次回 tagpr 実行 (リリース PR refresh / タグ付け両パス) が緑になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)