### PR TITLE
Archive server directory on soft-delete to allow name reuse

### DIFF
--- a/app/servers/adapters/_legacy_helpers.py
+++ b/app/servers/adapters/_legacy_helpers.py
@@ -554,10 +554,18 @@ class ServerDatabaseService:
             db.rollback()
             handle_database_error("update", "server", e)
 
-    def soft_delete_server(self, server: Server, db: Session) -> None:
+    def soft_delete_server(
+        self,
+        server: Server,
+        db: Session,
+        *,
+        directory_path: Optional[str] = None,
+    ) -> None:
         try:
             server.is_deleted = True
             server.status = ServerStatus.stopped
+            if directory_path is not None:
+                server.directory_path = directory_path
             db.commit()
             logger.info(f"Soft deleted server: {server.name} (ID: {server.id})")
         except Exception as e:

--- a/app/servers/adapters/repository.py
+++ b/app/servers/adapters/repository.py
@@ -227,12 +227,16 @@ class SqlAlchemyServerRepository:
         self._db.flush()
         return _server_to_entity(row)
 
-    async def soft_delete(self, server_id: int) -> bool:
+    async def soft_delete(
+        self, server_id: int, *, directory_path: Optional[str] = None
+    ) -> bool:
         row = self._db.query(Server).filter(Server.id == server_id).one_or_none()
         if row is None:
             return False
         row.is_deleted = True
         row.status = ServerStatus.stopped
+        if directory_path is not None:
+            row.directory_path = directory_path
         self._db.flush()
         return True
 

--- a/app/servers/application/service.py
+++ b/app/servers/application/service.py
@@ -35,7 +35,8 @@ import fcntl
 import logging
 import re
 import shlex
-from datetime import datetime
+import shutil
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -361,12 +362,25 @@ exec java -Xmx"${{MAX_MEMORY}}"M -Xms"${{MIN_MEMORY}}"M -jar "$JAR_FILE" nogui
     async def cleanup_server_directory(self, server_dir: Path) -> None:
         try:
             if server_dir.exists():
-                import shutil
-
                 shutil.rmtree(server_dir)
                 logger.info(f"Cleaned up server directory: {server_dir}")
         except Exception as e:
             logger.warning(f"Failed to cleanup server directory {server_dir}: {e}")
+
+    def compute_archive_path(self, server_id: int) -> Path:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        return self.base_directory / ".archived" / f"{server_id}_{timestamp}"
+
+    async def archive_server_directory(self, source: Path, destination: Path) -> None:
+        if not source.exists():
+            logger.warning(f"Server directory does not exist, skipping archive: {source}")
+            return
+        try:
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(source), str(destination))
+            logger.info(f"Archived server directory: {source} -> {destination}")
+        except Exception as e:
+            handle_file_error("archive directory", str(source), e)
 
 
 # `ServerJarService` and `ServerDatabaseService` (the SQLAlchemy-direct
@@ -917,18 +931,39 @@ class ServerService:
 
     async def delete_server(self, server_id: int, db: Session) -> bool:
         server = self.validation_service.validate_server_exists(server_id, db)
-        # Persist via UoW + repo when DI wired; legacy path otherwise
-        # (parity with `create_server` / `update_server`).
+        current_dir = Path(server.directory_path)
+        archived_path = self.filesystem_service.compute_archive_path(server_id)
+
         if self._uow is not None:
             async with self._uow as uow:
-                deleted = await uow.servers.soft_delete(server_id)
+                deleted = await uow.servers.soft_delete(
+                    server_id, directory_path=str(archived_path)
+                )
                 if not deleted:
                     raise RuntimeError(
                         f"Server {server_id} vanished between validation and delete"
                     )
                 await uow.commit()
         else:
-            self.database_service.soft_delete_server(server, db)
+            self.database_service.soft_delete_server(
+                server, db, directory_path=str(archived_path)
+            )
+
+        try:
+            await self.filesystem_service.archive_server_directory(
+                current_dir, archived_path
+            )
+        except Exception as e:
+            logger.warning(
+                "server_archive_failed",
+                extra={
+                    "server_id": server_id,
+                    "source": str(current_dir),
+                    "destination": str(archived_path),
+                    "error": str(e),
+                },
+            )
+
         return True
 
     # ===================

