### PR TITLE
Fix GET /servers/{id}/logs to return newest lines non-destructively

### DIFF
--- a/app/servers/application/minecraft/manager.py
+++ b/app/servers/application/minecraft/manager.py
@@ -9,6 +9,7 @@ preflight, monitoring) and adds the public manager surface
 import asyncio
 import inspect
 import os
+from collections import deque
 from datetime import datetime
 from pathlib import Path
 from typing import (
@@ -325,12 +326,14 @@ class MinecraftServerManager(
 
             # Create server process tracking (without process object for daemon)
             log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=self.log_queue_size)
+            log_buffer: deque = deque(maxlen=self.log_queue_size)
             server_process = ServerProcess(
                 server_id=server.id,
                 process=None,  # No process object for daemon processes
                 log_queue=log_queue,
                 status=ServerStatus.starting,
                 started_at=datetime.now(),
+                log_buffer=log_buffer,
                 pid=daemon_pid,
                 server_directory=server_dir,  # Store correct directory path for monitoring
                 rcon_port=rcon_port,  # Store RCON configuration
@@ -569,22 +572,15 @@ class MinecraftServerManager(
         }
 
     async def get_server_logs(self, server_id: int, lines: int = 100) -> List[str]:
-        """Get recent server logs"""
+        """Get recent server logs (most-recent *lines* entries)."""
         if server_id not in self.processes:
             return []
 
         server_process = self.processes[server_id]
-        logs = []
-
-        # Get logs from queue (non-blocking)
-        for _ in range(min(lines, server_process.log_queue.qsize())):
-            try:
-                log_line = server_process.log_queue.get_nowait()
-                logs.append(log_line)
-            except asyncio.QueueEmpty:
-                break
-
-        return logs
+        buf = server_process.log_buffer
+        if len(buf) <= lines:
+            return list(buf)
+        return list(buf)[-lines:]
 
     async def stream_server_logs(self, server_id: int) -> AsyncGenerator[str, None]:
         """Stream server logs in real-time"""
@@ -664,12 +660,13 @@ class MinecraftServerManager(
                             task.cancel()
                         cleanup_tasks.extend(tasks_to_cancel)
 
-                    # Clear log queue to free memory
+                    # Clear log queue and buffer to free memory
                     try:
                         while not server_process.log_queue.empty():
                             server_process.log_queue.get_nowait()
                     except (asyncio.QueueEmpty, AttributeError):
                         pass
+                    server_process.log_buffer.clear()
 
                     # Remove from processes dict but keep PID file and don't kill process
                     del self.processes[server_id]

--- a/app/servers/application/minecraft/manager.py
+++ b/app/servers/application/minecraft/manager.py
@@ -326,7 +326,7 @@ class MinecraftServerManager(
 
             # Create server process tracking (without process object for daemon)
             log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=self.log_queue_size)
-            log_buffer: deque = deque(maxlen=self.log_queue_size)
+            log_buffer: deque[str] = deque(maxlen=self.log_queue_size)
             server_process = ServerProcess(
                 server_id=server.id,
                 process=None,  # No process object for daemon processes
@@ -573,7 +573,7 @@ class MinecraftServerManager(
 
     async def get_server_logs(self, server_id: int, lines: int = 100) -> List[str]:
         """Get recent server logs (most-recent *lines* entries)."""
-        if server_id not in self.processes:
+        if server_id not in self.processes or lines <= 0:
             return []
 
         server_process = self.processes[server_id]

--- a/app/servers/application/minecraft/monitoring.py
+++ b/app/servers/application/minecraft/monitoring.py
@@ -340,6 +340,8 @@ class MonitoringMixin:
                         except (asyncio.QueueEmpty, AttributeError, TypeError):
                             break
 
+                server_process.log_buffer.clear()
+
                 # Remove PID file
                 try:
                     server_dir = server_process.server_directory or (
@@ -393,7 +395,8 @@ class MonitoringMixin:
                                 timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                                 formatted_line = f"[{timestamp}] {line.strip()}"
 
-                                # Put in queue (drop old logs if queue is full)
+                                server_process.log_buffer.append(formatted_line)
+
                                 try:
                                     server_process.log_queue.put_nowait(formatted_line)
                                 except asyncio.QueueFull:

--- a/app/servers/application/minecraft/pid_file.py
+++ b/app/servers/application/minecraft/pid_file.py
@@ -8,6 +8,7 @@ manager (``self.processes``, ``self.base_directory``,
 
 import asyncio
 import json
+from collections import deque
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -145,9 +146,8 @@ class PidFileMixin:
             except Exception as e:
                 logger.warning(f"Could not verify process {pid} command line: {e}")
 
-            # Create a pseudo subprocess object for monitoring
-            # Note: We can't fully recreate the original subprocess, but we can monitor the PID
             log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=self.log_queue_size)
+            log_buffer: deque = deque(maxlen=self.log_queue_size)
 
             # Parse started_at time
             try:
@@ -161,13 +161,14 @@ class PidFileMixin:
 
             server_process = ServerProcess(
                 server_id=server_id,
-                process=None,  # We'll set this to None since we can't recreate subprocess
+                process=None,
                 log_queue=log_queue,
-                status=ServerStatus.running,  # Assume running since process exists
+                status=ServerStatus.running,
                 started_at=started_at,
+                log_buffer=log_buffer,
                 pid=pid,
-                server_directory=server_dir,  # Store correct directory path for monitoring
-                rcon_port=rcon_port,  # Restore RCON configuration
+                server_directory=server_dir,
+                rcon_port=rcon_port,
                 rcon_password=rcon_password,
             )
 

--- a/app/servers/application/minecraft/pid_file.py
+++ b/app/servers/application/minecraft/pid_file.py
@@ -147,7 +147,7 @@ class PidFileMixin:
                 logger.warning(f"Could not verify process {pid} command line: {e}")
 
             log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=self.log_queue_size)
-            log_buffer: deque = deque(maxlen=self.log_queue_size)
+            log_buffer: deque[str] = deque(maxlen=self.log_queue_size)
 
             # Parse started_at time
             try:

--- a/app/servers/application/minecraft/server_process.py
+++ b/app/servers/application/minecraft/server_process.py
@@ -1,7 +1,8 @@
 """``ServerProcess`` dataclass: in-memory record for a managed server."""
 
 import asyncio
-from dataclasses import dataclass
+from collections import deque
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -18,6 +19,7 @@ class ServerProcess:
     log_queue: asyncio.Queue[str]
     status: ServerStatus
     started_at: datetime
+    log_buffer: deque = field(default_factory=deque)
     pid: Optional[int] = None
     # Directory path for the server (needed for log monitoring)
     server_directory: Optional[Path] = None

--- a/app/servers/application/minecraft/server_process.py
+++ b/app/servers/application/minecraft/server_process.py
@@ -19,7 +19,9 @@ class ServerProcess:
     log_queue: asyncio.Queue[str]
     status: ServerStatus
     started_at: datetime
-    log_buffer: deque = field(default_factory=deque)
+    # Real call sites pass deque(maxlen=log_queue_size); the unbounded
+    # default exists only so test fixtures can omit the field.
+    log_buffer: deque[str] = field(default_factory=deque)
     pid: Optional[int] = None
     # Directory path for the server (needed for log monitoring)
     server_directory: Optional[Path] = None

--- a/tests/infrastructure/servers/test_monitoring.py
+++ b/tests/infrastructure/servers/test_monitoring.py
@@ -791,6 +791,26 @@ sys.exit(0)
         assert logs == ["c", "d", "e"]
 
     @pytest.mark.asyncio
+    async def test_get_server_logs_zero_lines(self, manager):
+        """lines=0 returns an empty list even when the buffer is populated."""
+        from collections import deque
+
+        log_buffer = deque(["a", "b", "c"], maxlen=10)
+        server_process = ServerProcess(
+            server_id=1,
+            process=Mock(),
+            log_queue=asyncio.Queue(),
+            status=ServerStatus.running,
+            started_at=datetime.now(),
+            log_buffer=log_buffer,
+            pid=12345,
+        )
+        manager.processes[1] = server_process
+
+        assert await manager.get_server_logs(1, lines=0) == []
+        assert await manager.get_server_logs(1, lines=-1) == []
+
+    @pytest.mark.asyncio
     async def test_get_server_logs_is_non_destructive(self, manager):
         """Calling get_server_logs twice returns the same result."""
         from collections import deque

--- a/tests/infrastructure/servers/test_monitoring.py
+++ b/tests/infrastructure/servers/test_monitoring.py
@@ -648,11 +648,9 @@ sys.exit(0)
 
     @pytest.mark.asyncio
     async def test_get_server_logs_with_real_queue(self, manager):
-        """Test lines 545-556: Log retrieval from real queue"""
+        """Test log retrieval returns the tail and is non-destructive."""
+        from collections import deque
 
-        log_queue = asyncio.Queue()
-
-        # Add logs with timestamps (simulating real log format)
         test_logs = [
             "[2024-01-01 12:34:56] Server starting...",
             "[2024-01-01 12:34:57] Loading world...",
@@ -661,29 +659,27 @@ sys.exit(0)
             "[2024-01-01 12:35:00] Player left",
         ]
 
-        for log in test_logs:
-            await log_queue.put(log)
+        log_buffer = deque(test_logs, maxlen=500)
 
         server_process = ServerProcess(
             server_id=1,
             process=Mock(),
-            log_queue=log_queue,
+            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
+            log_buffer=log_buffer,
             pid=12345,
         )
         manager.processes[1] = server_process
 
-        # Test retrieving limited logs
         logs = await manager.get_server_logs(1, lines=3)
 
         assert len(logs) == 3
-        assert logs[0] == "[2024-01-01 12:34:56] Server starting..."
-        assert logs[1] == "[2024-01-01 12:34:57] Loading world..."
-        assert logs[2] == "[2024-01-01 12:34:58] Server ready!"
+        assert logs[0] == "[2024-01-01 12:34:58] Server ready!"
+        assert logs[1] == "[2024-01-01 12:34:59] Player joined"
+        assert logs[2] == "[2024-01-01 12:35:00] Player left"
 
-        # Verify remaining logs are still in queue
-        assert log_queue.qsize() == 2
+        assert len(log_buffer) == 5
 
     @pytest.mark.asyncio
     async def test_stream_server_logs_real_streaming(self, manager):
@@ -772,3 +768,126 @@ sys.exit(0)
         # Verify timeout was handled and log was eventually received
         assert len(streamed_logs) == 1
         assert streamed_logs[0] == "Delayed log"
+
+    @pytest.mark.asyncio
+    async def test_get_server_logs_returns_tail(self, manager):
+        """get_server_logs returns the most-recent N lines, not the oldest."""
+        from collections import deque
+
+        log_buffer = deque(["a", "b", "c", "d", "e"], maxlen=10)
+
+        server_process = ServerProcess(
+            server_id=1,
+            process=Mock(),
+            log_queue=asyncio.Queue(),
+            status=ServerStatus.running,
+            started_at=datetime.now(),
+            log_buffer=log_buffer,
+            pid=12345,
+        )
+        manager.processes[1] = server_process
+
+        logs = await manager.get_server_logs(1, lines=3)
+        assert logs == ["c", "d", "e"]
+
+    @pytest.mark.asyncio
+    async def test_get_server_logs_is_non_destructive(self, manager):
+        """Calling get_server_logs twice returns the same result."""
+        from collections import deque
+
+        entries = [f"line-{i}" for i in range(5)]
+        log_buffer = deque(entries, maxlen=10)
+
+        server_process = ServerProcess(
+            server_id=1,
+            process=Mock(),
+            log_queue=asyncio.Queue(),
+            status=ServerStatus.running,
+            started_at=datetime.now(),
+            log_buffer=log_buffer,
+            pid=12345,
+        )
+        manager.processes[1] = server_process
+
+        first = await manager.get_server_logs(1, lines=3)
+        second = await manager.get_server_logs(1, lines=3)
+        assert first == second
+        assert len(log_buffer) == 5
+
+    @pytest.mark.asyncio
+    async def test_log_buffer_and_queue_dual_write(self, manager, tmp_path):
+        """_read_server_logs populates both log_queue and log_buffer."""
+        from collections import deque
+
+        server_dir = tmp_path / "server"
+        server_dir.mkdir()
+        log_file = server_dir / "server.log"
+        log_file.write_text("line one\nline two\nline three\n")
+
+        log_queue = asyncio.Queue(maxsize=50)
+        log_buffer = deque(maxlen=50)
+        server_process = ServerProcess(
+            server_id=1,
+            process=None,
+            log_queue=log_queue,
+            status=ServerStatus.running,
+            started_at=datetime.now(),
+            log_buffer=log_buffer,
+            pid=12345,
+            server_directory=server_dir,
+        )
+        manager.processes[1] = server_process
+
+        log_task = asyncio.create_task(manager._read_server_logs(server_process))
+        await asyncio.sleep(1.0)
+
+        del manager.processes[1]
+        log_task.cancel()
+        try:
+            await log_task
+        except asyncio.CancelledError:
+            pass
+
+        assert log_queue.qsize() == len(log_buffer)
+        queue_items = []
+        while not log_queue.empty():
+            queue_items.append(log_queue.get_nowait())
+        assert queue_items == list(log_buffer)
+
+    @pytest.mark.asyncio
+    async def test_log_buffer_evicts_oldest_on_overflow(self, manager, tmp_path):
+        """log_buffer with maxlen evicts the oldest entries when full."""
+        from collections import deque
+
+        server_dir = tmp_path / "server"
+        server_dir.mkdir()
+        log_file = server_dir / "server.log"
+        log_file.write_text("line 1\nline 2\nline 3\nline 4\nline 5\n")
+
+        log_buffer = deque(maxlen=3)
+        server_process = ServerProcess(
+            server_id=1,
+            process=None,
+            log_queue=asyncio.Queue(maxsize=100),
+            status=ServerStatus.running,
+            started_at=datetime.now(),
+            log_buffer=log_buffer,
+            pid=12345,
+            server_directory=server_dir,
+        )
+        manager.processes[1] = server_process
+
+        log_task = asyncio.create_task(manager._read_server_logs(server_process))
+        await asyncio.sleep(1.0)
+
+        del manager.processes[1]
+        log_task.cancel()
+        try:
+            await log_task
+        except asyncio.CancelledError:
+            pass
+
+        assert len(log_buffer) == 3
+        assert "line 3" in log_buffer[-3]
+        assert "line 4" in log_buffer[-2]
+        assert "line 5" in log_buffer[-1]

--- a/tests/infrastructure/servers/test_simple.py
+++ b/tests/infrastructure/servers/test_simple.py
@@ -345,20 +345,19 @@ class TestMinecraftServerManagerSimpleIntegration:
 
     @pytest.mark.asyncio
     async def test_get_server_logs_success(self, manager):
-        """Test lines 545-556: Get server logs"""
-        log_queue = asyncio.Queue()
+        """Test get_server_logs returns the most-recent N lines non-destructively."""
+        from collections import deque
 
-        # Add some test logs
         test_logs = ["Log 1", "Log 2", "Log 3"]
-        for log in test_logs:
-            await log_queue.put(log)
+        log_buffer = deque(test_logs, maxlen=10)
 
         server_process = ServerProcess(
             server_id=1,
             process=Mock(),
-            log_queue=log_queue,
+            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
+            log_buffer=log_buffer,
             pid=12345,
         )
         manager.processes[1] = server_process
@@ -366,8 +365,8 @@ class TestMinecraftServerManagerSimpleIntegration:
         logs = await manager.get_server_logs(1, lines=2)
 
         assert len(logs) == 2
-        assert logs[0] == "Log 1"
-        assert logs[1] == "Log 2"
+        assert logs == ["Log 2", "Log 3"]
+        assert len(log_buffer) == 3
 
     @pytest.mark.asyncio
     async def test_get_server_logs_server_not_running(self, manager):


### PR DESCRIPTION
## Summary

- Add a `collections.deque` ring buffer (`log_buffer`) to `ServerProcess` alongside the existing `asyncio.Queue`
- The producer (`_read_server_logs`) dual-writes each formatted log line to both `log_buffer` and `log_queue`
- `get_server_logs()` now reads the tail of `log_buffer` (non-destructive, returns most-recent N lines) instead of draining the queue head
- The queue remains dedicated to real-time streaming consumers

Resolves #416

## Test plan

- [x] Updated `test_get_server_logs_success` and `test_get_server_logs_with_real_queue` to assert tail (most-recent) ordering
- [x] Added `test_get_server_logs_returns_tail` — buffer `[a,b,c,d,e]`, request 3 → `[c,d,e]`
- [x] Added `test_get_server_logs_is_non_destructive` — two identical calls return the same result, buffer unchanged
- [x] Added `test_log_buffer_and_queue_dual_write` — verify producer populates both queue and buffer identically
- [x] Added `test_log_buffer_evicts_oldest_on_overflow` — buffer with `maxlen=3`, 5 lines → only last 3 remain
- [x] All pre-commit hooks pass (ruff, mypy, pytest smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)