### PR TITLE
Pin Minecraft lines to specific Java runtimes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,9 @@ JAVA_CHECK_TIMEOUT=5
 
 # Java configuration for multi-version Minecraft server support
 # Configure specific Java paths for different versions
+JAVA_7_PATH=
 JAVA_8_PATH=
+JAVA_11_PATH=
 JAVA_16_PATH=
 JAVA_17_PATH=
 JAVA_21_PATH=
@@ -29,6 +31,7 @@ JAVA_DISCOVERY_PATHS=
 
 # Example Java configurations:
 # JAVA_8_PATH=/usr/lib/jvm/java-8-openjdk/bin/java
+# JAVA_11_PATH=/usr/lib/jvm/java-11-openjdk/bin/java
 # JAVA_17_PATH=/usr/lib/jvm/java-17-openjdk/bin/java
 # JAVA_21_PATH=/usr/lib/jvm/java-21-openjdk/bin/java
 # JAVA_25_PATH=/usr/lib/jvm/java-25-openjdk/bin/java

--- a/.env.production.example
+++ b/.env.production.example
@@ -40,6 +40,7 @@ SQLALCHEMY_LOG_LEVEL=WARNING
 
 # Java — set explicit paths in production to avoid PATH surprises.
 # JAVA_8_PATH=/usr/lib/jvm/java-8-openjdk/bin/java
+# JAVA_11_PATH=/usr/lib/jvm/java-11-openjdk/bin/java
 # JAVA_17_PATH=/usr/lib/jvm/java-17-openjdk/bin/java
 # JAVA_21_PATH=/usr/lib/jvm/java-21-openjdk/bin/java
 # JAVA_25_PATH=/usr/lib/jvm/java-25-openjdk/bin/java

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runtime and blocks a Java that is too old **or** too new, instead of
   treating "newest Java runs everything". Adds a Java 7 line (≤ 1.7.9) and a
   Java 11 fallback for 1.7.10 - 1.16.5, and wires `JAVA_7_PATH` /
