### PR TITLE
Start log reader for servers restored from PID files

### DIFF
--- a/app/servers/application/minecraft/pid_file.py
+++ b/app/servers/application/minecraft/pid_file.py
@@ -172,6 +172,12 @@ class PidFileMixin:
 
             self.processes[server_id] = server_process
 
+            # Start the log reader so the restored server keeps populating its
+            # log buffer (issue #427); track it for cleanup like start_server().
+            server_process.log_task = asyncio.create_task(
+                self._read_server_logs(server_process)
+            )
+
             # Start monitoring task for the restored process and track it
             server_process.monitor_task = asyncio.create_task(
                 self._monitor_restored_process(server_process)

--- a/tests/infrastructure/servers/test_process_persistence.py
+++ b/tests/infrastructure/servers/test_process_persistence.py
@@ -202,6 +202,20 @@ class TestProcessPersistence:
             server_process.process is None
         )  # Restored processes don't have subprocess handle
 
+        # Restored servers must run a log reader so the log buffer keeps
+        # filling after a dashboard restart (issue #427), alongside the monitor.
+        assert server_process.log_task is not None
+        assert not server_process.log_task.done()
+        assert server_process.monitor_task is not None
+
+        # Cancel background tasks so they don't leak past the test.
+        for task in (server_process.log_task, server_process.monitor_task):
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
     @patch("psutil.pid_exists")
     async def test_process_restoration_failure_no_process(
         self, mock_pid_exists, manager, temp_server_dir


### PR DESCRIPTION
## Summary

`_restore_process_from_pid()` (`app/servers/application/minecraft/pid_file.py`) started a monitor task but never started a `_read_server_logs` task. As a result, servers restored from PID files after a dashboard restart had an empty `log_buffer` — the HTTP log endpoint returned `[]` and no new lines appeared until the server was manually restarted.

The fix starts a tracked `_read_server_logs` task for the restored process, mirroring `start_server()` (`manager.py:343-345`). The task is stored on `server_process.log_task` so `_cleanup_server_process()` cancels it on teardown like every other managed task.

## Test changes

- Extended `test_process_restoration_success` to assert the log task is running after restoration (alongside the monitor task), and to cancel both background tasks so they don't leak past the test.
- Verified the assertion genuinely catches the bug: with the production fix reverted, the test fails with `log_task is None`.

## Verification

- pre-commit + pre-push hooks pass (ruff, ruff format, mypy, unit + integration smoke).
- `pytest tests/infrastructure/servers/` → **95 passed**.

Resolves #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)