### PR TITLE
Remove now-unused ServerProcess.log_queue

### DIFF
--- a/app/servers/application/minecraft/manager.py
+++ b/app/servers/application/minecraft/manager.py
@@ -324,12 +324,10 @@ class MinecraftServerManager(
                 )
 
             # Create server process tracking (without process object for daemon)
-            log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=self.log_queue_size)
             log_buffer: deque[str] = deque(maxlen=self.log_queue_size)
             server_process = ServerProcess(
                 server_id=server.id,
                 process=None,  # No process object for daemon processes
-                log_queue=log_queue,
                 status=ServerStatus.starting,
                 started_at=datetime.now(),
                 log_buffer=log_buffer,
@@ -640,12 +638,7 @@ class MinecraftServerManager(
                             task.cancel()
                         cleanup_tasks.extend(tasks_to_cancel)
 
-                    # Clear log queue and buffer to free memory
-                    try:
-                        while not server_process.log_queue.empty():
-                            server_process.log_queue.get_nowait()
-                    except (asyncio.QueueEmpty, AttributeError):
-                        pass
+                    # Clear log buffer to free memory
                     server_process.log_buffer.clear()
 
                     # Remove from processes dict but keep PID file and don't kill process

--- a/app/servers/application/minecraft/monitoring.py
+++ b/app/servers/application/minecraft/monitoring.py
@@ -321,25 +321,7 @@ class MonitoringMixin:
                     server_process.log_task = None
                     server_process.monitor_task = None
 
-                # Clear the log queue to free memory efficiently
-                try:
-                    queue_size = server_process.log_queue.qsize()
-                    for _ in range(queue_size):
-                        try:
-                            server_process.log_queue.get_nowait()
-                        except asyncio.QueueEmpty:
-                            break
-                except (AttributeError, TypeError):
-                    # Handle mock objects in tests that don't have qsize()
-                    # Fallback to while loop with safety limit
-                    count = 0
-                    while count < 1000:  # Safety limit to prevent infinite loops
-                        try:
-                            server_process.log_queue.get_nowait()
-                            count += 1
-                        except (asyncio.QueueEmpty, AttributeError, TypeError):
-                            break
-
+                # Clear the log buffer to free memory
                 server_process.log_buffer.clear()
 
                 # Remove PID file
@@ -364,7 +346,7 @@ class MonitoringMixin:
             )
 
     async def _read_server_logs(self, server_process: ServerProcess):
-        """Read server logs from file and put them in the queue"""
+        """Read server logs from file and append them to the log buffer"""
         try:
             server_dir = server_process.server_directory or (
                 self.base_directory / str(server_process.server_id)
@@ -396,18 +378,6 @@ class MonitoringMixin:
                                 formatted_line = f"[{timestamp}] {line.strip()}"
 
                                 server_process.log_buffer.append(formatted_line)
-
-                                try:
-                                    server_process.log_queue.put_nowait(formatted_line)
-                                except asyncio.QueueFull:
-                                    # Remove oldest log and add new one
-                                    try:
-                                        server_process.log_queue.get_nowait()
-                                        server_process.log_queue.put_nowait(
-                                            formatted_line
-                                        )
-                                    except asyncio.QueueEmpty:
-                                        pass
 
                                 # Note: Status updates are handled by _monitor_daemon_process
                                 # to avoid conflicts and ensure single source of truth

--- a/app/servers/application/minecraft/pid_file.py
+++ b/app/servers/application/minecraft/pid_file.py
@@ -146,7 +146,6 @@ class PidFileMixin:
             except Exception as e:
                 logger.warning(f"Could not verify process {pid} command line: {e}")
 
-            log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=self.log_queue_size)
             log_buffer: deque[str] = deque(maxlen=self.log_queue_size)
 
             # Parse started_at time
@@ -162,7 +161,6 @@ class PidFileMixin:
             server_process = ServerProcess(
                 server_id=server_id,
                 process=None,
-                log_queue=log_queue,
                 status=ServerStatus.running,
                 started_at=started_at,
                 log_buffer=log_buffer,

--- a/app/servers/application/minecraft/server_process.py
+++ b/app/servers/application/minecraft/server_process.py
@@ -16,7 +16,6 @@ class ServerProcess:
 
     server_id: int
     process: asyncio.subprocess.Process
-    log_queue: asyncio.Queue[str]
     status: ServerStatus
     started_at: datetime
     # Real call sites pass deque(maxlen=log_queue_size); the unbounded

--- a/tests/infrastructure/servers/test_daemon_detachment.py
+++ b/tests/infrastructure/servers/test_daemon_detachment.py
@@ -227,7 +227,6 @@ class TestDaemonDetachmentVerification:
         server_process = ServerProcess(
             server_id=1,
             process=None,  # Daemon process
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=test_pid,

--- a/tests/infrastructure/servers/test_daemon_lifecycle.py
+++ b/tests/infrastructure/servers/test_daemon_lifecycle.py
@@ -254,7 +254,6 @@ class TestDaemonLifecycleComprehensive:
         server_process = ServerProcess(
             server_id=1,
             process=None,  # Daemon process
-            log_queue=asyncio.Queue(),
             status=ServerStatus.starting,
             started_at=datetime.now(),
             pid=22222,
@@ -349,14 +348,9 @@ class TestDaemonLifecycleComprehensive:
         server_dir = tmp_path / "daemon_cleanup"
         server_dir.mkdir()
 
-        log_queue = asyncio.Queue()
-        await log_queue.put("Test log 1")
-        await log_queue.put("Test log 2")
-
         server_process = ServerProcess(
             server_id=1,
             process=None,
-            log_queue=log_queue,
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=55555,
@@ -383,7 +377,6 @@ class TestDaemonLifecycleComprehensive:
         # Verify cleanup
         assert 1 not in manager.processes
         assert (1, ServerStatus.stopped) in status_changes
-        assert log_queue.qsize() == 0
 
     # ===== Full Integration Test =====
 

--- a/tests/infrastructure/servers/test_lifecycle.py
+++ b/tests/infrastructure/servers/test_lifecycle.py
@@ -517,11 +517,9 @@ sys.exit(0)
         await asyncio.sleep(0.3)
 
         # Create server process tracking
-        log_queue = asyncio.Queue()
         server_process = ServerProcess(
             server_id=1,
             process=process,
-            log_queue=log_queue,
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=process.pid,
@@ -574,7 +572,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=12345,
@@ -640,7 +637,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=12345,
@@ -705,7 +701,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=process.pid,
@@ -752,7 +747,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=12345,
@@ -845,7 +839,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=process.pid,
@@ -894,7 +887,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=12345,
@@ -915,7 +907,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=12345,

--- a/tests/infrastructure/servers/test_manager.py
+++ b/tests/infrastructure/servers/test_manager.py
@@ -397,37 +397,6 @@ print("[12:35:01] [Server thread/INFO]: Server stopped")
                 mock_logger.error.call_args
             )
 
-    @pytest.mark.asyncio
-    async def test_cleanup_server_process_queue_exception(self, manager):
-        """Test lines 67-68: Queue cleanup exception handling in real scenario"""
-        # Create a real queue but force exception during cleanup
-        log_queue = asyncio.Queue()
-        await log_queue.put("test log")
-
-        # Create mock process
-        mock_process = Mock()
-        server_process = ServerProcess(
-            server_id=1,
-            process=mock_process,
-            log_queue=log_queue,
-            status=ServerStatus.running,
-            started_at=datetime.now(),
-        )
-        manager.processes[1] = server_process
-
-        # Force exception by patching qsize method
-        with patch.object(log_queue, "qsize", side_effect=Exception("Queue error")):
-            with patch("app.servers.application.minecraft_server.logger") as mock_logger:
-                await manager._cleanup_server_process(1)
-
-                # In new implementation, cleanup errors are logged as warnings, not errors
-                mock_logger.warning.assert_called()
-                # Check that the warning message contains the expected text
-                warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
-                assert any(
-                    "Error during cleanup for server 1" in call for call in warning_calls
-                )
-
     # ===== Server Process Integration Tests =====
 
     @pytest.mark.asyncio
@@ -441,7 +410,6 @@ print("[12:35:01] [Server thread/INFO]: Server stopped")
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=start_time,
             pid=12345,
@@ -467,7 +435,6 @@ print("[12:35:01] [Server thread/INFO]: Server stopped")
             server_process = ServerProcess(
                 server_id=server_id,
                 process=mock_process,
-                log_queue=asyncio.Queue(),
                 status=ServerStatus.running,
                 started_at=datetime.now(),
                 pid=1000 + server_id,
@@ -493,7 +460,6 @@ print("[12:35:01] [Server thread/INFO]: Server stopped")
             server_process = ServerProcess(
                 server_id=server_id,
                 process=mock_process,
-                log_queue=asyncio.Queue(),
                 status=ServerStatus.running,
                 started_at=datetime.now(),
             )
@@ -568,26 +534,17 @@ class TestMinecraftServerManagerComplexIntegration:
     async def test_resource_cleanup_under_stress(self, manager):
         """Test resource cleanup under stress conditions"""
         # Create many server processes and clean them up rapidly
-        server_processes = []
-
         for i in range(10):
             mock_process = Mock()
             mock_process.pid = 2000 + i
-            log_queue = asyncio.Queue()
-
-            # Add some logs to the queue
-            for j in range(5):
-                await log_queue.put(f"Log {j} from server {i}")
 
             server_process = ServerProcess(
                 server_id=i + 1,
                 process=mock_process,
-                log_queue=log_queue,
                 status=ServerStatus.running,
                 started_at=datetime.now(),
                 pid=2000 + i,
             )
-            server_processes.append(server_process)
             manager.processes[i + 1] = server_process
 
         # Cleanup all processes concurrently
@@ -600,7 +557,3 @@ class TestMinecraftServerManagerComplexIntegration:
 
         # Verify all processes were cleaned up
         assert len(manager.processes) == 0
-
-        # Verify queues were emptied
-        for server_process in server_processes:
-            assert server_process.log_queue.qsize() == 0

--- a/tests/infrastructure/servers/test_monitoring.py
+++ b/tests/infrastructure/servers/test_monitoring.py
@@ -136,11 +136,9 @@ sys.exit(0)
 """
         log_file.write_text(log_content)
 
-        log_queue = asyncio.Queue(maxsize=50)
         server_process = ServerProcess(
             server_id=1,
             process=None,  # Daemon processes have None process
-            log_queue=log_queue,
             status=ServerStatus.starting,
             started_at=datetime.now(),
             pid=12345,  # Mock PID
@@ -203,51 +201,6 @@ sys.exit(0)
         shutil.rmtree(server_dir.parent)
 
     @pytest.mark.asyncio
-    async def test_read_server_logs_queue_overflow_handling(
-        self, manager, server_with_log_output
-    ):
-        """Test lines 590-596: Queue overflow protection"""
-
-        process = await asyncio.create_subprocess_exec(
-            *server_with_log_output,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-        )
-
-        # Create a small queue to trigger overflow
-        log_queue = asyncio.Queue(maxsize=3)
-        server_process = ServerProcess(
-            server_id=1,
-            process=process,
-            log_queue=log_queue,
-            status=ServerStatus.starting,
-            started_at=datetime.now(),
-            pid=process.pid,
-        )
-
-        # Start log reading
-        log_task = asyncio.create_task(manager._read_server_logs(server_process))
-
-        # Wait for overflow to occur
-        await asyncio.sleep(1.0)
-
-        # Verify queue management - queue should not exceed maxsize
-        # The overflow protection should remove old logs and add new ones
-        assert log_queue.qsize() <= 3
-
-        # Stop
-        if process.returncode is None:
-            process.terminate()
-            await process.wait()
-
-        log_task.cancel()
-        try:
-            await log_task
-        except asyncio.CancelledError:
-            pass
-
-    @pytest.mark.asyncio
     async def test_read_server_logs_exception_handling(self, manager, tmp_path):
         """Test lines 607-608: Log reading exception handling"""
 
@@ -260,7 +213,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=None,  # Daemon process
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=12345,
@@ -332,7 +284,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.starting,
             started_at=datetime.now(),
             pid=process.pid,
@@ -382,7 +333,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.starting,
             started_at=datetime.now(),
             pid=process.pid,
@@ -451,7 +401,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.starting,
             started_at=datetime.now(),
             pid=12345,
@@ -538,7 +487,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.starting,
             started_at=datetime.now(),
             pid=12345,
@@ -610,7 +558,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.starting,
             started_at=datetime.now(),
             pid=12345,
@@ -664,7 +611,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=Mock(),
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             log_buffer=log_buffer,
@@ -691,7 +637,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=Mock(),
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             log_buffer=log_buffer,
@@ -711,7 +656,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=Mock(),
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             log_buffer=log_buffer,
@@ -733,7 +677,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=Mock(),
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             log_buffer=log_buffer,
@@ -747,8 +690,8 @@ sys.exit(0)
         assert len(log_buffer) == 5
 
     @pytest.mark.asyncio
-    async def test_log_buffer_and_queue_dual_write(self, manager, tmp_path):
-        """_read_server_logs populates both log_queue and log_buffer."""
+    async def test_log_buffer_populated_from_file(self, manager, tmp_path):
+        """_read_server_logs populates log_buffer in file order."""
         from collections import deque
 
         server_dir = tmp_path / "server"
@@ -756,12 +699,10 @@ sys.exit(0)
         log_file = server_dir / "server.log"
         log_file.write_text("line one\nline two\nline three\n")
 
-        log_queue = asyncio.Queue(maxsize=50)
         log_buffer = deque(maxlen=50)
         server_process = ServerProcess(
             server_id=1,
             process=None,
-            log_queue=log_queue,
             status=ServerStatus.running,
             started_at=datetime.now(),
             log_buffer=log_buffer,
@@ -780,11 +721,12 @@ sys.exit(0)
         except asyncio.CancelledError:
             pass
 
-        assert log_queue.qsize() == len(log_buffer)
-        queue_items = []
-        while not log_queue.empty():
-            queue_items.append(log_queue.get_nowait())
-        assert queue_items == list(log_buffer)
+        # Each formatted entry preserves the original line, in order.
+        assert [entry.split("] ", 1)[1] for entry in log_buffer] == [
+            "line one",
+            "line two",
+            "line three",
+        ]
 
     @pytest.mark.asyncio
     async def test_log_buffer_evicts_oldest_on_overflow(self, manager, tmp_path):
@@ -800,7 +742,6 @@ sys.exit(0)
         server_process = ServerProcess(
             server_id=1,
             process=None,
-            log_queue=asyncio.Queue(maxsize=100),
             status=ServerStatus.running,
             started_at=datetime.now(),
             log_buffer=log_buffer,

--- a/tests/infrastructure/servers/test_process_persistence.py
+++ b/tests/infrastructure/servers/test_process_persistence.py
@@ -343,7 +343,6 @@ class TestProcessPersistence:
         server_process = ServerProcess(
             server_id=server_id,
             process=MagicMock(),
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=12345,
@@ -372,7 +371,6 @@ class TestProcessPersistence:
             server_process = ServerProcess(
                 server_id=server_id,
                 process=MagicMock(),
-                log_queue=asyncio.Queue(),
                 status=ServerStatus.running,
                 started_at=time.time(),
                 pid=12345 + server_id,
@@ -396,7 +394,6 @@ class TestProcessPersistence:
         server_process = ServerProcess(
             server_id=server_id,
             process=None,  # Restored process doesn't have subprocess handle
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=pid,

--- a/tests/infrastructure/servers/test_simple.py
+++ b/tests/infrastructure/servers/test_simple.py
@@ -3,7 +3,6 @@ Simple integration tests for MinecraftServerManager
 Focus on testing actual uncovered lines with minimal complexity
 """
 
-import asyncio
 import socket
 from datetime import datetime
 from pathlib import Path
@@ -248,7 +247,6 @@ class TestMinecraftServerManagerSimpleIntegration:
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=12345,
@@ -278,7 +276,6 @@ class TestMinecraftServerManagerSimpleIntegration:
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=12345,
@@ -301,7 +298,6 @@ class TestMinecraftServerManagerSimpleIntegration:
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=12345,
@@ -325,7 +321,6 @@ class TestMinecraftServerManagerSimpleIntegration:
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=12345,
@@ -354,7 +349,6 @@ class TestMinecraftServerManagerSimpleIntegration:
         server_process = ServerProcess(
             server_id=1,
             process=Mock(),
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             log_buffer=log_buffer,
@@ -382,7 +376,6 @@ class TestMinecraftServerManagerSimpleIntegration:
         server_process = ServerProcess(
             server_id=1,
             process=Mock(),
-            log_queue=asyncio.Queue(),
             status=ServerStatus.running,
             started_at=datetime.now(),
             pid=12345,
@@ -397,32 +390,3 @@ class TestMinecraftServerManagerSimpleIntegration:
         """Test server status when not running"""
         status = manager.get_server_status(999)
         assert status == ServerStatus.stopped
-
-    # ===== Test Cleanup Error Handling =====
-
-    @pytest.mark.asyncio
-    async def test_cleanup_server_process_queue_exception(self, manager):
-        """Test lines 67-68: Cleanup with queue exception"""
-        # Create queue that will cause exception
-        log_queue = asyncio.Queue()
-        await log_queue.put("test log")
-
-        server_process = ServerProcess(
-            server_id=1,
-            process=Mock(),
-            log_queue=log_queue,
-            status=ServerStatus.running,
-            started_at=datetime.now(),
-            pid=12345,
-        )
-        manager.processes[1] = server_process
-
-        # Force exception by patching qsize
-        with patch.object(log_queue, "qsize", side_effect=Exception("Queue error")):
-            with patch("app.servers.application.minecraft_server.logger") as mock_logger:
-                await manager._cleanup_server_process(1)
-
-                mock_logger.warning.assert_called()
-                assert "Error during cleanup for server 1" in str(
-                    mock_logger.warning.call_args
-                )

--- a/tests/unit/servers/application/test_minecraft_server.py
+++ b/tests/unit/servers/application/test_minecraft_server.py
@@ -2,8 +2,8 @@
 Simple test coverage for MinecraftServerManager to achieve coverage targets
 """
 
-import asyncio
 import tempfile
+from collections import deque
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
@@ -41,100 +41,47 @@ class TestMinecraftServerManagerSimpleCoverage:
         assert manager.log_queue_size == 500
 
     @pytest.mark.asyncio
-    async def test_cleanup_server_process_queue_clear_with_qsize(self, manager):
-        """Test _cleanup_server_process with queue that has qsize method"""
-        # Create a mock queue with qsize
-        mock_queue = asyncio.Queue()
-        await mock_queue.put("log1")
-        await mock_queue.put("log2")
-
+    async def test_cleanup_server_process_clears_buffer(self, manager):
+        """Test _cleanup_server_process clears the log buffer and removes the process"""
+        log_buffer = deque(["log1", "log2"])
         mock_process = Mock()
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=mock_queue,
             status=ServerStatus.running,
             started_at=datetime.now(),
+            log_buffer=log_buffer,
         )
         manager.processes[1] = server_process
 
         await manager._cleanup_server_process(1)
 
-        # Queue should be empty and process removed
-        assert mock_queue.qsize() == 0
-        assert 1 not in manager.processes
-
-    @pytest.mark.asyncio
-    async def test_cleanup_server_process_queue_clear_fallback(self, manager):
-        """Test _cleanup_server_process fallback queue clearing"""
-        # Create a mock queue without qsize method
-        mock_queue = Mock()
-        mock_queue.qsize.side_effect = AttributeError("No qsize method")
-        mock_queue.get_nowait.side_effect = [None, None, asyncio.QueueEmpty()]
-
-        mock_process = Mock()
-        server_process = ServerProcess(
-            server_id=1,
-            process=mock_process,
-            log_queue=mock_queue,
-            status=ServerStatus.running,
-            started_at=datetime.now(),
-        )
-        manager.processes[1] = server_process
-
-        await manager._cleanup_server_process(1)
-
-        # Process should be removed
-        assert 1 not in manager.processes
-
-    @pytest.mark.asyncio
-    async def test_cleanup_server_process_queue_clear_exception_safety_limit(
-        self, manager
-    ):
-        """Test _cleanup_server_process safety limit in fallback"""
-        # Create a mock queue that always returns items (test safety limit)
-        mock_queue = Mock()
-        mock_queue.qsize.side_effect = AttributeError("No qsize method")
-        mock_queue.get_nowait.return_value = "log"  # Always returns something
-
-        mock_process = Mock()
-        server_process = ServerProcess(
-            server_id=1,
-            process=mock_process,
-            log_queue=mock_queue,
-            status=ServerStatus.running,
-            started_at=datetime.now(),
-        )
-        manager.processes[1] = server_process
-
-        await manager._cleanup_server_process(1)
-
-        # Should stop after 1000 iterations and remove process
-        assert mock_queue.get_nowait.call_count == 1000
+        # Buffer should be cleared and process removed
+        assert len(log_buffer) == 0
         assert 1 not in manager.processes
 
     @pytest.mark.asyncio
     async def test_cleanup_server_process_exception_handling(self, manager):
         """Test _cleanup_server_process exception handling"""
-        # Create a server process that will cause an exception during cleanup
+        # Force an exception inside the cleanup's outer try block by making
+        # buffer clearing raise.
         mock_process = Mock()
-        mock_queue = Mock()
-        # Force exception to happen in the outer try block by making server_id in processes check fail
-        mock_queue.qsize.side_effect = Exception("Queue error")
+        mock_buffer = Mock()
+        mock_buffer.clear.side_effect = Exception("Buffer error")
 
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=mock_queue,
             status=ServerStatus.running,
             started_at=datetime.now(),
+            log_buffer=mock_buffer,
         )
         manager.processes[1] = server_process
 
         with patch("app.servers.application.minecraft_server.logger") as mock_logger:
             await manager._cleanup_server_process(1)
 
-            # Should log warning and process may or may not be removed depending on when exception occurs
+            # Should log a warning when cleanup fails
             mock_logger.warning.assert_called()
 
     @pytest.mark.asyncio
@@ -264,7 +211,6 @@ class TestMinecraftServerManagerSimpleCoverage:
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=Mock(),
             status=ServerStatus.running,
             started_at=datetime.now(),
         )
@@ -285,7 +231,6 @@ class TestMinecraftServerManagerSimpleCoverage:
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=Mock(),
             status=ServerStatus.running,
             started_at=datetime.now(),
         )
@@ -314,7 +259,6 @@ class TestMinecraftServerManagerSimpleCoverage:
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=Mock(),
             status=ServerStatus.running,
             started_at=datetime.now(),
         )
@@ -348,7 +292,6 @@ class TestMinecraftServerManagerSimpleCoverage:
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=Mock(),
             status=ServerStatus.running,
             started_at=start_time,
             pid=12345,
@@ -393,7 +336,6 @@ class TestMinecraftServerManagerSimpleCoverage:
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=Mock(),
             status=ServerStatus.starting,
             started_at=datetime.now(),
         )
@@ -413,7 +355,6 @@ class TestMinecraftServerManagerSimpleCoverage:
         server_process = ServerProcess(
             server_id=1,
             process=mock_process,
-            log_queue=Mock(),
             status=ServerStatus.starting,
             started_at=datetime.now(),
         )


### PR DESCRIPTION
## Summary

Follow-up to #431. After `stream_server_logs()` was removed, `ServerProcess.log_queue` had **no consumer** — `_read_server_logs` wrote into it, but every other access only size-bounded or drained it on cleanup; nothing read its content. Actual log retrieval is served from the `log_buffer` deque via `get_server_logs()`, and the WebSocket service tails the log file on disk.

This removes the write-only queue:

- Delete the `log_queue` field from `ServerProcess`.
- Drop queue construction at both creation sites (`manager.py`, `pid_file.py`).
- Remove the dead `put_nowait` / overflow-bounding in `_read_server_logs` and the queue-drain blocks in cleanup/detach (`monitoring.py`, `manager.py`).
- `log_buffer` (bounded by the same `log_queue_size` setting) remains the single in-memory source of truth.

Net `-261` lines.

## Test changes

- Deleted tests that exercised only the removed queue paths (queue-overflow bounding, `qsize` cleanup fallback + 1000-iteration safety limit, queue-exception cleanup, queue↔buffer dual-write).
- Rewrote `test_cleanup_server_process_exception_handling` to trigger the cleanup exception via `log_buffer.clear()` instead of the gone `qsize` mock.
- Converted the dual-write test into `test_log_buffer_populated_from_file` (keeps the buffer-population/ordering coverage).
- Stripped `log_queue=` kwargs from all remaining `ServerProcess(...)` constructions across the infra test suite.

## Verification

- pre-commit hooks pass (ruff, ruff format, mypy, unit smoke).
- `pytest tests/unit tests/infrastructure/servers -m "not slow"` → **1527 passed, 5 skipped**.
- Full slow infra suite `pytest tests/infrastructure/servers` → **95 passed**.
- `grep` confirms no remaining `log_queue` references (only the kept `log_queue_size` setting).

Resolves #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)