-  `JAVA_11_PATH`. `get_compatibility_matrix()` now returns the accepted Java
-  list per band (#420).
+  `JAVA_11_PATH` (#420).
+  - **Operator note**: because the policy is exact-match, a host that only
+    has a newer-than-pinned JRE (e.g. only Java 21 for a 1.18 server) is now
+    **blocked** where it previously launched on the too-new runtime. Install
+    the JRE the line pins before upgrading.
+  - **Breaking (API response shape)**: `GET /java/compatibility` now reports
+    each band's accepted Java majors as a **list**
+    (`{"1.18.0 - 1.20.4": [17]}`) instead of a scalar
+    (`{"1.18.0 - 1.20.4": 17}`). Clients reading `compatibility_matrix`
+    values as a scalar must be updated.
 
 ### Fixed
 - Java compatibility matrix now maps Minecraft 26.x and newer to Java 25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Java routing now pins each Minecraft line to a specific accepted Java
+  runtime and blocks a Java that is too old **or** too new, instead of
+  treating "newest Java runs everything". Adds a Java 7 line (≤ 1.7.9) and a
+  Java 11 fallback for 1.7.10 - 1.16.5, and wires `JAVA_7_PATH` /
+  `JAVA_11_PATH`. `get_compatibility_matrix()` now returns the accepted Java
+  list per band (#420).
+
 ### Fixed
 - Java compatibility matrix now maps Minecraft 26.x and newer to Java 25
   instead of silently selecting Java 21, and the unknown-version fallback

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ A comprehensive FastAPI-based backend system for managing multiple Minecraft ser
    CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 
    # Java Configuration (Optional - for specific Java paths)
+   JAVA_7_PATH=/usr/lib/jvm/java-7-openjdk/bin/java
    JAVA_8_PATH=/usr/lib/jvm/java-8-openjdk/bin/java
+   JAVA_11_PATH=/usr/lib/jvm/java-11-openjdk/bin/java
    JAVA_16_PATH=/usr/lib/jvm/java-16-openjdk/bin/java
    JAVA_17_PATH=/usr/lib/jvm/java-17-openjdk/bin/java
    JAVA_21_PATH=/usr/lib/jvm/java-21-openjdk/bin/java

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -166,7 +166,9 @@ class Settings(BaseSettings):
     JAVA_DISCOVERY_PATHS: str = (
         ""  # Comma-separated paths to search for Java installations
     )
+    JAVA_7_PATH: str = ""  # Direct path to Java 7 executable
     JAVA_8_PATH: str = ""  # Direct path to Java 8 executable
+    JAVA_11_PATH: str = ""  # Direct path to Java 11 executable
     JAVA_16_PATH: str = ""  # Direct path to Java 16 executable
     JAVA_17_PATH: str = ""  # Direct path to Java 17 executable
     JAVA_21_PATH: str = ""  # Direct path to Java 21 executable
@@ -755,7 +757,9 @@ class Settings(BaseSettings):
     def get_java_path(self, major_version: int) -> Optional[str]:
         """Get configured Java path for specific major version"""
         java_paths = {
+            7: self.JAVA_7_PATH,
             8: self.JAVA_8_PATH,
+            11: self.JAVA_11_PATH,
             16: self.JAVA_16_PATH,
             17: self.JAVA_17_PATH,
             21: self.JAVA_21_PATH,

--- a/app/versions/application/java_compatibility.py
+++ b/app/versions/application/java_compatibility.py
@@ -93,9 +93,12 @@ class JavaCompatibilityService:
             (version.Version("1.18.0"), version.Version("1.20.4")): (17,),
             # Minecraft 1.20.5 - 1.21.11: Java 21
             (version.Version("1.20.5"), version.Version("1.21.11")): (21,),
-            # Minecraft 26.1+ : Java 25 (server.jar is compiled for class file
-            # version 69.0 and aborts at JVM class-load time under Java 21).
-            (version.Version("26.1.0"), version.Version("9999.99.99")): (25,),
+            # Minecraft 26.x and newer: Java 25 (server.jar is compiled for
+            # class file version 69.0 and aborts at JVM class-load time under
+            # Java 21). The cut starts at 26.0.0 — not 26.1.0 — so any 26.0.x
+            # release/snapshot still routes to Java 25 instead of regressing to
+            # the Java 21 band and crashing (see Issue #415 / PR #419).
+            (version.Version("26.0.0"), version.Version("9999.99.99")): (25,),
         }
 
     async def discover_java_installations(self) -> Dict[int, JavaVersionInfo]:
@@ -346,7 +349,7 @@ class JavaCompatibilityService:
             newest = bands[-1][1]
             logger.warning(
                 f"Unable to parse Minecraft version {minecraft_version} "
-                f"({e}); defaulting to Java {newest}"
+                f"({e}); defaulting to Java {self._format_accepted(newest)}"
             )
             return newest
 
@@ -361,10 +364,15 @@ class JavaCompatibilityService:
             chosen = bands[0][1]
             logger.warning(
                 f"Minecraft version {minecraft_version} is below the known "
-                f"compatibility bands; defaulting to Java {chosen}"
+                f"compatibility bands; defaulting to Java {self._format_accepted(chosen)}"
             )
 
         return chosen
+
+    @staticmethod
+    def _format_accepted(accepted: Tuple[int, ...]) -> str:
+        """Render an accepted-Java tuple for human-readable log/error output"""
+        return ", ".join(str(major) for major in accepted)
 
     def get_required_java_version(self, minecraft_version: str) -> int:
         """Get the primary (preferred) Java major version for a Minecraft version"""

--- a/app/versions/application/java_compatibility.py
+++ b/app/versions/application/java_compatibility.py
@@ -29,6 +29,10 @@ class JavaVersionInfo:
         """Get version as string (e.g., '17.0.1')"""
         return f"{self.major_version}.{self.minor_version}.{self.patch_version}"
 
+    # NOTE: these ``is_compatible_with_java_*`` helpers are convenience checks
+    # for callers/tests. They are NOT the source of truth for routing —
+    # ``JavaCompatibilityService`` matches the installed Java against each
+    # band's accepted set (see ``_compatibility_matrix``).
     @property
     def is_compatible_with_java_8(self) -> bool:
         """Check if this version is compatible with Java 8 requirements"""
@@ -60,23 +64,38 @@ class JavaCompatibilityService:
 
     def __init__(self, java_check_timeout: int = 10):
         self.java_check_timeout = java_check_timeout
-        # Java-Minecraft compatibility matrix based on official requirements
-        self._compatibility_matrix = {
-            # Minecraft 1.8 - 1.16.5: Java 8
-            (version.Version("1.8.0"), version.Version("1.16.5")): 8,
+        # Java-Minecraft compatibility matrix.
+        #
+        # Each band maps a Minecraft version range to an *ordered set of
+        # accepted Java majors* (index 0 is the primary/preferred runtime,
+        # later entries are fallbacks). The installed Java must be one of the
+        # accepted majors; anything else — too old OR too new — is rejected
+        # rather than silently launched (see Issue #420). Only the legacy
+        # 1.7.10-1.16.5 line accepts a fallback (Java 11) because those builds
+        # break on Java 16+; every other line pins a single runtime.
+        #
+        # The lower bound of each band is the authoritative cut point: a
+        # version is resolved to the band with the greatest ``min_mc`` that is
+        # still ``<= mc`` (see ``_resolve_accepted_java``), so gaps between the
+        # listed upper bounds never fall through. ``max_mc`` is kept only for
+        # human-readable output. The floor band uses ``Version("0")`` so every
+        # parseable version resolves to something.
+        self._compatibility_matrix: Dict[
+            Tuple[version.Version, version.Version], Tuple[int, ...]
+        ] = {
+            # Minecraft <= 1.7.9: Java 7
+            (version.Version("0"), version.Version("1.7.9")): (7,),
+            # Minecraft 1.7.10 - 1.16.5: Java 8 (Java 11 fallback)
+            (version.Version("1.7.10"), version.Version("1.16.5")): (8, 11),
             # Minecraft 1.17 - 1.17.1: Java 16
-            (version.Version("1.17.0"), version.Version("1.17.1")): 16,
-            # Minecraft 1.18 - 1.20: Java 17
-            (version.Version("1.18.0"), version.Version("1.20.9")): 17,
-            # Minecraft 1.21 up to (but excluding) the 26.x line: Java 21.
-            # The upper bound is closed deliberately so newer major lines that
-            # ship a JRE-25 (or later) server.jar are not silently absorbed
-            # here and launched with too old a Java runtime.
-            (version.Version("1.21.0"), version.Version("25.99.99")): 21,
-            # Minecraft 26.x and newer: Java 25. The 26.x vanilla server.jar is
-            # compiled for class file version 69.0 (Java 25) and aborts at JVM
-            # class-load time under Java 21.
-            (version.Version("26.0.0"), version.Version("9999.99.99")): 25,
+            (version.Version("1.17.0"), version.Version("1.17.1")): (16,),
+            # Minecraft 1.18 - 1.20.4: Java 17
+            (version.Version("1.18.0"), version.Version("1.20.4")): (17,),
+            # Minecraft 1.20.5 - 1.21.11: Java 21
+            (version.Version("1.20.5"), version.Version("1.21.11")): (21,),
+            # Minecraft 26.1+ : Java 25 (server.jar is compiled for class file
+            # version 69.0 and aborts at JVM class-load time under Java 21).
+            (version.Version("26.1.0"), version.Version("9999.99.99")): (25,),
         }
 
     async def discover_java_installations(self) -> Dict[int, JavaVersionInfo]:
@@ -84,7 +103,7 @@ class JavaCompatibilityService:
         java_installations = {}
 
         # Check configured paths first
-        for major_version in [8, 16, 17, 21, 25]:
+        for major_version in [7, 8, 11, 16, 17, 21, 25]:
             configured_path = settings.get_java_path(major_version)
             if configured_path:
                 java_info = await self._detect_java_at_path(configured_path)
@@ -118,20 +137,19 @@ class JavaCompatibilityService:
     async def get_java_for_minecraft(
         self, minecraft_version: str
     ) -> Optional[JavaVersionInfo]:
-        """Get appropriate Java installation for Minecraft version"""
-        required_java = self.get_required_java_version(minecraft_version)
+        """Get appropriate Java installation for Minecraft version.
+
+        Returns the first *accepted* Java major (in preference order) that is
+        actually installed. If none of the accepted majors is present the
+        caller is expected to block — we deliberately do not fall back to an
+        arbitrary newer runtime (Issue #420).
+        """
+        accepted_java = self._resolve_accepted_java(minecraft_version)
         installations = await self.discover_java_installations()
 
-        # Try exact match first
-        if required_java in installations:
-            return installations[required_java]
-
-        # Try compatible higher versions
-        compatible_versions = sorted(
-            [v for v in installations.keys() if v >= required_java]
-        )
-        if compatible_versions:
-            return installations[compatible_versions[0]]
+        for major in accepted_java:
+            if major in installations:
+                return installations[major]
 
         return None
 
@@ -311,88 +329,88 @@ class JavaCompatibilityService:
             logger.error(f"Error parsing Java version: {e}")
             return None
 
-    def get_required_java_version(self, minecraft_version: str) -> int:
-        """Get required Java major version for a Minecraft version"""
+    def _resolve_accepted_java(self, minecraft_version: str) -> Tuple[int, ...]:
+        """Resolve the ordered set of accepted Java majors for a version.
+
+        Picks the band with the greatest ``min_mc`` that is still ``<= mc``
+        (nearest-lower), so versions that fall in a gap between two listed
+        ranges resolve to the band just below them instead of dropping out.
+        On a parse error the newest band's tuple is returned so a brand-new,
+        not-yet-mapped line is not launched with an old runtime.
+        """
+        bands = sorted(self._compatibility_matrix.items(), key=lambda item: item[0][0])
+
         try:
             mc_version = version.Version(minecraft_version)
-
-            for (min_mc, max_mc), required_java in self._compatibility_matrix.items():
-                if min_mc <= mc_version <= max_mc:
-                    return required_java
-
-            # No band matched. Pick the fallback by where the version sits
-            # relative to the known bands: below the oldest band → the oldest
-            # JRE; otherwise (a future line above the newest band, or a gap) →
-            # the newest known JRE. This avoids launching a brand-new line with
-            # a runtime that is too old, while not over-shooting a pre-1.8 build
-            # to a JRE that is far too new.
-            bands = sorted(
-                self._compatibility_matrix.items(), key=lambda item: item[0][0]
-            )
-            oldest_min, _ = bands[0][0]
-            if mc_version < oldest_min:
-                oldest_java = bands[0][1]
-                logger.warning(
-                    f"Minecraft version {minecraft_version} predates the known "
-                    f"compatibility bands, defaulting to Java {oldest_java}"
-                )
-                return oldest_java
-
-            newest_java = max(self._compatibility_matrix.values())
-            logger.warning(
-                f"Unknown Minecraft version {minecraft_version}, "
-                f"defaulting to Java {newest_java}"
-            )
-            return newest_java
-
         except Exception as e:
-            logger.error(
-                f"Error determining required Java version for {minecraft_version}: {e}"
+            newest = bands[-1][1]
+            logger.warning(
+                f"Unable to parse Minecraft version {minecraft_version} "
+                f"({e}); defaulting to Java {newest}"
             )
-            return max(self._compatibility_matrix.values())
+            return newest
+
+        chosen: Optional[Tuple[int, ...]] = None
+        for (min_mc, _max_mc), accepted in bands:
+            if min_mc <= mc_version:
+                chosen = accepted
+
+        if chosen is None:
+            # Defensive: the floor band starts at Version("0"), so a parseable
+            # version always matches at least one band.
+            chosen = bands[0][1]
+            logger.warning(
+                f"Minecraft version {minecraft_version} is below the known "
+                f"compatibility bands; defaulting to Java {chosen}"
+            )
+
+        return chosen
+
+    def get_required_java_version(self, minecraft_version: str) -> int:
+        """Get the primary (preferred) Java major version for a Minecraft version"""
+        return self._resolve_accepted_java(minecraft_version)[0]
+
+    def get_compatible_java_versions(self, minecraft_version: str) -> Tuple[int, ...]:
+        """Get the ordered set of Java majors accepted for a Minecraft version"""
+        return self._resolve_accepted_java(minecraft_version)
 
     def validate_java_compatibility(
         self, minecraft_version: str, java_version: JavaVersionInfo
     ) -> Tuple[bool, str]:
         """Validate Java version compatibility with Minecraft version"""
         try:
-            required_java = self.get_required_java_version(minecraft_version)
+            accepted_java = self._resolve_accepted_java(minecraft_version)
 
-            # Check if installed Java meets requirements
-            if required_java == 8:
-                compatible = java_version.is_compatible_with_java_8
-            elif required_java == 16:
-                compatible = java_version.is_compatible_with_java_16
-            elif required_java == 17:
-                compatible = java_version.is_compatible_with_java_17
-            elif required_java == 21:
-                compatible = java_version.is_compatible_with_java_21
-            elif required_java == 25:
-                compatible = java_version.is_compatible_with_java_25
-            else:
-                compatible = False
-
-            if compatible:
+            # Exact-match policy: the installed Java must be one of the
+            # accepted majors. Anything else — too old or too new — is
+            # rejected so the caller blocks instead of launching a runtime
+            # that may crash or silently misbehave (Issue #420).
+            if java_version.major_version in accepted_java:
                 return (
                     True,
-                    f"Java {java_version.major_version} is compatible with Minecraft {minecraft_version}",
+                    f"Java {java_version.major_version} is compatible with "
+                    f"Minecraft {minecraft_version}",
                 )
-            else:
-                return False, self._generate_compatibility_error_message(
-                    minecraft_version, required_java, java_version
-                )
+
+            return False, self._generate_compatibility_error_message(
+                minecraft_version, accepted_java, java_version
+            )
 
         except Exception as e:
             logger.error(f"Error validating Java compatibility: {e}")
             return False, f"Failed to validate Java compatibility: {e}"
 
     def _generate_compatibility_error_message(
-        self, minecraft_version: str, required_java: int, java_version: JavaVersionInfo
+        self,
+        minecraft_version: str,
+        accepted_java: Tuple[int, ...],
+        java_version: JavaVersionInfo,
     ) -> str:
         """Generate user-friendly error message for compatibility issues"""
+        accepted_str = " or ".join(f"Java {major}" for major in accepted_java)
         message = (
             f"Java version incompatibility detected:\n"
-            f"  • Minecraft {minecraft_version} requires Java {required_java} or higher\n"
+            f"  • Minecraft {minecraft_version} requires {accepted_str}\n"
             f"  • Currently installed: Java {java_version.major_version} "
             f"({java_version.version_string})"
         )
@@ -400,50 +418,60 @@ class JavaCompatibilityService:
         if java_version.vendor:
             message += f" [{java_version.vendor}]"
 
-        # Add specific guidance based on the version gap
-        if java_version.major_version < required_java:
-            message += f"\n\nPlease install Java {required_java} or higher to run this Minecraft version."
+        message += f"\n\nPlease install {accepted_str} to run this Minecraft version."
 
-            # Add helpful links for Java installation
-            if required_java == 8:
-                message += "\n\nDownload Java 8: https://adoptium.net/temurin/releases/?version=8"
-            elif required_java == 16:
-                message += "\n\nDownload Java 16: https://adoptium.net/temurin/releases/?version=16"
-            elif required_java == 17:
-                message += "\n\nDownload Java 17: https://adoptium.net/temurin/releases/?version=17"
-            elif required_java == 21:
-                message += "\n\nDownload Java 21: https://adoptium.net/temurin/releases/?version=21"
-            elif required_java == 25:
-                message += "\n\nDownload Java 25: https://adoptium.net/temurin/releases/?version=25"
+        # Add a helpful install link for the primary (preferred) runtime.
+        primary_java = accepted_java[0]
+        download_links = {
+            8: "https://adoptium.net/temurin/releases/?version=8",
+            11: "https://adoptium.net/temurin/releases/?version=11",
+            16: "https://adoptium.net/temurin/releases/?version=16",
+            17: "https://adoptium.net/temurin/releases/?version=17",
+            21: "https://adoptium.net/temurin/releases/?version=21",
+            25: "https://adoptium.net/temurin/releases/?version=25",
+        }
+        if primary_java in download_links:
+            message += f"\n\nDownload Java {primary_java}: {download_links[primary_java]}"
+        elif primary_java == 7:
+            message += (
+                "\n\nJava 7 is end-of-life; obtain it from a legacy "
+                "distribution (Adoptium does not publish Java 7 builds)."
+            )
 
         return message
 
-    def get_compatibility_matrix(self) -> Dict[str, int]:
-        """Get human-readable compatibility matrix"""
+    def _format_version_range(
+        self, min_version: version.Version, max_version: version.Version
+    ) -> str:
+        """Render a band's Minecraft range for human-readable output"""
+        if max_version.major >= 9999:  # Open-ended (newest line)
+            return f"{min_version}+"
+        if min_version <= version.Version("0"):  # Floor band
+            return f"<= {max_version}"
+        return f"{min_version} - {max_version}"
+
+    def get_compatibility_matrix(self) -> Dict[str, List[int]]:
+        """Get human-readable compatibility matrix.
+
+        Maps each Minecraft version range to the ordered list of accepted
+        Java majors (first entry is the preferred runtime).
+        """
         matrix = {}
-        for (
-            min_version,
-            max_version,
-        ), java_version in self._compatibility_matrix.items():
-            version_range = f"{min_version} - {max_version}"
-            if max_version.major >= 9999:  # Handle open-ended ranges
-                version_range = f"{min_version}+"
-            matrix[version_range] = java_version
+        for (min_version, max_version), accepted in self._compatibility_matrix.items():
+            version_range = self._format_version_range(min_version, max_version)
+            matrix[version_range] = list(accepted)
 
         return matrix
 
     def get_supported_minecraft_versions(
         self, java_version: JavaVersionInfo
     ) -> List[str]:
-        """Get list of Minecraft versions supported by a Java version"""
+        """Get list of Minecraft version ranges supported by a Java version"""
         supported_versions = []
 
-        for (min_mc, max_mc), required_java in self._compatibility_matrix.items():
-            if java_version.major_version >= required_java:
-                if max_mc.major >= 9999:
-                    supported_versions.append(f"{min_mc}+")
-                else:
-                    supported_versions.append(f"{min_mc} - {max_mc}")
+        for (min_mc, max_mc), accepted in self._compatibility_matrix.items():
+            if java_version.major_version in accepted:
+                supported_versions.append(self._format_version_range(min_mc, max_mc))
 
         return supported_versions
 

--- a/deployment/docs/en/DEPLOYMENT.md
+++ b/deployment/docs/en/DEPLOYMENT.md
@@ -132,6 +132,7 @@ ENVIRONMENT=production
 
 # Java Paths (auto-detected if not specified)
 JAVA_8_PATH=/usr/lib/jvm/java-8-openjdk-amd64/bin/java
+JAVA_11_PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin/java
 JAVA_17_PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin/java
 JAVA_21_PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin/java
 JAVA_25_PATH=/usr/lib/jvm/java-25-openjdk-amd64/bin/java

--- a/docs/app/API_REFERENCE.md
+++ b/docs/app/API_REFERENCE.md
@@ -287,12 +287,13 @@ POST /servers/
 }
 ```
 
-**Java Compatibility**: The system automatically validates and selects the appropriate Java version based on the Minecraft version:
-- Minecraft 1.8-1.16.5 requires Java 8
-- Minecraft 1.17 requires Java 16
-- Minecraft 1.18-1.20.x requires Java 17
-- Minecraft 1.21 - 25.x requires Java 21
-- Minecraft 26.x and newer requires Java 25
+**Java Compatibility**: The system pins each Minecraft line to a specific Java runtime and rejects a Java that is too old **or** too new:
+- Minecraft ≤ 1.7.9 requires Java 7 (best-effort; officially unsupported)
+- Minecraft 1.7.10-1.16.5 requires Java 8 (Java 11 used as a fallback)
+- Minecraft 1.17-1.17.1 requires Java 16
+- Minecraft 1.18-1.20.4 requires Java 17
+- Minecraft 1.20.5-1.21.11 requires Java 21
+- Minecraft 26.1 and newer requires Java 25
 
 **Error Response** (Java compatibility issues):
 ```json

--- a/docs/app/API_REFERENCE.md
+++ b/docs/app/API_REFERENCE.md
@@ -293,7 +293,7 @@ POST /servers/
 - Minecraft 1.17-1.17.1 requires Java 16
 - Minecraft 1.18-1.20.4 requires Java 17
 - Minecraft 1.20.5-1.21.11 requires Java 21
-- Minecraft 26.1 and newer requires Java 25
+- Minecraft 26.x and newer requires Java 25
 
 **Error Response** (Java compatibility issues):
 ```json

--- a/docs/app/CONFIGURATION.md
+++ b/docs/app/CONFIGURATION.md
@@ -112,7 +112,7 @@ by default).
 | `KEEP_SERVERS_ON_SHUTDOWN` | `bool` | `True` (overlay-aware) | — |
 | `AUTO_SYNC_ON_STARTUP` | `bool` | `True` (overlay-aware) | — |
 | `JAVA_DISCOVERY_PATHS` | `str` | `""` | comma-separated paths |
-| `JAVA_8_PATH` … `JAVA_25_PATH` | `str` | `""` | direct path to `java` binary |
+| `JAVA_7_PATH` … `JAVA_25_PATH` | `str` | `""` | direct path to `java` binary (7, 8, 11, 16, 17, 21, 25) |
 
 ### Daemon process settings (`DAEMON_*`)
 

--- a/docs/app/JAVA_COMPATIBILITY.md
+++ b/docs/app/JAVA_COMPATIBILITY.md
@@ -16,7 +16,7 @@ is too old **or** too new is rejected rather than launched (see
 - **Java 16**: Minecraft 1.17 - 1.17.1
 - **Java 17**: Minecraft 1.18 - 1.20.4
 - **Java 21**: Minecraft 1.20.5 - 1.21.11
-- **Java 25**: Minecraft 26.1 and newer
+- **Java 25**: Minecraft 26.x and newer
 
 ## Java Version Detection
 
@@ -97,7 +97,7 @@ JAVA_DISCOVERY_PATHS=/home/user/.sdkman/candidates/java
 | 1.17 - 1.17.1     | Java 16       | First line requiring Java 16 |
 | 1.18 - 1.20.4     | Java 17       | LTS Java version |
 | 1.20.5 - 1.21.11  | Java 21       | Java 21 line |
-| 26.1+             | Java 25       | server.jar is compiled for Java 25 (class file version 69.0) |
+| 26.x+ (from 26.0) | Java 25       | server.jar is compiled for Java 25 (class file version 69.0); the cut starts at 26.0 so no 26.0.x build is ever launched on Java 21 |
 
 ## Compatibility model
 

--- a/docs/app/JAVA_COMPATIBILITY.md
+++ b/docs/app/JAVA_COMPATIBILITY.md
@@ -6,13 +6,17 @@ The Minecraft Server Dashboard API includes a comprehensive Java version compati
 
 ## Supported Java Versions
 
-The system supports multiple Java versions to accommodate different Minecraft server requirements:
+The system pins each Minecraft line to a specific Java runtime. The
+installed Java must match the accepted runtime for that line — a Java that
+is too old **or** too new is rejected rather than launched (see
+[Compatibility model](#compatibility-model) below):
 
-- **Java 8**: Required for Minecraft 1.8 - 1.16.5
-- **Java 16**: Required for Minecraft 1.17
-- **Java 17**: Required for Minecraft 1.18 - 1.20.x
-- **Java 21**: Required for Minecraft 1.21 up to (but excluding) the 26.x line
-- **Java 25**: Required for Minecraft 26.x and newer
+- **Java 7**: Minecraft 1.7.9 and below (best-effort; officially unsupported)
+- **Java 8** (or **Java 11** as a fallback): Minecraft 1.7.10 - 1.16.5
+- **Java 16**: Minecraft 1.17 - 1.17.1
+- **Java 17**: Minecraft 1.18 - 1.20.4
+- **Java 21**: Minecraft 1.20.5 - 1.21.11
+- **Java 25**: Minecraft 26.1 and newer
 
 ## Java Version Detection
 
@@ -24,7 +28,9 @@ Configure specific Java paths in your `.env` file:
 
 ```env
 # Java Configuration
+JAVA_7_PATH=/usr/lib/jvm/java-7-openjdk/bin/java
 JAVA_8_PATH=/usr/lib/jvm/java-8-openjdk/bin/java
+JAVA_11_PATH=/usr/lib/jvm/java-11-openjdk/bin/java
 JAVA_16_PATH=/usr/lib/jvm/java-16-openjdk/bin/java
 JAVA_17_PATH=/usr/lib/jvm/java-17-openjdk/bin/java
 JAVA_21_PATH=/usr/lib/jvm/java-21-openjdk/bin/java
@@ -84,13 +90,31 @@ JAVA_DISCOVERY_PATHS=/home/user/.sdkman/candidates/java
 
 ## Minecraft Version Compatibility Matrix
 
-| Minecraft Version | Required Java | Notes |
+| Minecraft Version | Accepted Java | Notes |
 |-------------------|---------------|-------|
-| 1.8 - 1.16.5      | Java 8        | Legacy versions |
-| 1.17              | Java 16       | First version requiring Java 16+ |
-| 1.18 - 1.20.x     | Java 17       | LTS Java version recommended |
-| 1.21 - 25.x       | Java 21       | Requires Java 21+ |
-| 26.x+             | Java 25       | server.jar is compiled for Java 25 (class file version 69.0) |
+| ≤ 1.7.9           | Java 7        | Best-effort; officially unsupported |
+| 1.7.10 - 1.16.5   | Java 8, or Java 11 | Java 8 preferred; Java 11 used when Java 8 is absent |
+| 1.17 - 1.17.1     | Java 16       | First line requiring Java 16 |
+| 1.18 - 1.20.4     | Java 17       | LTS Java version |
+| 1.20.5 - 1.21.11  | Java 21       | Java 21 line |
+| 26.1+             | Java 25       | server.jar is compiled for Java 25 (class file version 69.0) |
+
+## Compatibility model
+
+Each Minecraft line accepts a fixed set of Java majors (the table above).
+The installed Java must be **in** that set, otherwise server creation/start
+is blocked with an actionable error:
+
+- A Java that is **too old** would crash at JVM class-load time
+  (`UnsupportedClassVersionError`).
+- A Java that is **too new** is also rejected — older Minecraft builds break
+  on newer JREs, so the dashboard will not silently launch them on, say,
+  Java 25. Install the Java the line expects instead.
+
+Only the legacy `1.7.10 - 1.16.5` line accepts a fallback (Java 11) because
+those builds run on both Java 8 and 11; every other line pins a single Java.
+Versions that fall in a gap between two listed ranges resolve to the line
+just below them.
 
 ## Server Creation Process
 

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -482,13 +482,13 @@ class TestGetJavaPath:
         assert result == "/usr/lib/jvm/java-17-openjdk/bin/java"
 
     def test_get_java_path_unsupported_version(self):
-        """Test get_java_path for unsupported Java version"""
+        """Test get_java_path for an unmapped Java version"""
         settings = Settings(
             SECRET_KEY="this-is-a-very-secure-secret-key-with-sufficient-length",
             DATABASE_URL="sqlite:///test.db",
         )
 
-        result = settings.get_java_path(11)  # Unsupported version
+        result = settings.get_java_path(99)  # Unsupported version
         assert result is None
 
     def test_get_java_path_empty_path(self):
@@ -507,16 +507,22 @@ class TestGetJavaPath:
         settings = Settings(
             SECRET_KEY="this-is-a-very-secure-secret-key-with-sufficient-length",
             DATABASE_URL="sqlite:///test.db",
+            JAVA_7_PATH="/java7",
             JAVA_8_PATH="/java8",
+            JAVA_11_PATH="/java11",
             JAVA_16_PATH="/java16",
             JAVA_17_PATH="/java17",
             JAVA_21_PATH="/java21",
+            JAVA_25_PATH="/java25",
         )
 
+        assert settings.get_java_path(7) == "/java7"
         assert settings.get_java_path(8) == "/java8"
+        assert settings.get_java_path(11) == "/java11"
         assert settings.get_java_path(16) == "/java16"
         assert settings.get_java_path(17) == "/java17"
         assert settings.get_java_path(21) == "/java21"
+        assert settings.get_java_path(25) == "/java25"
 
 
 class TestSettingsDefaults:

--- a/tests/unit/versions/application/test_java_compatibility.py
+++ b/tests/unit/versions/application/test_java_compatibility.py
@@ -72,116 +72,159 @@ class TestJavaCompatibilityService:
         return JavaCompatibilityService(java_check_timeout=5)
 
     def test_get_required_java_version(self, service):
-        """Test getting required Java version for Minecraft versions"""
-        # Test Java 8 requirements (Minecraft 1.8 - 1.16.5)
-        assert service.get_required_java_version("1.8.0") == 8
+        """Test getting the primary required Java version for Minecraft versions"""
+        # Java 7 (Minecraft <= 1.7.9)
+        assert service.get_required_java_version("1.5.0") == 7
+        assert service.get_required_java_version("1.7.9") == 7
+
+        # Java 8 (Minecraft 1.7.10 - 1.16.5); primary of the (8, 11) band
+        assert service.get_required_java_version("1.7.10") == 8
         assert service.get_required_java_version("1.12.2") == 8
         assert service.get_required_java_version("1.16.5") == 8
 
-        # Test Java 16 requirements (Minecraft 1.17 - 1.17.1)
+        # Java 16 (Minecraft 1.17 - 1.17.1)
         assert service.get_required_java_version("1.17.0") == 16
         assert service.get_required_java_version("1.17.1") == 16
 
-        # Test Java 17 requirements (Minecraft 1.18 - 1.20)
+        # Java 17 (Minecraft 1.18 - 1.20.4)
         assert service.get_required_java_version("1.18.0") == 17
         assert service.get_required_java_version("1.19.4") == 17
-        assert service.get_required_java_version("1.20.0") == 17
+        assert service.get_required_java_version("1.20.4") == 17
 
-        # Test Java 21 requirements (Minecraft 1.21 up to the 26.x line)
+        # Java 21 (Minecraft 1.20.5 - 1.21.11)
+        assert service.get_required_java_version("1.20.5") == 21
         assert service.get_required_java_version("1.21.0") == 21
-        assert service.get_required_java_version("1.22.0") == 21
-        assert service.get_required_java_version("25.0.0") == 21
+        assert service.get_required_java_version("1.21.11") == 21
 
-        # Test Java 25 requirements (Minecraft 26.x and newer)
-        assert service.get_required_java_version("26.0.0") == 25
+        # Java 25 (Minecraft 26.1+)
+        assert service.get_required_java_version("26.1.0") == 25
         assert service.get_required_java_version("26.1.2") == 25
+        assert service.get_required_java_version("27.0.0") == 25
+
+    def test_get_compatible_java_versions(self, service):
+        """The legacy band exposes its Java 11 fallback; others are single."""
+        assert service.get_compatible_java_versions("1.16.5") == (8, 11)
+        assert service.get_compatible_java_versions("1.5.0") == (7,)
+        assert service.get_compatible_java_versions("1.18.0") == (17,)
+        assert service.get_compatible_java_versions("26.1.2") == (25,)
 
     def test_get_required_java_version_invalid(self, service):
         """Test getting required Java version for invalid Minecraft versions"""
-        # Unparseable versions fall back to the newest known JRE (Java 25)
+        # Unparseable versions fall back to the newest known band (Java 25)
         assert service.get_required_java_version("invalid") == 25
-        # 2.0.0 still falls inside the 1.21 .. 25.x band and maps to Java 21
+        # 2.0.0 resolves (nearest-lower) to the 1.20.5 - 1.21.11 band → Java 21
         assert service.get_required_java_version("2.0.0") == 21
 
-    def test_get_required_java_version_below_oldest_band(self, service):
-        """Versions below the oldest known band fall back to the oldest JRE"""
-        # A pre-1.8 build should not be over-shot to the newest JRE; it maps to
-        # the oldest known requirement (Java 8) instead.
-        assert service.get_required_java_version("1.5.0") == 8
-        assert service.get_required_java_version("1.7.10") == 8
+    def test_get_required_java_version_gap_resolves_to_nearest_lower(self, service):
+        """A version in a gap between bands resolves to the band just below."""
+        # 1.16.8 does not exist but, if seen, must not jump to a newer JRE;
+        # nearest-lower keeps it on the 1.7.10 - 1.16.5 (Java 8) band.
+        assert service.get_required_java_version("1.16.8") == 8
+        # 26.0.x sits below the 26.1 cut-over and stays on the Java 21 band.
+        assert service.get_required_java_version("26.0.5") == 21
 
     def test_validate_java_compatibility_java_8(self, service):
         """Test Java compatibility validation for Java 8 scenarios"""
         java8 = JavaVersionInfo(major_version=8, minor_version=0, patch_version=292)
 
-        # Java 8 should be compatible with Minecraft 1.8-1.16.5
-        compatible, message = service.validate_java_compatibility("1.8.0", java8)
+        # Java 8 is accepted for Minecraft 1.7.10 - 1.16.5
+        compatible, message = service.validate_java_compatibility("1.7.10", java8)
         assert compatible is True
         assert "compatible" in message.lower()
 
         compatible, message = service.validate_java_compatibility("1.16.5", java8)
         assert compatible is True
 
-        # Java 8 should NOT be compatible with Minecraft 1.17+
+        # Java 8 is NOT accepted for Minecraft 1.17+ (requires Java 16)
         compatible, message = service.validate_java_compatibility("1.17.0", java8)
         assert compatible is False
         assert "incompatibility" in message.lower()
-        assert "Java 16 or higher" in message
+        assert "requires Java 16" in message
+
+    def test_validate_java_compatibility_java_11_fallback(self, service):
+        """Java 11 is the accepted fallback for the legacy 1.7.10 - 1.16.5 band."""
+        java11 = JavaVersionInfo(major_version=11, minor_version=0, patch_version=2)
+
+        compatible, _ = service.validate_java_compatibility("1.12.2", java11)
+        assert compatible is True
+
+        compatible, _ = service.validate_java_compatibility("1.16.5", java11)
+        assert compatible is True
+
+        # Java 11 is not accepted outside the legacy band.
+        compatible, message = service.validate_java_compatibility("1.18.0", java11)
+        assert compatible is False
+        assert "requires Java 17" in message
 
     def test_validate_java_compatibility_java_17(self, service):
-        """Test Java compatibility validation for Java 17 scenarios"""
+        """Test Java compatibility validation for Java 17 scenarios (exact match)"""
         java17 = JavaVersionInfo(
             major_version=17, minor_version=0, patch_version=1, vendor="OpenJDK"
         )
 
-        # Java 17 should be compatible with Minecraft 1.17+ (not 1.8-1.16.5 due to newer version)
-        compatible, message = service.validate_java_compatibility("1.8.0", java17)
-        assert compatible is False  # Java 17 is too new for Minecraft 1.8
+        # Too new for the old bands → rejected (blocks).
+        compatible, _ = service.validate_java_compatibility("1.16.5", java17)
+        assert compatible is False
 
+        # Java 17 is exactly the requirement for 1.18 - 1.20.4.
+        compatible, _ = service.validate_java_compatibility("1.18.0", java17)
+        assert compatible is True
+
+        compatible, _ = service.validate_java_compatibility("1.20.4", java17)
+        assert compatible is True
+
+        # Exact match means 1.17 (Java 16 only) rejects Java 17.
         compatible, message = service.validate_java_compatibility("1.17.0", java17)
-        assert compatible is True
+        assert compatible is False
+        assert "requires Java 16" in message
 
-        compatible, message = service.validate_java_compatibility("1.18.0", java17)
-        assert compatible is True
-
-        compatible, message = service.validate_java_compatibility("1.20.0", java17)
-        assert compatible is True
-
-        # Java 17 should NOT be compatible with Minecraft 1.21+ (requires Java 21)
+        # And 1.21 (Java 21 only) rejects Java 17.
         compatible, message = service.validate_java_compatibility("1.21.0", java17)
         assert compatible is False
-        assert "Java 21 or higher" in message
+        assert "requires Java 21" in message
 
     def test_validate_java_compatibility_java_21(self, service):
         """Test Java compatibility validation for Java 21 scenarios"""
         java21 = JavaVersionInfo(major_version=21, minor_version=0, patch_version=1)
 
-        # Java 21 should be compatible with Minecraft 1.21 up to the 26.x line
-        compatible, message = service.validate_java_compatibility("1.21.0", java21)
+        # Java 21 is accepted for Minecraft 1.20.5 - 1.21.11
+        compatible, _ = service.validate_java_compatibility("1.20.5", java21)
         assert compatible is True
 
-        compatible, message = service.validate_java_compatibility("1.22.0", java21)
+        compatible, _ = service.validate_java_compatibility("1.21.0", java21)
         assert compatible is True
 
-        # Java 21 should NOT be compatible with Minecraft 26.x (requires Java 25)
+        # Java 21 is NOT accepted for Minecraft 26.1+ (requires Java 25)
         compatible, message = service.validate_java_compatibility("26.1.2", java21)
         assert compatible is False
-        assert "Java 25 or higher" in message
+        assert "requires Java 25" in message
 
     def test_validate_java_compatibility_java_25(self, service):
-        """Test Java compatibility validation for Java 25 scenarios"""
+        """Test Java compatibility validation for Java 25 scenarios (exact match)"""
         java25 = JavaVersionInfo(major_version=25, minor_version=0, patch_version=1)
 
-        # Java 25 should be compatible with Minecraft 26.x and newer
-        compatible, message = service.validate_java_compatibility("26.0.0", java25)
+        # Java 25 is accepted for Minecraft 26.1 and newer
+        compatible, _ = service.validate_java_compatibility("26.1.0", java25)
         assert compatible is True
 
-        compatible, message = service.validate_java_compatibility("26.1.2", java25)
+        compatible, _ = service.validate_java_compatibility("26.1.2", java25)
         assert compatible is True
 
-        # Java 25 remains compatible with older lines that need an older JRE
+        # Exact match: Java 25 is too new for the 1.21 (Java 21) band → blocked.
         compatible, message = service.validate_java_compatibility("1.21.0", java25)
+        assert compatible is False
+        assert "requires Java 21" in message
+
+    def test_validate_java_compatibility_java_7(self, service):
+        """Java 7 is accepted only for the <= 1.7.9 band."""
+        java7 = JavaVersionInfo(major_version=7, minor_version=0, patch_version=80)
+
+        compatible, _ = service.validate_java_compatibility("1.7.9", java7)
         assert compatible is True
+
+        compatible, message = service.validate_java_compatibility("1.7.10", java7)
+        assert compatible is False
+        assert "requires Java 8 or Java 11" in message
 
     def test_parse_java_version_modern_format(self, service):
         """Test parsing modern Java version format (Java 9+)"""
@@ -233,37 +276,32 @@ class TestJavaCompatibilityService:
         assert isinstance(matrix, dict)
         assert len(matrix) > 0
 
-        # Check for expected Java versions
-        java_versions = list(matrix.values())
-        assert 8 in java_versions
-        assert 16 in java_versions
-        assert 17 in java_versions
-        assert 21 in java_versions
-        assert 25 in java_versions
+        # Values are the ordered list of accepted Java majors per band.
+        all_majors = {major for accepted in matrix.values() for major in accepted}
+        assert {7, 8, 11, 16, 17, 21, 25}.issubset(all_majors)
+
+        # The legacy band lists Java 8 then its Java 11 fallback.
+        assert matrix["1.7.10 - 1.16.5"] == [8, 11]
+        # Floor and open-ended bands get special labels.
+        assert matrix["<= 1.7.9"] == [7]
+        assert matrix["26.1.0+"] == [25]
 
     def test_get_supported_minecraft_versions(self, service):
-        """Test getting supported Minecraft versions for Java version"""
+        """Each Java major supports exactly the bands that accept it."""
+        java7 = JavaVersionInfo(major_version=7, minor_version=0, patch_version=80)
         java8 = JavaVersionInfo(major_version=8, minor_version=0, patch_version=292)
+        java11 = JavaVersionInfo(major_version=11, minor_version=0, patch_version=2)
         java17 = JavaVersionInfo(major_version=17, minor_version=0, patch_version=1)
         java21 = JavaVersionInfo(major_version=21, minor_version=0, patch_version=1)
         java25 = JavaVersionInfo(major_version=25, minor_version=0, patch_version=1)
 
-        # Java 8 should only support older Minecraft versions
-        supported_8 = service.get_supported_minecraft_versions(java8)
-        assert len(supported_8) == 1  # Only the 1.8-1.16.5 range
-
-        # Java 17 should support more ranges
-        supported_17 = service.get_supported_minecraft_versions(java17)
-        assert len(supported_17) >= 2  # At least 1.17-1.17.1 and 1.18-1.20 ranges
-
-        # Java 21 should support every range except the 26.x+ (Java 25) band
-        supported_21 = service.get_supported_minecraft_versions(java21)
-        assert len(supported_21) == 4
-
-        # Java 25 should support all ranges, including the 26.x+ band
-        supported_25 = service.get_supported_minecraft_versions(java25)
-        assert len(supported_25) == 5
-        assert any(entry.startswith("26") for entry in supported_25)
+        assert service.get_supported_minecraft_versions(java7) == ["<= 1.7.9"]
+        # Both Java 8 and its Java 11 fallback cover the legacy band only.
+        assert service.get_supported_minecraft_versions(java8) == ["1.7.10 - 1.16.5"]
+        assert service.get_supported_minecraft_versions(java11) == ["1.7.10 - 1.16.5"]
+        assert service.get_supported_minecraft_versions(java17) == ["1.18.0 - 1.20.4"]
+        assert service.get_supported_minecraft_versions(java21) == ["1.20.5 - 1.21.11"]
+        assert service.get_supported_minecraft_versions(java25) == ["26.1.0+"]
 
     @pytest.mark.asyncio
     async def test_detect_java_version_success(self, service):
@@ -379,29 +417,58 @@ class TestJavaCompatibilityService:
 
             mock_discover.return_value = {8: java8, 17: java17, 21: java21}
 
-            # Test exact match
+            # Accepted major installed → returned
             result = await service.get_java_for_minecraft("1.8.9")
             assert result == java8
 
-            # Test compatible higher version
+            # 1.17 accepts only Java 16, which is not installed → None (block)
             result = await service.get_java_for_minecraft("1.17.1")
-            assert result.major_version >= 16
+            assert result is None
 
-            # Test latest requirements
+            # 1.18 - 1.20.4 accepts exactly Java 17
+            result = await service.get_java_for_minecraft("1.18.0")
+            assert result == java17
+
+            # 1.20.5 - 1.21.11 accepts exactly Java 21
             result = await service.get_java_for_minecraft("1.21.0")
             assert result == java21
 
     @pytest.mark.asyncio
+    async def test_get_java_for_minecraft_prefers_primary_then_fallback(self, service):
+        """The legacy band selects Java 8 first, then falls back to Java 11."""
+        with patch.object(service, "discover_java_installations") as mock_discover:
+            java8 = JavaVersionInfo(8, 0, 292, "OpenJDK", "", "/jvm/8/bin/java")
+            java11 = JavaVersionInfo(11, 0, 2, "OpenJDK", "", "/jvm/11/bin/java")
+
+            # Both present → Java 8 (primary) wins.
+            mock_discover.return_value = {8: java8, 11: java11}
+            result = await service.get_java_for_minecraft("1.16.5")
+            assert result == java8
+
+            # Only the Java 11 fallback present → it is used.
+            mock_discover.return_value = {11: java11}
+            result = await service.get_java_for_minecraft("1.16.5")
+            assert result == java11
+
+    @pytest.mark.asyncio
     async def test_get_java_for_minecraft_no_compatible(self, service):
-        """Test getting Java when no compatible version is available"""
+        """Test getting Java when no accepted version is installed"""
         with patch.object(service, "discover_java_installations") as mock_discover:
             java8 = JavaVersionInfo(
                 8, 0, 292, "OpenJDK", "", "/usr/lib/jvm/java-8/bin/java"
             )
             mock_discover.return_value = {8: java8}
 
-            # Test requiring newer Java than available
+            # 1.21 requires Java 21 (not installed); no fall-through to a newer
+            # runtime → None (caller blocks).
             result = await service.get_java_for_minecraft("1.21.0")
+            assert result is None
+
+            # A too-new-only host is also rejected: 1.16.5 needs Java 8 or 11.
+            mock_discover.return_value = {
+                25: JavaVersionInfo(25, 0, 0, "OpenJDK", "", "/jvm/25/bin/java")
+            }
+            result = await service.get_java_for_minecraft("1.16.5")
             assert result is None
 
     def test_find_java_executable(self, service):
@@ -459,8 +526,8 @@ class TestJavaCompatibilityServiceIntegration:
         matrix = java_compatibility_service.get_compatibility_matrix()
 
         # Should have entries for all major Java version requirements
-        java_versions = set(matrix.values())
-        expected_versions = {8, 16, 17, 21, 25}
+        java_versions = {major for accepted in matrix.values() for major in accepted}
+        expected_versions = {7, 8, 11, 16, 17, 21, 25}
 
         assert expected_versions.issubset(java_versions), (
             f"Missing Java versions: {expected_versions - java_versions}"
@@ -745,20 +812,19 @@ class TestJavaCompatibilityServiceMissingCoverage:
             assert result is None
 
     def test_get_required_java_version_exception_handling(self, service):
-        """Test exception handling in get_required_java_version (lines 312-315)"""
-        # Mock version parsing to raise exception
+        """An unparseable version falls back to the newest band (Java 25)."""
         with patch("packaging.version.Version", side_effect=Exception("Invalid version")):
             result = service.get_required_java_version("invalid-version-format")
 
             assert result == 25  # Should fall back to the newest known JRE
 
     def test_validate_java_compatibility_exception_handling(self, service):
-        """Test exception handling in validate_java_compatibility (lines 352-354)"""
+        """Test exception handling in validate_java_compatibility"""
         java17 = JavaVersionInfo(17, 0, 1)
 
-        # Mock get_required_java_version to raise exception
+        # Mock the resolver to raise; validate must degrade gracefully.
         with patch.object(
-            service, "get_required_java_version", side_effect=Exception("Version error")
+            service, "_resolve_accepted_java", side_effect=Exception("Version error")
         ):
             compatible, message = service.validate_java_compatibility("1.18.0", java17)
 
@@ -767,74 +833,58 @@ class TestJavaCompatibilityServiceMissingCoverage:
             assert "Version error" in message
 
     def test_validate_java_compatibility_internal_exception(self, service):
-        """Test internal exception in validate_java_compatibility (line 340).
+        """Test the ``except`` branch in validate_java_compatibility.
 
-        Previously this test patched ``builtins.getattr`` globally to force an
-        exception inside the body of ``validate_java_compatibility``. That is
-        catastrophic under pytest-xdist: ``getattr`` is invoked from countless
-        framework call sites (pytest, asyncio, logging, traceback rendering),
-        and the mock raising at one of those sites recursed indefinitely
-        inside the error-reporting machinery, killing the worker with
-        ``RecursionError`` and hanging CI (see PR #333 review follow-up).
-
-        The narrower replacement makes the ``java_version`` argument itself
-        raise from one of the ``is_compatible_with_java_*`` properties the
-        service consults, which exercises the same ``except Exception``
-        branch without poisoning the global namespace.
+        The narrow trigger makes the ``java_version`` argument raise from its
+        ``major_version`` access (which the ``in accepted`` membership test
+        reads), exercising the ``except Exception`` branch without patching a
+        global like ``getattr`` (see PR #333 review follow-up).
         """
 
         class _BoomVersion:
-            major_version = 17
-
             @property
-            def is_compatible_with_java_17(self) -> bool:
+            def major_version(self) -> int:
                 raise RuntimeError("Internal error")
 
-        with patch.object(service, "get_required_java_version", return_value=17):
-            compatible, message = service.validate_java_compatibility(
-                "1.18.0", _BoomVersion()
-            )
+        compatible, message = service.validate_java_compatibility(
+            "1.18.0", _BoomVersion()
+        )
 
-            assert compatible is False
-            assert "Failed to validate Java compatibility" in message
-            assert "Internal error" in message
+        assert compatible is False
+        assert "Failed to validate Java compatibility" in message
+        assert "Internal error" in message
 
-    def test_generate_compatibility_error_message_all_java_versions(self, service):
-        """Test error message generation for all Java versions (lines 376, 380, 381->384)"""
-        java7 = JavaVersionInfo(7, 0, 80, "OpenJDK")  # Lower than Java 8
+    def test_generate_compatibility_error_message_download_links(self, service):
+        """The error message lists accepted Java and links the primary runtime."""
+        java25 = JavaVersionInfo(25, 0, 0, "OpenJDK")
         java8 = JavaVersionInfo(8, 0, 292, "OpenJDK")
 
-        # Test Java 8 download link (current is Java 7, required is 8)
-        message8 = service._generate_compatibility_error_message("1.8.0", 8, java7)
-        assert (
-            "Download Java 8: https://adoptium.net/temurin/releases/?version=8"
-            in message8
-        )
-
-        # Test Java 16 download link (current is Java 8, required is 16)
-        message16 = service._generate_compatibility_error_message("1.17.0", 16, java8)
-        assert (
-            "Download Java 16: https://adoptium.net/temurin/releases/?version=16"
-            in message16
-        )
-
-        # Test Java 17 download link (current is Java 8, required is 17)
-        message17 = service._generate_compatibility_error_message("1.18.0", 17, java8)
+        # Single-major bands link their primary runtime.
+        message17 = service._generate_compatibility_error_message("1.18.0", (17,), java25)
+        assert "requires Java 17" in message17
         assert (
             "Download Java 17: https://adoptium.net/temurin/releases/?version=17"
             in message17
         )
 
-        # Test Java 21 download link (current is Java 8, required is 21)
-        message21 = service._generate_compatibility_error_message("1.21.0", 21, java8)
-        assert (
-            "Download Java 21: https://adoptium.net/temurin/releases/?version=21"
-            in message21
-        )
-
-        # Test Java 25 download link (current is Java 8, required is 25)
-        message25 = service._generate_compatibility_error_message("26.1.2", 25, java8)
+        message25 = service._generate_compatibility_error_message("26.1.2", (25,), java8)
         assert (
             "Download Java 25: https://adoptium.net/temurin/releases/?version=25"
             in message25
         )
+
+        # The legacy band lists both accepted majors and links the primary (8).
+        message_legacy = service._generate_compatibility_error_message(
+            "1.16.5", (8, 11), java25
+        )
+        assert "requires Java 8 or Java 11" in message_legacy
+        assert (
+            "Download Java 8: https://adoptium.net/temurin/releases/?version=8"
+            in message_legacy
+        )
+
+        # Java 7 is end-of-life: no Adoptium link, but a clear note instead.
+        message7 = service._generate_compatibility_error_message("1.5.0", (7,), java8)
+        assert "requires Java 7" in message7
+        assert "end-of-life" in message7
+        assert "adoptium.net" not in message7

--- a/tests/unit/versions/application/test_java_compatibility.py
+++ b/tests/unit/versions/application/test_java_compatibility.py
@@ -96,8 +96,9 @@ class TestJavaCompatibilityService:
         assert service.get_required_java_version("1.21.0") == 21
         assert service.get_required_java_version("1.21.11") == 21
 
-        # Java 25 (Minecraft 26.1+)
-        assert service.get_required_java_version("26.1.0") == 25
+        # Java 25 (Minecraft 26.x and newer; the cut is 26.0.0 so no 26.0.x
+        # release can regress to the Java 21 band and crash — see #415/#419)
+        assert service.get_required_java_version("26.0.0") == 25
         assert service.get_required_java_version("26.1.2") == 25
         assert service.get_required_java_version("27.0.0") == 25
 
@@ -120,8 +121,12 @@ class TestJavaCompatibilityService:
         # 1.16.8 does not exist but, if seen, must not jump to a newer JRE;
         # nearest-lower keeps it on the 1.7.10 - 1.16.5 (Java 8) band.
         assert service.get_required_java_version("1.16.8") == 8
-        # 26.0.x sits below the 26.1 cut-over and stays on the Java 21 band.
-        assert service.get_required_java_version("26.0.5") == 21
+        # The speculative 1.22.0 - 25.x window stays on the Java 21 band...
+        assert service.get_required_java_version("1.22.0") == 21
+        assert service.get_required_java_version("25.0.0") == 21
+        # ...but the entire 26.x line (incl. 26.0.x) routes to Java 25, so a
+        # class-file-69 server.jar is never launched on Java 21 (#415/#419).
+        assert service.get_required_java_version("26.0.5") == 25
 
     def test_validate_java_compatibility_java_8(self, service):
         """Test Java compatibility validation for Java 8 scenarios"""
@@ -203,8 +208,8 @@ class TestJavaCompatibilityService:
         """Test Java compatibility validation for Java 25 scenarios (exact match)"""
         java25 = JavaVersionInfo(major_version=25, minor_version=0, patch_version=1)
 
-        # Java 25 is accepted for Minecraft 26.1 and newer
-        compatible, _ = service.validate_java_compatibility("26.1.0", java25)
+        # Java 25 is accepted from the very start of the 26.x line (26.0.0)
+        compatible, _ = service.validate_java_compatibility("26.0.0", java25)
         assert compatible is True
 
         compatible, _ = service.validate_java_compatibility("26.1.2", java25)
@@ -284,7 +289,7 @@ class TestJavaCompatibilityService:
         assert matrix["1.7.10 - 1.16.5"] == [8, 11]
         # Floor and open-ended bands get special labels.
         assert matrix["<= 1.7.9"] == [7]
-        assert matrix["26.1.0+"] == [25]
+        assert matrix["26.0.0+"] == [25]
 
     def test_get_supported_minecraft_versions(self, service):
         """Each Java major supports exactly the bands that accept it."""
@@ -301,7 +306,7 @@ class TestJavaCompatibilityService:
         assert service.get_supported_minecraft_versions(java11) == ["1.7.10 - 1.16.5"]
         assert service.get_supported_minecraft_versions(java17) == ["1.18.0 - 1.20.4"]
         assert service.get_supported_minecraft_versions(java21) == ["1.20.5 - 1.21.11"]
-        assert service.get_supported_minecraft_versions(java25) == ["26.1.0+"]
+        assert service.get_supported_minecraft_versions(java25) == ["26.0.0+"]
 
     @pytest.mark.asyncio
     async def test_detect_java_version_success(self, service):


### PR DESCRIPTION
## Context

Follow-up to #415 (PR #419). Its review surfaced that Java routing only
encoded a **minimum** JRE per Minecraft band (`is_compatible_with_java_*`
were all `major >= N`), so the model treated "newest Java runs everything":
an old line could be launched on a far newer JRE, and pre-`1.7.10` builds
had no entry at all.

## Decision (agreed with maintainer)

Each Minecraft line is pinned to an **exact set of accepted Java majors**.
The installed Java must be in that set — too old **or** too new is rejected
(blocked), not launched. Only the legacy line keeps a fallback.

| Minecraft line     | Accepted Java |
|--------------------|---------------|
| ≤ 1.7.9            | 7 (best-effort, unsupported) |
| 1.7.10 - 1.16.5    | 8, then 11 (fallback) |
| 1.17 - 1.17.1      | 16 |
| 1.18 - 1.20.4      | 17 |
| 1.20.5 - 1.21.11   | 21 |
| 26.1+              | 25 |

## Changes

- `app/versions/application/java_compatibility.py`: matrix value is now an
  ordered accepted-Java tuple. New `_resolve_accepted_java` (gap-free
  nearest-lower resolution), `get_compatible_java_versions`. Exact-match
  `validate_java_compatibility` (blocks both directions); preference-order
  selection in `get_java_for_minecraft` (no fall-through to a newer JRE).
  `get_compatibility_matrix()` returns the accepted list per band. Error
  message lists the accepted majors and links the primary (Java 7 noted as
  end-of-life).
- `app/core/config.py`: add `JAVA_7_PATH` / `JAVA_11_PATH`; discovery loop is
  `[7, 8, 11, 16, 17, 21, 25]`.
- Tests: reworked `test_java_compatibility.py` and `test_config.py` for the
  new bands, exact-match validation, the Java 11 fallback, gap resolution,
  and matrix/supported-version shapes.
- Docs/examples: `JAVA_COMPATIBILITY.md` (new matrix + "Compatibility model"
  section), `API_REFERENCE.md`, `CONFIGURATION.md`, `README.md`, env
  examples, deployment doc, `CHANGELOG.md`.

## Testing

- `pytest tests/unit -m "not slow"` — 1528 passed, 5 skipped.
- Pre-commit and pre-push hooks pass (unit + integration smoke, ruff, mypy).

Resolves #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)