### PR TITLE
Centralize CREATE INDEX DDL behind a validated identifier helper

### DIFF
--- a/app/audit/adapters/migrations.py
+++ b/app/audit/adapters/migrations.py
@@ -23,7 +23,7 @@ scope for Phase 1 and tracked as a follow-up.
 import logging
 from typing import Any
 
-from sqlalchemy import text
+from app.core.db_ddl import create_index_if_not_exists
 
 logger = logging.getLogger(__name__)
 
@@ -58,11 +58,8 @@ def migrate_audit_indexes(engine: Any) -> None:
     with engine.connect() as conn:
         for index_name, column in _AUDIT_SINGLE_INDEXES:
             try:
-                conn.execute(
-                    text(
-                        f"CREATE INDEX IF NOT EXISTS {index_name} "
-                        f"ON audit_logs ({column})"
-                    )
+                create_index_if_not_exists(
+                    conn, index_name=index_name, table="audit_logs", columns=column
                 )
             except Exception as exc:  # pragma: no cover - defensive
                 logger.warning(
@@ -73,11 +70,8 @@ def migrate_audit_indexes(engine: Any) -> None:
                 )
         for index_name, columns in _AUDIT_COMPOSITE_INDEXES:
             try:
-                conn.execute(
-                    text(
-                        f"CREATE INDEX IF NOT EXISTS {index_name} "
-                        f"ON audit_logs ({columns})"
-                    )
+                create_index_if_not_exists(
+                    conn, index_name=index_name, table="audit_logs", columns=columns
                 )
             except Exception as exc:  # pragma: no cover - defensive
                 logger.warning(

--- a/app/auth/adapters/migrations.py
+++ b/app/auth/adapters/migrations.py
@@ -16,7 +16,7 @@ COUNT query can be served from a single index range scan.
 import logging
 from typing import Any
 
-from sqlalchemy import text
+from app.core.db_ddl import create_index_if_not_exists
 
 logger = logging.getLogger(__name__)
 
@@ -44,11 +44,11 @@ def migrate_login_attempt_indexes(engine: Any) -> None:
     with engine.connect() as conn:
         for index_name, columns in _LOGIN_ATTEMPT_COMPOSITE_INDEXES:
             try:
-                conn.execute(
-                    text(
-                        f"CREATE INDEX IF NOT EXISTS {index_name} "
-                        f"ON login_attempts ({columns})"
-                    )
+                create_index_if_not_exists(
+                    conn,
+                    index_name=index_name,
+                    table="login_attempts",
+                    columns=columns,
                 )
             except Exception as exc:  # pragma: no cover - defensive
                 logger.warning(

--- a/app/backups/adapters/migrations.py
+++ b/app/backups/adapters/migrations.py
@@ -17,7 +17,7 @@ filters).
 import logging
 from typing import Any
 
-from sqlalchemy import text
+from app.core.db_ddl import create_index_if_not_exists
 
 logger = logging.getLogger(__name__)
 
@@ -56,8 +56,8 @@ def migrate_backup_indexes(engine: Any) -> None:
     with engine.connect() as conn:
         for index_name, column in _BACKUP_SINGLE_INDEXES:
             try:
-                conn.execute(
-                    text(f"CREATE INDEX IF NOT EXISTS {index_name} ON backups ({column})")
+                create_index_if_not_exists(
+                    conn, index_name=index_name, table="backups", columns=column
                 )
             except Exception as exc:  # pragma: no cover - defensive
                 logger.warning(
@@ -68,10 +68,8 @@ def migrate_backup_indexes(engine: Any) -> None:
                 )
         for index_name, columns in _BACKUP_COMPOSITE_INDEXES:
             try:
-                conn.execute(
-                    text(
-                        f"CREATE INDEX IF NOT EXISTS {index_name} ON backups ({columns})"
-                    )
+                create_index_if_not_exists(
+                    conn, index_name=index_name, table="backups", columns=columns
                 )
             except Exception as exc:  # pragma: no cover - defensive
                 logger.warning(

--- a/app/core/db_ddl.py
+++ b/app/core/db_ddl.py
@@ -49,11 +49,13 @@ def create_index_if_not_exists(
         conn: An open SQLAlchemy :class:`~sqlalchemy.engine.Connection`.
         index_name: Name of the index to create.
         table: Table to index.
-        columns: A single column, a comma-separated string of columns (for a
-            composite index), or an iterable of column names.
+        columns: The index columns. A ``str`` is split on commas (so a single
+            column and a comma-separated composite are both accepted); any other
+            iterable is taken as an already-split list of column names.
 
-    Every identifier must match ``^[A-Za-z_][A-Za-z0-9_]*$`` or a
-    :class:`ValueError` is raised before any SQL is executed.
+    Every identifier (index, table, and each column) must be a plain SQL
+    identifier per :data:`_IDENTIFIER_RE`, or a :class:`ValueError` is raised
+    before any SQL is executed.
     """
     if isinstance(columns, str):
         column_list = columns.split(",")

--- a/app/core/db_ddl.py
+++ b/app/core/db_ddl.py
@@ -1,0 +1,78 @@
+"""Safe DDL helpers for domain index migrations.
+
+Each domain's ``adapters/migrations.py`` retro-fits performance indexes at
+startup with ``CREATE INDEX IF NOT EXISTS``. Index / table / column names are
+module-level constants today, but building that DDL by raw f-string
+interpolation is a SQL-injection footgun the moment any dynamic value reaches
+it — and identifiers cannot be passed as bound parameters the way values can.
+
+:func:`create_index_if_not_exists` is the single choke point: it validates every
+identifier against a strict pattern (raising before any SQL runs) and quotes
+each via the dialect's identifier preparer, so the interpolation can never
+inject and reserved-word table names (e.g. ``groups``) are quoted correctly.
+"""
+
+import re
+from typing import Iterable, Union
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+# A conservative SQL identifier: a leading letter/underscore followed by
+# letters, digits, or underscores. Deliberately stricter than any dialect
+# allows — domain index/table/column names all satisfy it.
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _safe_identifier(name: str) -> str:
+    """Return ``name`` (stripped) if it is a safe SQL identifier.
+
+    Raises:
+        ValueError: if ``name`` does not match :data:`_IDENTIFIER_RE`.
+    """
+    candidate = name.strip()
+    if not _IDENTIFIER_RE.match(candidate):
+        raise ValueError(f"Unsafe SQL identifier: {name!r}")
+    return candidate
+
+
+def create_index_if_not_exists(
+    conn: Connection,
+    *,
+    index_name: str,
+    table: str,
+    columns: Union[str, Iterable[str]],
+) -> None:
+    """Emit ``CREATE INDEX IF NOT EXISTS`` with validated, quoted identifiers.
+
+    Args:
+        conn: An open SQLAlchemy :class:`~sqlalchemy.engine.Connection`.
+        index_name: Name of the index to create.
+        table: Table to index.
+        columns: A single column, a comma-separated string of columns (for a
+            composite index), or an iterable of column names.
+
+    Every identifier must match ``^[A-Za-z_][A-Za-z0-9_]*$`` or a
+    :class:`ValueError` is raised before any SQL is executed.
+    """
+    if isinstance(columns, str):
+        column_list = columns.split(",")
+    else:
+        column_list = list(columns)
+
+    if not column_list:
+        raise ValueError("create_index_if_not_exists requires at least one column")
+
+    preparer = conn.dialect.identifier_preparer
+    quoted_index = preparer.quote(_safe_identifier(index_name))
+    quoted_table = preparer.quote(_safe_identifier(table))
+    quoted_columns = ", ".join(
+        preparer.quote(_safe_identifier(column)) for column in column_list
+    )
+
+    conn.execute(
+        text(
+            f"CREATE INDEX IF NOT EXISTS {quoted_index} "
+            f"ON {quoted_table} ({quoted_columns})"
+        )
+    )

--- a/app/files/adapters/migrations.py
+++ b/app/files/adapters/migrations.py
@@ -16,6 +16,8 @@ from typing import Any
 
 from sqlalchemy import text
 
+from app.core.db_ddl import create_index_if_not_exists
+
 logger = logging.getLogger(__name__)
 
 
@@ -131,11 +133,11 @@ def migrate_file_history_indexes(engine: Any) -> None:
     with engine.connect() as conn:
         for index_name, column in _FILE_HISTORY_INDEXES:
             try:
-                conn.execute(
-                    text(
-                        f"CREATE INDEX IF NOT EXISTS {index_name} "
-                        f"ON file_edit_history ({column})"
-                    )
+                create_index_if_not_exists(
+                    conn,
+                    index_name=index_name,
+                    table="file_edit_history",
+                    columns=column,
                 )
             except Exception as exc:  # pragma: no cover - defensive
                 logger.warning(

--- a/app/groups/adapters/migrations.py
+++ b/app/groups/adapters/migrations.py
@@ -15,7 +15,7 @@ listings and the per-group server-attachment join.
 import logging
 from typing import Any
 
-from sqlalchemy import text
+from app.core.db_ddl import create_index_if_not_exists
 
 logger = logging.getLogger(__name__)
 
@@ -44,8 +44,8 @@ def migrate_group_indexes(engine: Any) -> None:
     with engine.connect() as conn:
         for table, index_name, column in _GROUP_INDEXES:
             try:
-                conn.execute(
-                    text(f"CREATE INDEX IF NOT EXISTS {index_name} ON {table} ({column})")
+                create_index_if_not_exists(
+                    conn, index_name=index_name, table=table, columns=column
                 )
             except Exception as exc:  # pragma: no cover - defensive
                 logger.warning(

--- a/app/servers/adapters/migrations.py
+++ b/app/servers/adapters/migrations.py
@@ -24,6 +24,8 @@ from typing import Any
 
 from sqlalchemy import text
 
+from app.core.db_ddl import create_index_if_not_exists
+
 logger = logging.getLogger(__name__)
 
 # Index names must match SQLAlchemy's auto-generated convention
@@ -58,8 +60,8 @@ def migrate_server_indexes(engine: Any) -> None:
     with engine.connect() as conn:
         for index_name, column in _SERVER_INDEXES:
             try:
-                conn.execute(
-                    text(f"CREATE INDEX IF NOT EXISTS {index_name} ON servers ({column})")
+                create_index_if_not_exists(
+                    conn, index_name=index_name, table="servers", columns=column
                 )
             except Exception as exc:  # pragma: no cover - defensive
                 logger.warning(
@@ -133,10 +135,11 @@ def migrate_drop_templates(engine: Any) -> None:
 
                 for index_name, column in _SERVER_INDEXES:
                     try:
-                        conn.execute(
-                            text(
-                                f"CREATE INDEX IF NOT EXISTS {index_name} ON servers ({column})"
-                            )
+                        create_index_if_not_exists(
+                            conn,
+                            index_name=index_name,
+                            table="servers",
+                            columns=column,
                         )
                     except Exception:
                         pass

--- a/tests/unit/core/test_db_ddl.py
+++ b/tests/unit/core/test_db_ddl.py
@@ -1,0 +1,121 @@
+"""Tests for `app.core.db_ddl.create_index_if_not_exists` (Issue #412).
+
+The helper is the single choke point that all domain index migrations route
+through, so it must (a) create the requested index, (b) be idempotent, (c)
+handle composite columns, (d) quote reserved-word identifiers, and (e) reject
+any identifier that is not a plain SQL identifier *before* running SQL.
+"""
+
+import pytest
+from sqlalchemy import (
+    Column,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    text,
+)
+
+from app.core.db_ddl import create_index_if_not_exists
+
+metadata = MetaData()
+
+# Includes a reserved-word table name (`groups`) and a multi-column table so
+# composite-index and quoting behaviour can be exercised end to end.
+groups_table = Table(
+    "groups",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("owner_id", Integer),
+    Column("created_at", String(40)),
+)
+
+
+@pytest.fixture
+def conn():
+    engine = create_engine("sqlite:///:memory:")
+    metadata.create_all(engine)
+    connection = engine.connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+        engine.dispose()
+
+
+def _index_names(conn, table: str) -> set[str]:
+    rows = conn.execute(
+        text("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = :t"),
+        {"t": table},
+    ).fetchall()
+    return {row[0] for row in rows}
+
+
+def test_creates_single_column_index(conn):
+    create_index_if_not_exists(
+        conn, index_name="ix_groups_owner_id", table="groups", columns="owner_id"
+    )
+    assert "ix_groups_owner_id" in _index_names(conn, "groups")
+
+
+def test_is_idempotent(conn):
+    for _ in range(2):
+        create_index_if_not_exists(
+            conn, index_name="ix_groups_owner_id", table="groups", columns="owner_id"
+        )
+    assert "ix_groups_owner_id" in _index_names(conn, "groups")
+
+
+def test_composite_columns_from_comma_string(conn):
+    create_index_if_not_exists(
+        conn,
+        index_name="ix_groups_owner_created",
+        table="groups",
+        columns="owner_id, created_at",
+    )
+    assert "ix_groups_owner_created" in _index_names(conn, "groups")
+
+
+def test_composite_columns_from_iterable(conn):
+    create_index_if_not_exists(
+        conn,
+        index_name="ix_groups_created_owner",
+        table="groups",
+        columns=["created_at", "owner_id"],
+    )
+    assert "ix_groups_created_owner" in _index_names(conn, "groups")
+
+
+def test_reserved_word_table_is_quoted(conn):
+    """A reserved-word table name (`groups`) must not raise — it is quoted."""
+    create_index_if_not_exists(
+        conn, index_name="ix_groups_id", table="groups", columns="id"
+    )
+    assert "ix_groups_id" in _index_names(conn, "groups")
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"index_name": "ix); DROP TABLE groups;--", "table": "groups", "columns": "id"},
+        {"index_name": "ix_ok", "table": "groups) --", "columns": "id"},
+        {"index_name": "ix_ok", "table": "groups", "columns": "id); DROP TABLE x;--"},
+        {"index_name": "ix_ok", "table": "groups", "columns": "owner_id) --"},
+        {"index_name": "1bad", "table": "groups", "columns": "id"},
+        {"index_name": "ix_ok", "table": "", "columns": "id"},
+    ],
+)
+def test_rejects_unsafe_identifiers_before_executing(conn, kwargs):
+    before = _index_names(conn, "groups")
+    with pytest.raises(ValueError, match="Unsafe SQL identifier"):
+        create_index_if_not_exists(conn, **kwargs)
+    # Nothing was executed.
+    assert _index_names(conn, "groups") == before
+
+
+def test_rejects_empty_columns(conn):
+    with pytest.raises(ValueError):
+        create_index_if_not_exists(
+            conn, index_name="ix_ok", table="groups", columns=[]
+        )

--- a/tests/unit/core/test_db_ddl.py
+++ b/tests/unit/core/test_db_ddl.py
@@ -87,6 +87,17 @@ def test_composite_columns_from_iterable(conn):
     assert "ix_groups_created_owner" in _index_names(conn, "groups")
 
 
+def test_whitespace_around_identifiers_is_stripped(conn):
+    """Leading/trailing whitespace is stripped, not treated as invalid."""
+    create_index_if_not_exists(
+        conn,
+        index_name="  ix_groups_owner_ws  ",
+        table=" groups ",
+        columns=" owner_id , created_at ",
+    )
+    assert "ix_groups_owner_ws" in _index_names(conn, "groups")
+
+
 def test_reserved_word_table_is_quoted(conn):
     """A reserved-word table name (`groups`) must not raise — it is quoted."""
     create_index_if_not_exists(


### PR DESCRIPTION
## Summary

Domain startup migrations built `CREATE INDEX IF NOT EXISTS` DDL by raw f-string interpolation of table / index / column identifiers. The values are module-level constants today (no live injection vector), but the pattern is a SQL-injection footgun the moment any dynamic value reaches it, and identifiers cannot be passed as bound parameters. The consolidated review flagged it (P1 #6 / Section 2 High) for two files; the same pattern was present in six.

## Changes

- **New `app/core/db_ddl.py`** — `create_index_if_not_exists(conn, *, index_name, table, columns)`:
  - validates every identifier against `^[A-Za-z_][A-Za-z0-9_]*$`, raising `ValueError` **before** any SQL runs;
  - quotes each via the dialect's `identifier_preparer` (also fixes the reserved-word `groups` table reference);
  - accepts a single column, a comma-separated string (composite), or an iterable.
- **Routed all six migration loops through it** — `groups`, `audit` (single + composite), `auth`, `backups` (single + composite), `files`, `servers` (`migrate_server_indexes` + the index recreation inside `migrate_drop_templates`). Each migration keeps its existing per-index "log at WARNING and swallow" behaviour.
- **`tests/unit/core/test_db_ddl.py`** — creation, idempotency, composite (string + iterable), reserved-word quoting, and rejection of unsafe identifiers (asserting no SQL executes on rejection).

Out of scope: `migrate_drop_templates`' `CREATE TABLE servers_new (...)` is built from `PRAGMA table_info` (DB-reflected schema, not external input); only its index-recreation loop is converted.

## Verification

- New helper tests (12) + all six domains' existing migration tests pass — no behavioral regression.
- `ruff` (incl. unused-import check), `mypy` clean on all touched files.
- pre-commit + pre-push full unit + integration smoke passed.

Note: a pre-existing **flaky, unrelated** test (`test_get_forge_versions_success` makes a real HTTP call to the Forge API) tripped the first pre-push run; filed as #413. It passes in isolation and the re-run was green.

Resolves #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)