--- a/app/servers/application/service.py
+++ b/app/servers/application/service.py
@@ -368,19 +368,42 @@ exec java -Xmx"${{MAX_MEMORY}}"M -Xms"${{MIN_MEMORY}}"M -jar "$JAR_FILE" nogui
             logger.warning(f"Failed to cleanup server directory {server_dir}: {e}")
 
     def compute_archive_path(self, server_id: int) -> Path:
+        # The ``.archived`` dot-prefix is deliberate: server names cannot
+        # start with ``.`` (see ``ServerCreateRequest`` validation in
+        # ``schemas.py``), so an archived directory can never collide with
+        # or be mistaken for a live server directory. ``server_id`` is
+        # unique, so the second-precision timestamp suffix only needs to
+        # keep repeated deletes of the *same* id readable, not unique.
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
         return self.base_directory / ".archived" / f"{server_id}_{timestamp}"
 
-    async def archive_server_directory(self, source: Path, destination: Path) -> None:
+    async def archive_server_directory(self, source: Path, destination: Path) -> bool:
+        """Move a server directory into the ``.archived`` area.
+
+        Returns ``True`` only when the directory was actually moved.
+        Returns ``False`` when the source does not exist (nothing to
+        archive) or the move fails. The caller MUST keep the original
+        ``directory_path`` whenever this returns ``False`` — repointing
+        the row at an archive location that does not hold the files would
+        break backup-restore and still leave the original name occupied.
+
+        Because ``.archived`` lives under ``base_directory`` (same
+        filesystem), ``shutil.move`` is an atomic rename: a failure leaves
+        the source fully intact.
+        """
         if not source.exists():
             logger.warning(f"Server directory does not exist, skipping archive: {source}")
-            return
+            return False
         try:
             destination.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(source), str(destination))
             logger.info(f"Archived server directory: {source} -> {destination}")
+            return True
         except Exception as e:
-            handle_file_error("archive directory", str(source), e)
+            logger.warning(
+                f"Failed to archive server directory {source} -> {destination}: {e}"
+            )
+            return False
 
 
 # `ServerJarService` and `ServerDatabaseService` (the SQLAlchemy-direct
@@ -934,35 +957,29 @@ class ServerService:
         current_dir = Path(server.directory_path)
         archived_path = self.filesystem_service.compute_archive_path(server_id)
 
+        # Archive the directory FIRST, then repoint ``directory_path`` only
+        # when the move actually happened (#429 review). Doing the DB write
+        # first would, on a failed/skipped move, leave the row pointing at
+        # an archive location that holds no files (breaking backup-restore)
+        # while ``servers/{name}`` stays occupied (blocking name reuse) —
+        # strictly worse than not touching ``directory_path`` at all. The
+        # move is an atomic rename within ``base_directory``, so on failure
+        # the source is intact and the original path remains valid.
+        moved = await self.filesystem_service.archive_server_directory(
+            current_dir, archived_path
+        )
+        dir_arg = str(archived_path) if moved else None
+
         if self._uow is not None:
             async with self._uow as uow:
-                deleted = await uow.servers.soft_delete(
-                    server_id, directory_path=str(archived_path)
-                )
+                deleted = await uow.servers.soft_delete(server_id, directory_path=dir_arg)
                 if not deleted:
                     raise RuntimeError(
                         f"Server {server_id} vanished between validation and delete"
                     )
                 await uow.commit()
         else:
-            self.database_service.soft_delete_server(
-                server, db, directory_path=str(archived_path)
-            )
-
-        try:
-            await self.filesystem_service.archive_server_directory(
-                current_dir, archived_path
-            )
-        except Exception as e:
-            logger.warning(
-                "server_archive_failed",
-                extra={
-                    "server_id": server_id,
-                    "source": str(current_dir),
-                    "destination": str(archived_path),
-                    "error": str(e),
-                },
-            )
+            self.database_service.soft_delete_server(server, db, directory_path=dir_arg)
 
         return True
 

--- a/app/servers/domain/ports.py
+++ b/app/servers/domain/ports.py
@@ -124,7 +124,9 @@ class ServerRepository(Protocol):
         self, server_id: int, command: UpdateServerCommand
     ) -> Optional[ServerEntity]: ...
 
-    async def soft_delete(self, server_id: int) -> bool: ...
+    async def soft_delete(
+        self, server_id: int, *, directory_path: Optional[str] = None
+    ) -> bool: ...
 
     # ----- Status writes (own-transaction via with_transaction) -----
 

