### PR TITLE
Map Minecraft 26.x to Java 25 in compatibility matrix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ JAVA_8_PATH=
 JAVA_16_PATH=
 JAVA_17_PATH=
 JAVA_21_PATH=
+JAVA_25_PATH=
 
 # Additional Java discovery paths (comma-separated)
 JAVA_DISCOVERY_PATHS=
@@ -30,6 +31,7 @@ JAVA_DISCOVERY_PATHS=
 # JAVA_8_PATH=/usr/lib/jvm/java-8-openjdk/bin/java
 # JAVA_17_PATH=/usr/lib/jvm/java-17-openjdk/bin/java
 # JAVA_21_PATH=/usr/lib/jvm/java-21-openjdk/bin/java
+# JAVA_25_PATH=/usr/lib/jvm/java-25-openjdk/bin/java
 # JAVA_DISCOVERY_PATHS=/opt/java,/usr/local/java
 
 # Database configuration

--- a/.env.production.example
+++ b/.env.production.example
@@ -42,3 +42,4 @@ SQLALCHEMY_LOG_LEVEL=WARNING
 # JAVA_8_PATH=/usr/lib/jvm/java-8-openjdk/bin/java
 # JAVA_17_PATH=/usr/lib/jvm/java-17-openjdk/bin/java
 # JAVA_21_PATH=/usr/lib/jvm/java-21-openjdk/bin/java
+# JAVA_25_PATH=/usr/lib/jvm/java-25-openjdk/bin/java

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Java compatibility matrix now maps Minecraft 26.x and newer to Java 25
+  instead of silently selecting Java 21, and the unknown-version fallback
+  defaults to the newest known JRE rather than Java 21 (#415).
+
 ## [0.1.1] - 2026-05-28
 
 Aggregates 106 commits since v0.1.0. Centered on the staged migration to a

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A comprehensive FastAPI-based backend system for managing multiple Minecraft ser
    JAVA_16_PATH=/usr/lib/jvm/java-16-openjdk/bin/java
    JAVA_17_PATH=/usr/lib/jvm/java-17-openjdk/bin/java
    JAVA_21_PATH=/usr/lib/jvm/java-21-openjdk/bin/java
+   JAVA_25_PATH=/usr/lib/jvm/java-25-openjdk/bin/java
    JAVA_DISCOVERY_PATHS=/opt/java,/usr/local/java
 
    # All other knobs (DAEMON_*, DB_POOL_*, PASSWORD_*, BRUTE_FORCE_*,

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -170,6 +170,7 @@ class Settings(BaseSettings):
     JAVA_16_PATH: str = ""  # Direct path to Java 16 executable
     JAVA_17_PATH: str = ""  # Direct path to Java 17 executable
     JAVA_21_PATH: str = ""  # Direct path to Java 21 executable
+    JAVA_25_PATH: str = ""  # Direct path to Java 25 executable
 
     # Database configuration
     DATABASE_MAX_RETRIES: int = 3
@@ -758,6 +759,7 @@ class Settings(BaseSettings):
             16: self.JAVA_16_PATH,
             17: self.JAVA_17_PATH,
             21: self.JAVA_21_PATH,
+            25: self.JAVA_25_PATH,
         }
         path = java_paths.get(major_version, "")
         return path if path else None

--- a/app/versions/application/java_compatibility.py
+++ b/app/versions/application/java_compatibility.py
@@ -320,9 +320,24 @@ class JavaCompatibilityService:
                 if min_mc <= mc_version <= max_mc:
                     return required_java
 
