### PR TITLE
Fix flaky test_base_metadata_operations under xdist

### DIFF
--- a/tests/unit/core/test_database.py
+++ b/tests/unit/core/test_database.py
@@ -201,17 +201,27 @@ class TestDatabaseIntegration:
             session.close()
 
     def test_base_metadata_operations(self):
-        """Test Base metadata operations"""
-        from app.core.database import Base, engine
+        """Test Base metadata operations against an isolated engine.
 
-        # Test that Base.metadata can interact with engine
+        Uses a throwaway in-memory engine instead of the shared module-level
+        engine so create_all/drop_all do not mutate global schema and race
+        with other tests under pytest-xdist (Issue #435).
+        """
+        from sqlalchemy import create_engine
+
+        from app.core.database import Base
+
+        # Test that Base.metadata exposes the schema operations
         assert Base.metadata is not None
         assert hasattr(Base.metadata, "create_all")
         assert hasattr(Base.metadata, "drop_all")
 
-        # These operations should not fail (even if no models are defined)
-        Base.metadata.create_all(bind=engine)
-        Base.metadata.drop_all(bind=engine)
-
-        # Restore schema for subsequent tests (session-scoped fixture in conftest)
-        Base.metadata.create_all(bind=engine)
+        # These operations should not fail (even if no models are defined).
+        # Bind to a dedicated throwaway engine so the shared engine's schema
+        # is never disturbed.
+        throwaway_engine = create_engine("sqlite:///:memory:")
+        try:
+            Base.metadata.create_all(bind=throwaway_engine)
+            Base.metadata.drop_all(bind=throwaway_engine)
+        finally:
+            throwaway_engine.dispose()


### PR DESCRIPTION
## Problem

`tests/unit/core/test_database.py::test_base_metadata_operations` ran
`Base.metadata.create_all`/`drop_all` against the **shared** module-level
`engine`, mutating global DB schema. Under pytest-xdist parallel execution it
raced with other tests and intermittently failed (`1 failed, 2069 passed`).

## Fix

Bind the `create_all`/`drop_all` exercise to a dedicated throwaway in-memory
SQLite engine, so the shared engine's schema is never disturbed. This also
removes the now-unnecessary "restore schema for subsequent tests" workaround.

## Verification

- `pytest tests/unit/core/test_database.py` → 13/13 pass.
- `pytest tests/unit tests/integration -m "not slow" -n auto` →
  `2070 passed, 5 skipped` (previously `1 failed, 2069 passed`).

Resolves #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)