### PR TITLE
fix: serialize Python booleans as lowercase for server.properties

### DIFF
--- a/app/servers/application/service.py
+++ b/app/servers/application/service.py
@@ -1177,7 +1177,12 @@ class ServerService:
             if custom_properties:
                 for key, value in custom_properties.items():
                     normalized_key = key.replace("_", "-")
-                    properties[normalized_key] = str(value)
+                    # Minecraft expects lowercase "true"/"false" for booleans,
+                    # not Python's "True"/"False" from str().
+                    if isinstance(value, bool):
+                        properties[normalized_key] = "true" if value else "false"
+                    else:
+                        properties[normalized_key] = str(value)
 
             with open(properties_path, "w", encoding="utf-8") as f:
                 f.write("#Minecraft server properties\n")

--- a/tests/unit/servers/application/test_server_service.py
+++ b/tests/unit/servers/application/test_server_service.py
@@ -465,3 +465,49 @@ class TestServerService:
         result = service.update_server_status(1, ServerStatus.running, db=mock_db_session)
 
         assert result is False
+
+    # Test _sync_server_properties_after_update boolean serialization
+    @pytest.mark.asyncio
+    async def test_sync_properties_boolean_lowercase(self, service, tmp_path):
+        """Test that Python booleans are serialized as lowercase 'true'/'false'
+        for Minecraft's server.properties parser (issue #417)."""
+        # Create a minimal server.properties file
+        props_file = tmp_path / "server.properties"
+        props_file.write_text("#Minecraft server properties\npvp=true\n")
+
+        server = Mock(spec=Server)
+        server.id = 1
+        server.port = 25565
+        server.max_players = 20
+        server.directory_path = str(tmp_path)
+
+        await service._sync_server_properties_after_update(
+            server, custom_properties={"pvp": False, "online_mode": True}
+        )
+
+        content = props_file.read_text()
+        assert "pvp=false" in content
+        assert "online-mode=true" in content
+        # Ensure Python-cased booleans are NOT written
+        assert "pvp=False" not in content
+        assert "online-mode=True" not in content
+
+    @pytest.mark.asyncio
+    async def test_sync_properties_non_boolean_values_unchanged(self, service, tmp_path):
+        """Test that non-boolean custom properties are still serialized with str()."""
+        props_file = tmp_path / "server.properties"
+        props_file.write_text("#Minecraft server properties\n")
+
+        server = Mock(spec=Server)
+        server.id = 1
+        server.port = 25565
+        server.max_players = 20
+        server.directory_path = str(tmp_path)
+
+        await service._sync_server_properties_after_update(
+            server, custom_properties={"level-name": "my-world", "max-players": 50}
+        )
+
+        content = props_file.read_text()
+        assert "level-name=my-world" in content
+        assert "max-players=50" in content


### PR DESCRIPTION
Fixes #417

## Problem
`PUT /api/v1/servers/{id}` with a boolean value in `server_properties` writes a Python-cased boolean (`False` / `True`) into `server.properties`, which Minecraft does not recognise. `str(False)` produces `"False"` but Minecraft expects `"false"`.

## Fix
Check `isinstance(value, bool)` before serialization and emit lowercase `"true"`/`"false"` for boolean values. Non-boolean values continue to use `str()`.

## Testing
- Added unit test `test_sync_properties_boolean_lowercase` — verifies `pvp: false` and `online_mode: true` are written as lowercase
- Added unit test `test_sync_properties_non_boolean_values_unchanged` — verifies string/int values still work correctly
- No Python-cased booleans (`False`/`True`) appear in output