-            # Default fallback for unknown versions: assume the newest known JRE
-            # rather than an older one, so an as-yet-unmapped major line is not
-            # launched with a Java runtime that is too old to load its server.jar.
+            # No band matched. Pick the fallback by where the version sits
+            # relative to the known bands: below the oldest band → the oldest
+            # JRE; otherwise (a future line above the newest band, or a gap) →
+            # the newest known JRE. This avoids launching a brand-new line with
+            # a runtime that is too old, while not over-shooting a pre-1.8 build
+            # to a JRE that is far too new.
+            bands = sorted(
+                self._compatibility_matrix.items(), key=lambda item: item[0][0]
+            )
+            oldest_min, _ = bands[0][0]
+            if mc_version < oldest_min:
+                oldest_java = bands[0][1]
+                logger.warning(
+                    f"Minecraft version {minecraft_version} predates the known "
+                    f"compatibility bands, defaulting to Java {oldest_java}"
+                )
+                return oldest_java
+
             newest_java = max(self._compatibility_matrix.values())
             logger.warning(
                 f"Unknown Minecraft version {minecraft_version}, "

--- a/app/versions/application/java_compatibility.py
+++ b/app/versions/application/java_compatibility.py
@@ -49,6 +49,11 @@ class JavaVersionInfo:
         """Check if this version is compatible with Java 21 requirements"""
         return self.major_version >= 21
 
+    @property
+    def is_compatible_with_java_25(self) -> bool:
+        """Check if this version is compatible with Java 25 requirements"""
+        return self.major_version >= 25
+
 
 class JavaCompatibilityService:
     """Service for Java version detection and Minecraft compatibility validation"""
@@ -63,8 +68,15 @@ class JavaCompatibilityService:
             (version.Version("1.17.0"), version.Version("1.17.1")): 16,
             # Minecraft 1.18 - 1.20: Java 17
             (version.Version("1.18.0"), version.Version("1.20.9")): 17,
-            # Minecraft 1.21+: Java 21
-            (version.Version("1.21.0"), version.Version("9999.99.99")): 21,
+            # Minecraft 1.21 up to (but excluding) the 26.x line: Java 21.
+            # The upper bound is closed deliberately so newer major lines that
+            # ship a JRE-25 (or later) server.jar are not silently absorbed
+            # here and launched with too old a Java runtime.
+            (version.Version("1.21.0"), version.Version("25.99.99")): 21,
+            # Minecraft 26.x and newer: Java 25. The 26.x vanilla server.jar is
+            # compiled for class file version 69.0 (Java 25) and aborts at JVM
+            # class-load time under Java 21.
+            (version.Version("26.0.0"), version.Version("9999.99.99")): 25,
         }
 
     async def discover_java_installations(self) -> Dict[int, JavaVersionInfo]:
@@ -72,7 +84,7 @@ class JavaCompatibilityService:
         java_installations = {}
 
         # Check configured paths first
-        for major_version in [8, 16, 17, 21]:
+        for major_version in [8, 16, 17, 21, 25]:
             configured_path = settings.get_java_path(major_version)
             if configured_path:
                 java_info = await self._detect_java_at_path(configured_path)
@@ -308,17 +320,21 @@ class JavaCompatibilityService:
                 if min_mc <= mc_version <= max_mc:
                     return required_java
 
-            # Default fallback for unknown versions
+            # Default fallback for unknown versions: assume the newest known JRE
+            # rather than an older one, so an as-yet-unmapped major line is not
+            # launched with a Java runtime that is too old to load its server.jar.
+            newest_java = max(self._compatibility_matrix.values())
             logger.warning(
-                f"Unknown Minecraft version {minecraft_version}, defaulting to Java 21"
+                f"Unknown Minecraft version {minecraft_version}, "
+                f"defaulting to Java {newest_java}"
             )
-            return 21
+            return newest_java
 
         except Exception as e:
             logger.error(
                 f"Error determining required Java version for {minecraft_version}: {e}"
             )
