### PR TITLE
Normalize booleans to lowercase in server properties update path

### DIFF
--- a/app/servers/application/service.py
+++ b/app/servers/application/service.py
@@ -1177,7 +1177,10 @@ class ServerService:
             if custom_properties:
                 for key, value in custom_properties.items():
                     normalized_key = key.replace("_", "-")
-                    properties[normalized_key] = str(value)
+                    if isinstance(value, bool):
+                        properties[normalized_key] = str(value).lower()
+                    else:
+                        properties[normalized_key] = str(value)
 
             with open(properties_path, "w", encoding="utf-8") as f:
                 f.write("#Minecraft server properties\n")

--- a/tests/unit/servers/test_service.py
+++ b/tests/unit/servers/test_service.py
@@ -435,6 +435,45 @@ class TestServerService:
         with pytest.raises(RuntimeError, match="vanished between validation and delete"):
             await service.delete_server(99, mock_db)
 
+    @pytest.mark.asyncio
+    async def test_sync_server_properties_after_update_boolean_values(
+        self, server_service, tmp_path
+    ):
+        """Booleans in custom_properties are written as lowercase Java literals."""
+        props_file = tmp_path / "server.properties"
+        props_file.write_text(
+            "#Minecraft server properties\nserver-port=25565\npvp=true\n"
+        )
+
+        server = Mock(spec=Server)
+        server.id = 1
+        server.directory_path = str(tmp_path)
+        server.port = 25565
+        server.max_players = 20
+
+        await server_service._sync_server_properties_after_update(
+            server,
+            custom_properties={
+                "pvp": False,
+                "enable_command_block": True,
+                "view_distance": 12,
+                "motd": "Hello",
+            },
+        )
+
+        written = {}
+        for line in props_file.read_text().splitlines():
+            if line and not line.startswith("#") and "=" in line:
+                k, v = line.split("=", 1)
+                written[k] = v
+
+        assert written["pvp"] == "false"
+        assert written["enable-command-block"] == "true"
+        assert written["view-distance"] == "12"
+        assert written["motd"] == "Hello"
+        assert written["server-port"] == "25565"
+        assert written["max-players"] == "20"
+
 
 class TestServerValidationServiceExtended:
     """Additional tests for ServerValidationService methods"""


### PR DESCRIPTION
## Summary

- Fix `_sync_server_properties_after_update` in `service.py` to write Java-cased booleans (`true`/`false`) instead of Python-cased (`True`/`False`) into `server.properties`.
- Add test covering boolean, numeric, and string value serialization through the update path.

Resolves #417

## Test plan

- [x] New unit test `test_sync_server_properties_after_update_boolean_values` asserts `pvp=false`, `enable-command-block=true`, and correct handling of non-boolean values.
- [x] Full unit suite passes (1524 passed).
- [x] Pre-commit hooks pass (ruff, mypy, pytest smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)