### PR TITLE
Offload blocking DB retry off the event loop

### DIFF
--- a/app/core/database_utils.py
+++ b/app/core/database_utils.py
@@ -47,6 +47,12 @@ def with_transaction(
     """
     Execute a function within a database transaction with retry logic.
 
+    This function is **synchronous and blocking**: its retry path calls
+    ``time.sleep`` for backoff. Do not call it directly from a coroutine on the
+    event loop — wrap it in ``asyncio.to_thread`` (see
+    ``app/servers/adapters/repository.py``) so the backoff does not stall the
+    loop.
+
     Args:
         session: SQLAlchemy session
         func: Function to execute within transaction

--- a/app/servers/adapters/repository.py
+++ b/app/servers/adapters/repository.py
@@ -22,6 +22,7 @@ allowed to touch the ORM directly; only the **application** layer is
 forbidden.
 """
 
+import asyncio
 from typing import List, Mapping, Optional
 
 from sqlalchemy.orm import Session, joinedload
@@ -260,7 +261,10 @@ class SqlAlchemyServerRepository:
             session.flush()
             return _server_to_entity(row)
 
-        return with_transaction(self._db, _do)
+        # `with_transaction` is synchronous and its retry path calls
+        # `time.sleep`; offload to a worker thread so the backoff never blocks
+        # the event loop (mirrors `health/adapters/database_check.py`).
+        return await asyncio.to_thread(with_transaction, self._db, _do)
 
     async def update_port(self, server_id: int, port: int) -> Optional[ServerEntity]:
         """Set a single server's port atomically (with retry).
@@ -285,7 +289,9 @@ class SqlAlchemyServerRepository:
             session.flush()
             return _server_to_entity(row)
 
-        return with_transaction(self._db, _do)
+        # Offload the blocking retry/commit off the event loop (see
+        # `update_status`).
+        return await asyncio.to_thread(with_transaction, self._db, _do)
 
     async def batch_update_statuses(
         self, updates: Mapping[int, ServerStatus]
@@ -329,4 +335,6 @@ class SqlAlchemyServerRepository:
                 for sid in updates.keys()
             }
 
-        return with_transaction(self._db, _do)
+        # Offload the blocking retry/commit off the event loop (see
+        # `update_status`).
+        return await asyncio.to_thread(with_transaction, self._db, _do)

--- a/app/servers/adapters/repository.py
+++ b/app/servers/adapters/repository.py
@@ -8,11 +8,13 @@ Per the UnitOfWork pattern, most repository methods **do not commit**.
 They stage changes on the session and rely on the surrounding
 `SqlAlchemyServersUnitOfWork` (or the caller) to commit.
 
-The two status writes (`update_status`, `batch_update_statuses`) are
-the documented exception: they own their transaction via
-`app.core.database_utils.with_transaction` so the existing
-backoff/retry semantics the legacy code relied on are preserved (M-8
-/ D-5 in the #228 plan).
+The three own-transaction writes (`update_status`, `update_port`,
+`batch_update_statuses`) are the documented exception: they own their
+transaction via `app.core.database_utils.with_transaction` so the
+existing backoff/retry semantics the legacy code relied on are
+preserved (M-8 / D-5 in the #228 plan). Because `with_transaction` is
+synchronous and its retry path blocks, those callsites offload it with
+`asyncio.to_thread` so the backoff never stalls the event loop.
 
 Cross-domain JOIN against `User` (for `owner_username`) is
 intentionally kept inside this adapter rather than dispatched through

--- a/tests/unit/servers/adapters/test_repository_async_retry.py
+++ b/tests/unit/servers/adapters/test_repository_async_retry.py
@@ -1,0 +1,97 @@
+"""Regression tests for Issue #410.
+
+`SqlAlchemyServerRepository`'s status/port write methods own their transaction
+via the synchronous `with_transaction`, whose retry path calls a blocking
+`time.sleep`. These methods are `async def` and awaited on the event loop, so
+the call must be offloaded to a worker thread or a backoff stalls the whole API.
+
+Each test replaces `with_transaction` with a deliberately blocking stub and
+asserts a concurrent heartbeat coroutine keeps ticking while the write runs —
+i.e. the event loop is not blocked. Against the pre-fix code (a direct
+synchronous call) the heartbeat would not advance.
+"""
+
+import asyncio
+import time
+from unittest.mock import Mock
+
+import pytest
+
+import app.servers.adapters.repository as repo_mod
+from app.servers.adapters.repository import SqlAlchemyServerRepository
+from app.servers.models import ServerStatus
+
+pytestmark = pytest.mark.asyncio
+
+# Long enough that a heartbeat ticking every 1 ms accrues many ticks if the
+# loop stays free, but short enough to keep the test fast.
+BLOCK_SECONDS = 0.1
+SENTINEL = "transaction-result"
+
+
+async def _assert_not_blocked(coro_factory):
+    """Run ``coro_factory()`` while a heartbeat ticks; return its result.
+
+    Asserts the heartbeat advanced during the call, proving the event loop was
+    not blocked by the (stubbed) synchronous transaction.
+    """
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0.001)
+
+    hb = asyncio.create_task(heartbeat())
+    await asyncio.sleep(0)  # let the heartbeat start
+    try:
+        result = await coro_factory()
+    finally:
+        hb.cancel()
+
+    # A blocking on-loop sleep of BLOCK_SECONDS would leave ticks ~0.
+    assert ticks > 5, f"event loop appears blocked (ticks={ticks})"
+    return result
+
+
+@pytest.fixture
+def blocking_with_transaction(monkeypatch):
+    """Patch `with_transaction` with a blocking stub returning a sentinel."""
+
+    def _stub(db, fn):
+        time.sleep(BLOCK_SECONDS)  # stand in for retry backoff / blocking I/O
+        return SENTINEL
+
+    monkeypatch.setattr(repo_mod, "with_transaction", _stub)
+    return _stub
+
+
+async def test_update_status_does_not_block_event_loop(blocking_with_transaction):
+    repo = SqlAlchemyServerRepository(db=Mock())
+    result = await _assert_not_blocked(
+        lambda: repo.update_status(1, ServerStatus.running)
+    )
+    assert result == SENTINEL
+
+
+async def test_update_port_does_not_block_event_loop(blocking_with_transaction):
+    repo = SqlAlchemyServerRepository(db=Mock())
+    result = await _assert_not_blocked(lambda: repo.update_port(1, 25565))
+    assert result == SENTINEL
+
+
+async def test_batch_update_statuses_does_not_block_event_loop(
+    blocking_with_transaction,
+):
+    repo = SqlAlchemyServerRepository(db=Mock())
+    result = await _assert_not_blocked(
+        lambda: repo.batch_update_statuses({1: ServerStatus.running})
+    )
+    assert result == SENTINEL
+
+
+async def test_batch_update_statuses_empty_short_circuits(blocking_with_transaction):
+    """Empty input returns immediately without touching the transaction."""
+    repo = SqlAlchemyServerRepository(db=Mock())
+    assert await repo.batch_update_statuses({}) == {}


### PR DESCRIPTION
## Summary

`with_transaction` (`app/core/database_utils.py`) is synchronous and its retry path calls a blocking `time.sleep`. In production its only callers are three `async def` methods on `SqlAlchemyServerRepository` that invoked it **directly on the event loop**:

- `update_status` (`repository.py:263`)
- `update_port` (`repository.py:288`)
- `batch_update_statuses` (`repository.py:332`)

These are awaited from `database_integration.py` / `simplified_sync.py`. A retryable `OperationalError` / `DisconnectionError` (connection blip, lock contention) ran the backoff `time.sleep` on the loop and stalled the **entire API** — exactly when the DB is already struggling. Release-blocker P0 #4 from the consolidated review.

## Changes

- **`app/servers/adapters/repository.py`** — wrap the three `with_transaction(...)` calls in `await asyncio.to_thread(...)`, so the backoff and the transaction's blocking DB I/O run off the event loop. Mirrors the existing precedent in `app/health/adapters/database_check.py:34`.
- **`app/core/database_utils.py`** — document `with_transaction` as synchronous/blocking and direct async callers to offload it, preventing regressions.
- **`tests/unit/servers/adapters/test_repository_async_retry.py`** — regression tests asserting a concurrent heartbeat coroutine keeps ticking while each write runs (loop not blocked). Verified to **fail against the pre-fix direct-call code** (`ticks=1`) and pass after the fix.

`@transactional` is unused in production (docstring/tests only), so these three methods are the complete reachable set.

## Verification

- `ruff`, `mypy` clean on touched files.
- `pytest tests/unit/servers tests/unit/core -m "not slow"` green; new tests pass.
- pre-commit + pre-push (unit + integration smoke, mypy) passed.

Resolves #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)