-            return 21
+            return max(self._compatibility_matrix.values())
 
     def validate_java_compatibility(
         self, minecraft_version: str, java_version: JavaVersionInfo
@@ -336,6 +352,8 @@ class JavaCompatibilityService:
                 compatible = java_version.is_compatible_with_java_17
             elif required_java == 21:
                 compatible = java_version.is_compatible_with_java_21
+            elif required_java == 25:
+                compatible = java_version.is_compatible_with_java_25
             else:
                 compatible = False
 
@@ -380,6 +398,8 @@ class JavaCompatibilityService:
                 message += "\n\nDownload Java 17: https://adoptium.net/temurin/releases/?version=17"
             elif required_java == 21:
                 message += "\n\nDownload Java 21: https://adoptium.net/temurin/releases/?version=21"
+            elif required_java == 25:
+                message += "\n\nDownload Java 25: https://adoptium.net/temurin/releases/?version=25"
 
         return message
 

--- a/deployment/docs/en/DEPLOYMENT.md
+++ b/deployment/docs/en/DEPLOYMENT.md
@@ -134,6 +134,7 @@ ENVIRONMENT=production
 JAVA_8_PATH=/usr/lib/jvm/java-8-openjdk-amd64/bin/java
 JAVA_17_PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin/java
 JAVA_21_PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin/java
+JAVA_25_PATH=/usr/lib/jvm/java-25-openjdk-amd64/bin/java
 
 # Logging
 LOG_LEVEL=INFO

--- a/docs/app/API_REFERENCE.md
+++ b/docs/app/API_REFERENCE.md
@@ -291,7 +291,8 @@ POST /servers/
 - Minecraft 1.8-1.16.5 requires Java 8
 - Minecraft 1.17 requires Java 16
 - Minecraft 1.18-1.20.x requires Java 17
-- Minecraft 1.21+ requires Java 21
+- Minecraft 1.21 - 25.x requires Java 21
+- Minecraft 26.x and newer requires Java 25
 
 **Error Response** (Java compatibility issues):
 ```json

--- a/docs/app/CONFIGURATION.md
+++ b/docs/app/CONFIGURATION.md
@@ -112,7 +112,7 @@ by default).
 | `KEEP_SERVERS_ON_SHUTDOWN` | `bool` | `True` (overlay-aware) | — |
 | `AUTO_SYNC_ON_STARTUP` | `bool` | `True` (overlay-aware) | — |
 | `JAVA_DISCOVERY_PATHS` | `str` | `""` | comma-separated paths |
-| `JAVA_8_PATH` … `JAVA_21_PATH` | `str` | `""` | direct path to `java` binary |
+| `JAVA_8_PATH` … `JAVA_25_PATH` | `str` | `""` | direct path to `java` binary |
 
 ### Daemon process settings (`DAEMON_*`)
 

--- a/docs/app/JAVA_COMPATIBILITY.md
+++ b/docs/app/JAVA_COMPATIBILITY.md
@@ -11,7 +11,8 @@ The system supports multiple Java versions to accommodate different Minecraft se
 - **Java 8**: Required for Minecraft 1.8 - 1.16.5
 - **Java 16**: Required for Minecraft 1.17
 - **Java 17**: Required for Minecraft 1.18 - 1.20.x
-- **Java 21**: Required for Minecraft 1.21+
+- **Java 21**: Required for Minecraft 1.21 up to (but excluding) the 26.x line
+- **Java 25**: Required for Minecraft 26.x and newer
 
 ## Java Version Detection
 
@@ -27,6 +28,7 @@ JAVA_8_PATH=/usr/lib/jvm/java-8-openjdk/bin/java
 JAVA_16_PATH=/usr/lib/jvm/java-16-openjdk/bin/java
 JAVA_17_PATH=/usr/lib/jvm/java-17-openjdk/bin/java
 JAVA_21_PATH=/usr/lib/jvm/java-21-openjdk/bin/java
+JAVA_25_PATH=/usr/lib/jvm/java-25-openjdk/bin/java
 
 # Additional discovery paths (comma-separated)
 JAVA_DISCOVERY_PATHS=/opt/java,/usr/local/java,/home/user/.sdkman/candidates/java
@@ -87,7 +89,8 @@ JAVA_DISCOVERY_PATHS=/home/user/.sdkman/candidates/java
 | 1.8 - 1.16.5      | Java 8        | Legacy versions |
 | 1.17              | Java 16       | First version requiring Java 16+ |
 | 1.18 - 1.20.x     | Java 17       | LTS Java version recommended |
-| 1.21+             | Java 21       | Latest versions require Java 21+ |
+| 1.21 - 25.x       | Java 21       | Requires Java 21+ |
+| 26.x+             | Java 25       | server.jar is compiled for Java 25 (class file version 69.0) |
 
 ## Server Creation Process
 

--- a/tests/unit/versions/application/test_java_compatibility.py
+++ b/tests/unit/versions/application/test_java_compatibility.py
@@ -54,6 +54,14 @@ class TestJavaVersionInfo:
         assert java17.is_compatible_with_java_21 is False
         assert java21.is_compatible_with_java_21 is True
 
+    def test_java_25_compatibility(self):
+        """Test Java 25+ compatibility checks"""
+        java21 = JavaVersionInfo(major_version=21, minor_version=0, patch_version=1)
+        java25 = JavaVersionInfo(major_version=25, minor_version=0, patch_version=1)
+
+        assert java21.is_compatible_with_java_25 is False
+        assert java25.is_compatible_with_java_25 is True
+
 
 class TestJavaCompatibilityService:
     """Test JavaCompatibilityService"""
@@ -79,14 +87,20 @@ class TestJavaCompatibilityService:
         assert service.get_required_java_version("1.19.4") == 17
         assert service.get_required_java_version("1.20.0") == 17
 
-        # Test Java 21 requirements (Minecraft 1.21+)
+        # Test Java 21 requirements (Minecraft 1.21 up to the 26.x line)
         assert service.get_required_java_version("1.21.0") == 21
         assert service.get_required_java_version("1.22.0") == 21
+        assert service.get_required_java_version("25.0.0") == 21
+
+        # Test Java 25 requirements (Minecraft 26.x and newer)
+        assert service.get_required_java_version("26.0.0") == 25
+        assert service.get_required_java_version("26.1.2") == 25
 
     def test_get_required_java_version_invalid(self, service):
         """Test getting required Java version for invalid Minecraft versions"""
-        # Should default to Java 21 for unknown versions
-        assert service.get_required_java_version("invalid") == 21
+        # Unparseable versions fall back to the newest known JRE (Java 25)
+        assert service.get_required_java_version("invalid") == 25
+        # 2.0.0 still falls inside the 1.21 .. 25.x band and maps to Java 21
         assert service.get_required_java_version("2.0.0") == 21
 
     def test_validate_java_compatibility_java_8(self, service):
@@ -135,11 +149,31 @@ class TestJavaCompatibilityService:
         """Test Java compatibility validation for Java 21 scenarios"""
         java21 = JavaVersionInfo(major_version=21, minor_version=0, patch_version=1)
 
-        # Java 21 should be compatible with Minecraft 1.21+
+        # Java 21 should be compatible with Minecraft 1.21 up to the 26.x line
         compatible, message = service.validate_java_compatibility("1.21.0", java21)
         assert compatible is True
 
         compatible, message = service.validate_java_compatibility("1.22.0", java21)
+        assert compatible is True
+
+        # Java 21 should NOT be compatible with Minecraft 26.x (requires Java 25)
+        compatible, message = service.validate_java_compatibility("26.1.2", java21)
+        assert compatible is False
+        assert "Java 25 or higher" in message
+
+    def test_validate_java_compatibility_java_25(self, service):
+        """Test Java compatibility validation for Java 25 scenarios"""
+        java25 = JavaVersionInfo(major_version=25, minor_version=0, patch_version=1)
+
+        # Java 25 should be compatible with Minecraft 26.x and newer
+        compatible, message = service.validate_java_compatibility("26.0.0", java25)
+        assert compatible is True
+
+        compatible, message = service.validate_java_compatibility("26.1.2", java25)
+        assert compatible is True
+
+        # Java 25 remains compatible with older lines that need an older JRE
+        compatible, message = service.validate_java_compatibility("1.21.0", java25)
         assert compatible is True
 
     def test_parse_java_version_modern_format(self, service):
@@ -198,12 +232,14 @@ class TestJavaCompatibilityService:
         assert 16 in java_versions
         assert 17 in java_versions
         assert 21 in java_versions
+        assert 25 in java_versions
 
     def test_get_supported_minecraft_versions(self, service):
         """Test getting supported Minecraft versions for Java version"""
         java8 = JavaVersionInfo(major_version=8, minor_version=0, patch_version=292)
         java17 = JavaVersionInfo(major_version=17, minor_version=0, patch_version=1)
         java21 = JavaVersionInfo(major_version=21, minor_version=0, patch_version=1)
+        java25 = JavaVersionInfo(major_version=25, minor_version=0, patch_version=1)
 
         # Java 8 should only support older Minecraft versions
         supported_8 = service.get_supported_minecraft_versions(java8)
@@ -213,9 +249,14 @@ class TestJavaCompatibilityService:
         supported_17 = service.get_supported_minecraft_versions(java17)
         assert len(supported_17) >= 2  # At least 1.17-1.17.1 and 1.18-1.20 ranges
 
-        # Java 21 should support all ranges
+        # Java 21 should support every range except the 26.x+ (Java 25) band
         supported_21 = service.get_supported_minecraft_versions(java21)
-        assert len(supported_21) >= 4  # All version ranges
+        assert len(supported_21) == 4
+
+        # Java 25 should support all ranges, including the 26.x+ band
+        supported_25 = service.get_supported_minecraft_versions(java25)
+        assert len(supported_25) == 5
+        assert any(entry.startswith("26") for entry in supported_25)
 
     @pytest.mark.asyncio
     async def test_detect_java_version_success(self, service):
@@ -412,7 +453,7 @@ class TestJavaCompatibilityServiceIntegration:
 
         # Should have entries for all major Java version requirements
         java_versions = set(matrix.values())
-        expected_versions = {8, 16, 17, 21}
+        expected_versions = {8, 16, 17, 21, 25}
 
         assert expected_versions.issubset(java_versions), (
             f"Missing Java versions: {expected_versions - java_versions}"
@@ -702,7 +743,7 @@ class TestJavaCompatibilityServiceMissingCoverage:
         with patch("packaging.version.Version", side_effect=Exception("Invalid version")):
             result = service.get_required_java_version("invalid-version-format")
 
-            assert result == 21  # Should fallback to Java 21
+            assert result == 25  # Should fall back to the newest known JRE
 
     def test_validate_java_compatibility_exception_handling(self, service):
         """Test exception handling in validate_java_compatibility (lines 352-354)"""
@@ -782,4 +823,11 @@ class TestJavaCompatibilityServiceMissingCoverage:
         assert (
             "Download Java 21: https://adoptium.net/temurin/releases/?version=21"
             in message21
+        )
+
+        # Test Java 25 download link (current is Java 8, required is 25)
+        message25 = service._generate_compatibility_error_message("26.1.2", 25, java8)
+        assert (
+            "Download Java 25: https://adoptium.net/temurin/releases/?version=25"
+            in message25
         )

--- a/tests/unit/versions/application/test_java_compatibility.py
+++ b/tests/unit/versions/application/test_java_compatibility.py
@@ -103,6 +103,13 @@ class TestJavaCompatibilityService:
         # 2.0.0 still falls inside the 1.21 .. 25.x band and maps to Java 21
         assert service.get_required_java_version("2.0.0") == 21
 
+    def test_get_required_java_version_below_oldest_band(self, service):
+        """Versions below the oldest known band fall back to the oldest JRE"""
+        # A pre-1.8 build should not be over-shot to the newest JRE; it maps to
+        # the oldest known requirement (Java 8) instead.
+        assert service.get_required_java_version("1.5.0") == 8
+        assert service.get_required_java_version("1.7.10") == 8
+
     def test_validate_java_compatibility_java_8(self, service):
         """Test Java compatibility validation for Java 8 scenarios"""
         java8 = JavaVersionInfo(major_version=8, minor_version=0, patch_version=292)


### PR DESCRIPTION
## Problem

The Java compatibility matrix mapped every Minecraft version `>= 1.21.0`
to Java 21 through an open-ended `1.21.0 .. 9999.99.99` band. The 26.x
line (e.g. vanilla `26.1.2`) ships a `server.jar` compiled for Java 25
(class file version 69.0), so a server created on the current `stable`
latest was launched with Java 21 and aborted at JVM class-load time with
`UnsupportedClassVersionError`. The unknown-version fallback had the same
flaw, defaulting to Java 21 rather than the newest known JRE.

## Changes

- Close the `1.21.0 .. 25.99.99` band so it no longer absorbs newer major
  lines, and add a `26.0.0+ -> Java 25` range to `_compatibility_matrix`.
- Add `JavaVersionInfo.is_compatible_with_java_25` plus the Java 25 branch
  in `validate_java_compatibility` and the download-link in the error
  message.
- Default the unknown-version fallback (and the exception path) to the
  newest known JRE in the matrix instead of a hardcoded Java 21.
- Wire `JAVA_25_PATH` through `config.get_java_path` and the discovery
  loop.
- Refresh docs (`JAVA_COMPATIBILITY.md`, `API_REFERENCE.md`,
  `CONFIGURATION.md`, `README.md`, deployment docs), env examples, and the
  changelog.
- Update and extend the unit tests covering the new range, the fallback,
  and the Java 25 validation/error paths.

## Testing

- `pytest tests/unit/versions/application/test_java_compatibility.py` —
  46 passed.
- Pre-commit and pre-push hooks pass (unit + integration smoke, ruff,
  mypy).

Resolves #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)