### PR TITLE
Release for v0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mc-server-dashboard-api"
-version = "0.1.1"
+version = "0.2.0"
 description = "Minecraft server management dashboard API"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "mc-server-dashboard-api"
-version = "0.1.1"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This pull request is for the next release as v0.2.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at master -->

## What's Changed
* ci(tagpr): disable uv cache to fix release-tag run failure by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/404
* Refresh and restructure documentation by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/406
* Validate ZIP archive members on extraction by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/408
* Offload blocking DB retry off the event loop by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/411
* Centralize CREATE INDEX DDL behind a validated identifier helper by @mmiura-2351 in https://github.com/mmiura-2351/mc-server-dashboard-api/pull/414


**Full Changelog**: https://github.com/mmiura-2351/mc-server-dashboard-api/compare/v0.1.1...tagpr-from-v0.1.1