### PR TITLE
Remove unused is_compatible_with_java_* helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (`{"1.18.0 - 1.20.4": 17}`). Clients reading `compatibility_matrix`
     values as a scalar must be updated.
 
+### Removed
+- Dropped the unused `JavaVersionInfo.is_compatible_with_java_*` helper
+  properties. They were superseded by the accepted-set routing in #420 and
+  had inconsistent semantics (`== 8` vs `>= N`); nothing in production
+  referenced them (#423).
+
 ### Fixed
 - Java compatibility matrix now maps Minecraft 26.x and newer to Java 25
   instead of silently selecting Java 21, and the unknown-version fallback

--- a/app/versions/application/java_compatibility.py
+++ b/app/versions/application/java_compatibility.py
@@ -29,35 +29,6 @@ class JavaVersionInfo:
         """Get version as string (e.g., '17.0.1')"""
         return f"{self.major_version}.{self.minor_version}.{self.patch_version}"
 
-    # NOTE: these ``is_compatible_with_java_*`` helpers are convenience checks
-    # for callers/tests. They are NOT the source of truth for routing —
-    # ``JavaCompatibilityService`` matches the installed Java against each
-    # band's accepted set (see ``_compatibility_matrix``).
-    @property
-    def is_compatible_with_java_8(self) -> bool:
-        """Check if this version is compatible with Java 8 requirements"""
-        return self.major_version == 8
-
-    @property
-    def is_compatible_with_java_16(self) -> bool:
-        """Check if this version is compatible with Java 16 requirements"""
-        return self.major_version >= 16
-
-    @property
-    def is_compatible_with_java_17(self) -> bool:
-        """Check if this version is compatible with Java 17 requirements"""
-        return self.major_version >= 17
-
-    @property
-    def is_compatible_with_java_21(self) -> bool:
-        """Check if this version is compatible with Java 21 requirements"""
-        return self.major_version >= 21
-
-    @property
-    def is_compatible_with_java_25(self) -> bool:
-        """Check if this version is compatible with Java 25 requirements"""
-        return self.major_version >= 25
-
 
 class JavaCompatibilityService:
     """Service for Java version detection and Minecraft compatibility validation"""

--- a/tests/unit/versions/application/test_java_compatibility.py
+++ b/tests/unit/versions/application/test_java_compatibility.py
@@ -18,50 +18,6 @@ class TestJavaVersionInfo:
         java_info = JavaVersionInfo(major_version=17, minor_version=0, patch_version=1)
         assert java_info.version_string == "17.0.1"
 
-    def test_java_8_compatibility(self):
-        """Test Java 8 compatibility checks"""
-        java8 = JavaVersionInfo(major_version=8, minor_version=0, patch_version=292)
-        java17 = JavaVersionInfo(major_version=17, minor_version=0, patch_version=1)
-
-        assert java8.is_compatible_with_java_8 is True
-        assert java17.is_compatible_with_java_8 is False
-
-    def test_java_16_compatibility(self):
-        """Test Java 16+ compatibility checks"""
-        java8 = JavaVersionInfo(major_version=8, minor_version=0, patch_version=292)
-        java16 = JavaVersionInfo(major_version=16, minor_version=0, patch_version=1)
-        java17 = JavaVersionInfo(major_version=17, minor_version=0, patch_version=1)
-
-        assert java8.is_compatible_with_java_16 is False
-        assert java16.is_compatible_with_java_16 is True
-        assert java17.is_compatible_with_java_16 is True
-
-    def test_java_17_compatibility(self):
-        """Test Java 17+ compatibility checks"""
-        java8 = JavaVersionInfo(major_version=8, minor_version=0, patch_version=292)
-        java16 = JavaVersionInfo(major_version=16, minor_version=0, patch_version=1)
-        java17 = JavaVersionInfo(major_version=17, minor_version=0, patch_version=1)
-
-        assert java8.is_compatible_with_java_17 is False
-        assert java16.is_compatible_with_java_17 is False
-        assert java17.is_compatible_with_java_17 is True
-
-    def test_java_21_compatibility(self):
-        """Test Java 21+ compatibility checks"""
-        java17 = JavaVersionInfo(major_version=17, minor_version=0, patch_version=1)
-        java21 = JavaVersionInfo(major_version=21, minor_version=0, patch_version=1)
-
-        assert java17.is_compatible_with_java_21 is False
-        assert java21.is_compatible_with_java_21 is True
-
-    def test_java_25_compatibility(self):
-        """Test Java 25+ compatibility checks"""
-        java21 = JavaVersionInfo(major_version=21, minor_version=0, patch_version=1)
-        java25 = JavaVersionInfo(major_version=25, minor_version=0, patch_version=1)
-
-        assert java21.is_compatible_with_java_25 is False
-        assert java25.is_compatible_with_java_25 is True
-
 
 class TestJavaCompatibilityService:
     """Test JavaCompatibilityService"""


### PR DESCRIPTION
## Context

Follow-up to #420 (raised in the PR #422 review). After Java routing moved
to the accepted-set model, the `JavaVersionInfo.is_compatible_with_java_*`
properties became dead code: nothing in production referenced them, only
their own unit tests did. They were also semantically inconsistent —
`is_compatible_with_java_8` was `major == 8` while `_16/_17/_21/_25` were
`major >= N` — which is misleading to a future reader.

## Changes

- Remove the five `is_compatible_with_java_*` properties from
  `JavaVersionInfo` (and the now-redundant NOTE comment).
- Remove the five corresponding unit tests in `test_java_compatibility.py`.
- CHANGELOG: note the removal under Unreleased.

Routing behavior is unchanged — `JavaCompatibilityService` already matches
the installed Java against each band's accepted set.

## Testing

- `pytest tests/unit/versions/application/test_java_compatibility.py` —
  46 passed.
- Pre-commit and pre-push hooks pass.

Resolves #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)