--- a/tests/integration/servers/test_name_reuse.py
+++ b/tests/integration/servers/test_name_reuse.py
@@ -1,0 +1,118 @@
+"""End-to-end coverage for the core goal of #429: a server name freed by
+deletion can be reused.
+
+Before the fix, soft-delete left ``servers/{name}`` on disk, so creating a
+second server with the same name failed at the directory-existence guard in
+``ServerFileSystemService.create_server_directory`` even though the DB
+uniqueness check (which excludes soft-deleted rows) passed.
+
+This drives the real API create -> delete -> create cycle, so it also
+guards the ordering of archive-then-repoint inside ``delete_server``.
+"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+# The create endpoint triggers real Java discovery inside
+# MinecraftServerManager — skip without a JRE (parity with
+# ``test_port_conflicts.py``).
+pytestmark = [pytest.mark.requires_java, pytest.mark.slow]
+
+
+def _seed_version(db):
+    from app.core.datetime_utils import utcnow
+    from app.versions.models import MinecraftVersion
+
+    db.add(
+        MinecraftVersion(
+            server_type="vanilla",
+            version="1.21.6",
+            download_url="https://launcher.mojang.com/v1/objects/test.jar",
+            release_date=utcnow(),
+            is_stable=True,
+            is_active=True,
+        )
+    )
+    db.commit()
+
+
+def _create_payload(name: str) -> dict:
+    return {
+        "name": name,
+        "description": "name-reuse e2e",
+        "minecraft_version": "1.21.6",
+        "server_type": "vanilla",
+        "max_memory": 1024,
+        "max_players": 20,
+    }
+
+
+class TestServerNameReuseAfterDeletion:
+    def test_name_can_be_reused_after_delete(
+        self, client: TestClient, admin_headers, db, admin_user
+    ):
+        from unittest.mock import patch
+
+        _seed_version(db)
+        name = "reuse-me"
+        created_dirs: list[Path] = []
+
+        try:
+            with (
+                patch(
+                    "app.versions.application.jar_cache_manager."
+                    "jar_cache_manager.get_or_download_jar"
+                ) as mock_cache,
+                patch(
+                    "app.versions.application.jar_cache_manager."
+                    "jar_cache_manager.copy_jar_to_server"
+                ) as mock_copy,
+            ):
+                mock_cache.return_value = "/cache/test-vanilla-1.21.6.jar"
+                mock_copy.return_value = "/server/server.jar"
+
+                # 1) Create the first server and confirm its directory exists.
+                first = client.post(
+                    "/api/v1/servers/",
+                    headers=admin_headers,
+                    json=_create_payload(name),
+                )
+                assert first.status_code == status.HTTP_201_CREATED, first.text
+                first_body = first.json()
+                first_dir = Path(first_body["directory_path"])
+                created_dirs.append(first_dir)
+                assert first_dir.exists()
+
+                # 2) Delete it — the directory should be archived away so the
+                #    original path is freed.
+                deleted = client.delete(
+                    f"/api/v1/servers/{first_body['id']}", headers=admin_headers
+                )
+                assert deleted.status_code == status.HTTP_204_NO_CONTENT
+                assert not first_dir.exists()
+
+                # 3) Create a *second* server with the same name — this is the
+                #    behaviour #429 is about and must now succeed.
+                second = client.post(
+                    "/api/v1/servers/",
+                    headers=admin_headers,
+                    json=_create_payload(name),
+                )
+                assert second.status_code == status.HTTP_201_CREATED, second.text
+                second_body = second.json()
+                assert second_body["name"] == name
+                assert second_body["id"] != first_body["id"]
+                second_dir = Path(second_body["directory_path"])
+                created_dirs.append(second_dir)
+                assert second_dir.exists()
+        finally:
+            archived = Path("servers/.archived")
+            if archived.exists():
+                shutil.rmtree(archived, ignore_errors=True)
+            for d in created_dirs:
+                if d.exists():
+                    shutil.rmtree(d, ignore_errors=True)

--- a/tests/integration/servers/test_name_reuse.py
+++ b/tests/integration/servers/test_name_reuse.py
@@ -60,6 +60,11 @@ class TestServerNameReuseAfterDeletion:
         _seed_version(db)
         name = "reuse-me"
         created_dirs: list[Path] = []
+        # Ids whose directory gets archived by a delete in this test, so
+        # cleanup can target only the archives this test produced rather
+        # than wiping every ``servers/.archived/*`` (which may hold real
+        # archived servers in a developer's working tree).
+        archived_ids: list[int] = []
 
         try:
             with (
@@ -94,6 +99,7 @@ class TestServerNameReuseAfterDeletion:
                 )
                 assert deleted.status_code == status.HTTP_204_NO_CONTENT
                 assert not first_dir.exists()
+                archived_ids.append(first_body["id"])
 
                 # 3) Create a *second* server with the same name — this is the
                 #    behaviour #429 is about and must now succeed.
@@ -110,9 +116,10 @@ class TestServerNameReuseAfterDeletion:
                 created_dirs.append(second_dir)
                 assert second_dir.exists()
         finally:
-            archived = Path("servers/.archived")
-            if archived.exists():
-                shutil.rmtree(archived, ignore_errors=True)
+            archive_root = Path("servers/.archived")
+            for sid in archived_ids:
+                for d in archive_root.glob(f"{sid}_*"):
+                    shutil.rmtree(d, ignore_errors=True)
             for d in created_dirs:
                 if d.exists():
                     shutil.rmtree(d, ignore_errors=True)

--- a/tests/integration/servers/test_server_repository.py
+++ b/tests/integration/servers/test_server_repository.py
@@ -427,6 +427,42 @@ class TestServerRepositoryWrites:
     async def test_soft_delete_unknown_returns_false(self, repository):
         assert await repository.soft_delete(99999) is False
 
+    @pytest.mark.asyncio
+    async def test_soft_delete_updates_directory_path(
+        self, repository, db, admin_user
+    ):
+        row = _seed_server(
+            db, admin_user.id, name="sd-dir", port=25721
+        )
+        original_dir = row.directory_path
+
+        ok = await repository.soft_delete(
+            row.id, directory_path="servers/.archived/1_20260601_120000"
+        )
+        db.commit()
+        assert ok is True
+
+        db.expire_all()
+        refreshed = db.query(Server).filter(Server.id == row.id).one()
+        assert refreshed.directory_path == "servers/.archived/1_20260601_120000"
+        assert refreshed.directory_path != original_dir
+
+    @pytest.mark.asyncio
+    async def test_soft_delete_without_directory_path_preserves_original(
+        self, repository, db, admin_user
+    ):
+        row = _seed_server(
+            db, admin_user.id, name="sd-keep", port=25722
+        )
+        original_dir = row.directory_path
+
+        ok = await repository.soft_delete(row.id)
+        db.commit()
+
+        db.expire_all()
+        refreshed = db.query(Server).filter(Server.id == row.id).one()
+        assert refreshed.directory_path == original_dir
+
 
 # ---------------------------------------------------------------------------
 # Status writes (own-transaction with retry)

--- a/tests/unit/servers/fakes.py
+++ b/tests/unit/servers/fakes.py
@@ -153,16 +153,20 @@ class FakeServerRepository:
         self._records[server_id] = updated
         return updated
 
-    async def soft_delete(self, server_id: int) -> bool:
+    async def soft_delete(
+        self, server_id: int, *, directory_path: Optional[str] = None
+    ) -> bool:
         existing = self._records.get(server_id)
         if existing is None:
             return False
-        self._records[server_id] = replace(
-            existing,
+        updates: dict = dict(
             is_deleted=True,
             status=ServerStatus.stopped,
             updated_at=utcnow(),
         )
+        if directory_path is not None:
+            updates["directory_path"] = directory_path
+        self._records[server_id] = replace(existing, **updates)
         return True
 
     # ----- Status writes (own-transaction in production; flat here) -----

--- a/tests/unit/servers/test_service.py
+++ b/tests/unit/servers/test_service.py
@@ -301,10 +301,16 @@ class TestServerService:
     async def test_delete_server_success(self, server_service, mock_db):
         """Test successful server deletion (lines 659-663)"""
         mock_server = Mock()
+        mock_server.directory_path = "servers/test-server"
         server_service.validation_service.validate_server_exists = Mock(
             return_value=mock_server
         )
         server_service.database_service.soft_delete_server = Mock()
+        archived = Path("servers/.archived/1_20260601_120000")
+        server_service.filesystem_service.compute_archive_path = Mock(
+            return_value=archived
+        )
+        server_service.filesystem_service.archive_server_directory = AsyncMock()
 
         result = await server_service.delete_server(1, mock_db)
 
@@ -313,7 +319,10 @@ class TestServerService:
             1, mock_db
         )
         server_service.database_service.soft_delete_server.assert_called_once_with(
-            mock_server, mock_db
+            mock_server, mock_db, directory_path=str(archived)
+        )
+        server_service.filesystem_service.archive_server_directory.assert_awaited_once_with(
+            Path("servers/test-server"), archived
         )
 
     @pytest.mark.asyncio
@@ -364,10 +373,12 @@ class TestServerService:
 
         class _FakeServersRepo:
             def __init__(self) -> None:
-                self.soft_delete_called_with: list[int] = []
+                self.soft_delete_called_with: list[tuple] = []
 
-            async def soft_delete(self, server_id: int) -> bool:
-                self.soft_delete_called_with.append(server_id)
+            async def soft_delete(
+                self, server_id: int, *, directory_path: str | None = None
+            ) -> bool:
+                self.soft_delete_called_with.append((server_id, directory_path))
                 return True
 
         class _FakeUoW:
@@ -392,7 +403,11 @@ class TestServerService:
         uow = _FakeUoW()
         service = ServerService(uow=uow)
         mock_server = Mock()
+        mock_server.directory_path = "servers/test-server"
         service.validation_service.validate_server_exists = Mock(return_value=mock_server)
+        archived = Path("servers/.archived/42_20260601_120000")
+        service.filesystem_service.compute_archive_path = Mock(return_value=archived)
+        service.filesystem_service.archive_server_directory = AsyncMock()
         # Legacy path must NOT be used.
         service.database_service.soft_delete_server = Mock(
             side_effect=AssertionError("legacy path must not be used with UoW")
@@ -401,7 +416,9 @@ class TestServerService:
         result = await service.delete_server(42, mock_db)
 
         assert result is True
-        assert uow.servers.soft_delete_called_with == [42]
+        assert uow.servers.soft_delete_called_with == [
+            (42, str(archived))
+        ]
         assert uow.commits == 1
         assert uow.entered == 1
 
@@ -410,7 +427,9 @@ class TestServerService:
         """If the row vanishes between validation and UoW delete, raise."""
 
         class _FakeServersRepo:
-            async def soft_delete(self, server_id: int) -> bool:
+            async def soft_delete(
+                self, server_id: int, *, directory_path: str | None = None
+            ) -> bool:
                 return False
 
         class _FakeUoW:
@@ -430,10 +449,41 @@ class TestServerService:
                 pass
 
         service = ServerService(uow=_FakeUoW())
-        service.validation_service.validate_server_exists = Mock(return_value=Mock())
+        mock_server = Mock()
+        mock_server.directory_path = "servers/test-server"
+        service.validation_service.validate_server_exists = Mock(
+            return_value=mock_server
+        )
+        service.filesystem_service.compute_archive_path = Mock(
+            return_value=Path("servers/.archived/99_20260601_120000")
+        )
 
         with pytest.raises(RuntimeError, match="vanished between validation and delete"):
             await service.delete_server(99, mock_db)
+
+    @pytest.mark.asyncio
+    async def test_delete_server_archive_failure_still_succeeds(
+        self, server_service, mock_db
+    ):
+        """If archiving the directory fails, soft-delete still succeeds."""
+        mock_server = Mock()
+        mock_server.directory_path = "servers/test-server"
+        server_service.validation_service.validate_server_exists = Mock(
+            return_value=mock_server
+        )
+        server_service.database_service.soft_delete_server = Mock()
+        archived = Path("servers/.archived/1_20260601_120000")
+        server_service.filesystem_service.compute_archive_path = Mock(
+            return_value=archived
+        )
+        server_service.filesystem_service.archive_server_directory = AsyncMock(
+            side_effect=OSError("Permission denied")
+        )
+
+        result = await server_service.delete_server(1, mock_db)
+
+        assert result is True
+        server_service.database_service.soft_delete_server.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_sync_server_properties_after_update_boolean_values(
@@ -620,6 +670,59 @@ class TestServerFileSystemServiceExtended:
         filesystem_service._generate_eula_file.assert_called_once()
         filesystem_service._generate_startup_script.assert_called_once()
 
+    def test_compute_archive_path_format(self, filesystem_service):
+        result = filesystem_service.compute_archive_path(42)
+        assert result.parent == Path("servers/.archived")
+        assert result.name.startswith("42_")
+        assert len(result.name) == len("42_YYYYMMDD_HHMMSS")
+
+    @pytest.mark.asyncio
+    async def test_archive_server_directory_moves_dir(self, tmp_path):
+        svc = ServerFileSystemService()
+        svc.base_directory = tmp_path / "servers"
+        svc.base_directory.mkdir()
+
+        source = svc.base_directory / "my-server"
+        source.mkdir()
+        (source / "server.jar").write_bytes(b"jar-contents")
+
+        dest = svc.base_directory / ".archived" / "1_20260601_120000"
+
+        await svc.archive_server_directory(source, dest)
+
+        assert not source.exists()
+        assert (dest / "server.jar").read_bytes() == b"jar-contents"
+
+    @pytest.mark.asyncio
+    async def test_archive_server_directory_source_missing(self, tmp_path):
+        svc = ServerFileSystemService()
+        svc.base_directory = tmp_path / "servers"
+        svc.base_directory.mkdir()
+
+        source = svc.base_directory / "nonexistent"
+        dest = svc.base_directory / ".archived" / "1_20260601_120000"
+
+        await svc.archive_server_directory(source, dest)
+
+        assert not dest.exists()
+
+    @pytest.mark.asyncio
+    async def test_archive_server_directory_creates_archived_parent(self, tmp_path):
+        svc = ServerFileSystemService()
+        svc.base_directory = tmp_path / "servers"
+        svc.base_directory.mkdir()
+
+        source = svc.base_directory / "my-server"
+        source.mkdir()
+
+        dest = svc.base_directory / ".archived" / "1_20260601_120000"
+        assert not dest.parent.exists()
+
+        await svc.archive_server_directory(source, dest)
+
+        assert dest.parent.exists()
+        assert dest.exists()
+
 
 class TestServerDatabaseService:
     """Tests for ServerDatabaseService methods"""
@@ -668,4 +771,18 @@ class TestServerDatabaseService:
         database_service.soft_delete_server(mock_server, mock_db)
 
         assert mock_server.is_deleted is True
+        mock_db.commit.assert_called_once()
+
+    def test_soft_delete_server_updates_directory_path(self, database_service):
+        mock_server = Mock()
+        mock_server.is_deleted = False
+        mock_server.directory_path = "servers/old-server"
+        mock_db = Mock()
+
+        database_service.soft_delete_server(
+            mock_server, mock_db, directory_path="servers/.archived/1_20260601"
+        )
+
+        assert mock_server.is_deleted is True
+        assert mock_server.directory_path == "servers/.archived/1_20260601"
         mock_db.commit.assert_called_once()

--- a/tests/unit/servers/test_service.py
+++ b/tests/unit/servers/test_service.py
@@ -310,7 +310,10 @@ class TestServerService:
         server_service.filesystem_service.compute_archive_path = Mock(
             return_value=archived
         )
-        server_service.filesystem_service.archive_server_directory = AsyncMock()
+        # Archive succeeds -> directory_path is repointed at the archive.
+        server_service.filesystem_service.archive_server_directory = AsyncMock(
+            return_value=True
+        )
 
         result = await server_service.delete_server(1, mock_db)
 
@@ -407,7 +410,9 @@ class TestServerService:
         service.validation_service.validate_server_exists = Mock(return_value=mock_server)
         archived = Path("servers/.archived/42_20260601_120000")
         service.filesystem_service.compute_archive_path = Mock(return_value=archived)
-        service.filesystem_service.archive_server_directory = AsyncMock()
+        service.filesystem_service.archive_server_directory = AsyncMock(
+            return_value=True
+        )
         # Legacy path must NOT be used.
         service.database_service.soft_delete_server = Mock(
             side_effect=AssertionError("legacy path must not be used with UoW")
@@ -457,15 +462,20 @@ class TestServerService:
         service.filesystem_service.compute_archive_path = Mock(
             return_value=Path("servers/.archived/99_20260601_120000")
         )
+        service.filesystem_service.archive_server_directory = AsyncMock(
+            return_value=False
+        )
 
         with pytest.raises(RuntimeError, match="vanished between validation and delete"):
             await service.delete_server(99, mock_db)
 
     @pytest.mark.asyncio
-    async def test_delete_server_archive_failure_still_succeeds(
+    async def test_delete_server_archive_failure_keeps_original_path(
         self, server_service, mock_db
     ):
-        """If archiving the directory fails, soft-delete still succeeds."""
+        """If archiving fails/skips, soft-delete still succeeds but the row
+        keeps its original ``directory_path`` (passed as ``None``) rather
+        than repointing at an archive location that holds no files (#429)."""
         mock_server = Mock()
         mock_server.directory_path = "servers/test-server"
         server_service.validation_service.validate_server_exists = Mock(
@@ -476,14 +486,17 @@ class TestServerService:
         server_service.filesystem_service.compute_archive_path = Mock(
             return_value=archived
         )
+        # Archive returns False (move failed or source missing).
         server_service.filesystem_service.archive_server_directory = AsyncMock(
-            side_effect=OSError("Permission denied")
+            return_value=False
         )
 
         result = await server_service.delete_server(1, mock_db)
 
         assert result is True
-        server_service.database_service.soft_delete_server.assert_called_once()
+        server_service.database_service.soft_delete_server.assert_called_once_with(
+            mock_server, mock_db, directory_path=None
+        )
 
     @pytest.mark.asyncio
     async def test_sync_server_properties_after_update_boolean_values(
@@ -688,8 +701,9 @@ class TestServerFileSystemServiceExtended:
 
         dest = svc.base_directory / ".archived" / "1_20260601_120000"
 
-        await svc.archive_server_directory(source, dest)
+        moved = await svc.archive_server_directory(source, dest)
 
+        assert moved is True
         assert not source.exists()
         assert (dest / "server.jar").read_bytes() == b"jar-contents"
 
@@ -702,9 +716,32 @@ class TestServerFileSystemServiceExtended:
         source = svc.base_directory / "nonexistent"
         dest = svc.base_directory / ".archived" / "1_20260601_120000"
 
-        await svc.archive_server_directory(source, dest)
+        moved = await svc.archive_server_directory(source, dest)
 
+        assert moved is False
         assert not dest.exists()
+
+    @pytest.mark.asyncio
+    async def test_archive_server_directory_move_failure_returns_false(
+        self, tmp_path
+    ):
+        svc = ServerFileSystemService()
+        svc.base_directory = tmp_path / "servers"
+        svc.base_directory.mkdir()
+
+        source = svc.base_directory / "my-server"
+        source.mkdir()
+        dest = svc.base_directory / ".archived" / "1_20260601_120000"
+
+        with patch(
+            "app.servers.application.service.shutil.move",
+            side_effect=OSError("Permission denied"),
+        ):
+            moved = await svc.archive_server_directory(source, dest)
+
+        assert moved is False
+        # The atomic-rename guarantee: the source is left fully intact.
+        assert source.exists()
 
     @pytest.mark.asyncio
     async def test_archive_server_directory_creates_archived_parent(self, tmp_path):
@@ -718,8 +755,9 @@ class TestServerFileSystemServiceExtended:
         dest = svc.base_directory / ".archived" / "1_20260601_120000"
         assert not dest.parent.exists()
 
-        await svc.archive_server_directory(source, dest)
+        moved = await svc.archive_server_directory(source, dest)
 
+        assert moved is True
         assert dest.parent.exists()
         assert dest.exists()
 


### PR DESCRIPTION
## Summary

- On soft-delete, move the server directory from `servers/{name}` to
  `servers/.archived/{id}_{timestamp}/` and update the `directory_path`
  column in the database so backup-restore paths continue to work.
- The filesystem archive is best-effort: if it fails the soft-delete
  still succeeds and a warning is logged.
- Add `compute_archive_path` and `archive_server_directory` methods to
  `ServerFileSystemService`.

Resolves #429

## Test plan

- [ ] Existing unit tests for `delete_server` updated for the new archive
      flow (legacy path, UoW path, missing-row path).
- [ ] New unit test: archive failure does not block soft-delete.
- [ ] New unit tests: `compute_archive_path` format,
      `archive_server_directory` moves/creates/skips correctly.
- [ ] New integration tests: `soft_delete` with/without `directory_path`
      kwarg.
- [ ] Full suite: `just test` — 2202 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)