### PR TITLE
Tail existing log on restore instead of full read + now() restamp

### DIFF
--- a/app/servers/application/minecraft/monitoring.py
+++ b/app/servers/application/minecraft/monitoring.py
@@ -9,6 +9,34 @@ from app.servers.application.minecraft._compat import logger
 from app.servers.application.minecraft.server_process import ServerProcess
 from app.servers.models import ServerStatus
 
+# Bound the restore-time tail read so a large existing server.log cannot cause a
+# one-time memory spike (issue #436).
+_LOG_TAIL_MAX_BYTES = 64 * 1024
+
+
+def _tail_file_lines(path: Path, max_bytes: int, max_lines: int) -> tuple[list[str], int]:
+    """Read the tail of ``path`` without loading the whole file.
+
+    Returns up to the last ``max_lines`` complete, non-empty lines found within
+    the final ``max_bytes`` of the file, together with the byte offset of EOF at
+    read time. Opens in binary mode so we can seek to an arbitrary byte offset,
+    then decodes as utf-8 ignoring errors (a multibyte char split at the window
+    boundary is simply dropped). When we seek into the middle of the file the
+    first line is likely partial, so it is discarded.
+    """
+    with open(path, "rb") as f:
+        f.seek(0, os.SEEK_END)
+        end = f.tell()
+        start = max(0, end - max_bytes)
+        f.seek(start)
+        data = f.read(end - start)
+
+    lines = data.decode("utf-8", errors="ignore").split("\n")
+    if start > 0 and lines:
+        lines = lines[1:]
+    lines = [line.strip() for line in lines if line.strip()]
+    return lines[-max_lines:], end
+
 
 class MonitoringMixin:
     """Mixin: log readers, status monitors, and resource cleanup."""
@@ -345,8 +373,17 @@ class MonitoringMixin:
                 f"Error during cleanup for server {server_id}: {type(e).__name__}: {e}"
             )
 
-    async def _read_server_logs(self, server_process: ServerProcess):
-        """Read server logs from file and append them to the log buffer"""
+    async def _read_server_logs(
+        self, server_process: ServerProcess, *, tail_existing: bool = False
+    ):
+        """Read server logs from file and append them to the log buffer.
+
+        ``tail_existing`` is set on the restore-from-PID path (issue #436), where
+        ``server.log`` can already be large. Instead of reading the whole file
+        from position 0 and re-stamping every historical line with ``now()``, we
+        backfill the buffer once from the tail of the file (preserving the lines'
+        original embedded timestamps), then continue forward from EOF.
+        """
         try:
             server_dir = server_process.server_directory or (
                 self.base_directory / str(server_process.server_id)
@@ -355,11 +392,31 @@ class MonitoringMixin:
 
             # Track last read position to avoid re-reading
             last_position = 0
+            backfilled = False
 
             while server_process.server_id in self.processes:
                 try:
                     # Check if log file exists
                     if not log_file_path.exists():
+                        await asyncio.sleep(0.5)
+                        continue
+
+                    if tail_existing and not backfilled:
+                        # One-time backfill from the tail of the existing log.
+                        # Historical lines keep their original content (no now()
+                        # prefix); `end` from the same read becomes the forward
+                        # start position, avoiding gaps/double-counting if the
+                        # server writes between stat() and read.
+                        backfilled = True
+                        max_lines = (
+                            server_process.log_buffer.maxlen or self.log_queue_size
+                        )
+                        historical, end = _tail_file_lines(
+                            log_file_path, _LOG_TAIL_MAX_BYTES, max_lines
+                        )
+                        for line in historical:
+                            server_process.log_buffer.append(line)
+                        last_position = end
                         await asyncio.sleep(0.5)
                         continue
 

--- a/app/servers/application/minecraft/monitoring.py
+++ b/app/servers/application/minecraft/monitoring.py
@@ -407,6 +407,12 @@ class MonitoringMixin:
                         # prefix); `end` from the same read becomes the forward
                         # start position, avoiding gaps/double-counting if the
                         # server writes between stat() and read.
+                        #
+                        # Assumes server.log lines are newline-terminated (they
+                        # are for Minecraft). If the file ends mid-line at restore
+                        # time, that final fragment is backfilled as one entry and
+                        # its continuation is later read forward as a separate
+                        # stamped entry -- a rare, purely cosmetic split.
                         backfilled = True
                         max_lines = (
                             server_process.log_buffer.maxlen or self.log_queue_size
@@ -420,11 +426,17 @@ class MonitoringMixin:
                         await asyncio.sleep(0.5)
                         continue
 
-                    # Read new content from file
-                    with open(log_file_path, "r", encoding="utf-8", errors="ignore") as f:
+                    # Read new content from file. Open in binary so the seek
+                    # offset is always a plain byte count -- uniform with the
+                    # `end` offset produced by _tail_file_lines() and free of
+                    # text-mode seek()'s "offset must come from tell()"
+                    # restriction. Decode with errors="ignore" so a multibyte
+                    # char split at the read boundary is simply dropped.
+                    with open(log_file_path, "rb") as f:
                         f.seek(last_position)
-                        new_content = f.read()
+                        new_bytes = f.read()
                         last_position = f.tell()
+                    new_content = new_bytes.decode("utf-8", errors="ignore")
 
                     if new_content:
                         lines = new_content.strip().split("\n")

--- a/app/servers/application/minecraft/pid_file.py
+++ b/app/servers/application/minecraft/pid_file.py
@@ -174,8 +174,11 @@ class PidFileMixin:
 
             # Start the log reader so the restored server keeps populating its
             # log buffer (issue #427); track it for cleanup like start_server().
+            # Tail the existing server.log instead of reading it whole, so a
+            # large pre-existing log neither spikes memory nor re-stamps history
+            # with the restart time (issue #436).
             server_process.log_task = asyncio.create_task(
-                self._read_server_logs(server_process)
+                self._read_server_logs(server_process, tail_existing=True)
             )
 
             # Start monitoring task for the restored process and track it

--- a/tests/infrastructure/servers/test_monitoring.py
+++ b/tests/infrastructure/servers/test_monitoring.py
@@ -764,3 +764,70 @@ sys.exit(0)
         assert "line 3" in log_buffer[-3]
         assert "line 4" in log_buffer[-2]
         assert "line 5" in log_buffer[-1]
+
+    @pytest.mark.asyncio
+    async def test_read_server_logs_tail_existing_backfills_then_forwards(
+        self, manager, tmp_path
+    ):
+        """Restore path backfills the tail verbatim, then stamps live lines.
+
+        issue #436: with tail_existing=True the reader must not re-read the whole
+        file or re-stamp historical lines with now(); it backfills the last N
+        lines preserving their original [HH:MM:SS] timestamps, then continues
+        forward from EOF (live lines get the [YYYY-MM-DD HH:MM:SS] prefix).
+        """
+        from collections import deque
+
+        server_dir = tmp_path / "server"
+        server_dir.mkdir()
+        log_file = server_dir / "server.log"
+        log_file.write_text(
+            "[12:34:56] [Server thread/INFO]: historical one\n"
+            "[12:34:57] [Server thread/INFO]: historical two\n"
+        )
+
+        log_buffer = deque(maxlen=50)
+        server_process = ServerProcess(
+            server_id=1,
+            process=None,
+            status=ServerStatus.running,
+            started_at=datetime.now(),
+            log_buffer=log_buffer,
+            pid=12345,
+            server_directory=server_dir,
+        )
+        manager.processes[1] = server_process
+
+        log_task = asyncio.create_task(
+            manager._read_server_logs(server_process, tail_existing=True)
+        )
+        try:
+            await asyncio.sleep(1.0)
+
+            # Historical lines are backfilled verbatim (no now() prefix).
+            assert list(log_buffer) == [
+                "[12:34:56] [Server thread/INFO]: historical one",
+                "[12:34:57] [Server thread/INFO]: historical two",
+            ]
+
+            # Append a new line; it must be read once, after EOF, and stamped.
+            with open(log_file, "a", encoding="utf-8") as f:
+                f.write("[12:35:00] [Server thread/INFO]: live line\n")
+            await asyncio.sleep(1.0)
+        finally:
+            del manager.processes[1]
+            log_task.cancel()
+            try:
+                await log_task
+            except asyncio.CancelledError:
+                pass
+
+        # No historical line was re-read; exactly one new entry was added.
+        assert len(log_buffer) == 3
+        live_entry = log_buffer[-1]
+        assert live_entry.endswith(
+            "[12:35:00] [Server thread/INFO]: live line"
+        )
+        # Live line carries the reader's [YYYY-MM-DD HH:MM:SS] prefix.
+        prefix = live_entry.split("] ", 1)[0].lstrip("[")
+        datetime.strptime(prefix, "%Y-%m-%d %H:%M:%S")

--- a/tests/unit/servers/application/test_log_tail.py
+++ b/tests/unit/servers/application/test_log_tail.py
@@ -1,0 +1,74 @@
+"""Unit tests for the pure ``_tail_file_lines`` log-tail helper (issue #436)."""
+
+from app.servers.application.minecraft.monitoring import _tail_file_lines
+
+
+def test_tail_small_file_returns_all_lines(tmp_path):
+    log_file = tmp_path / "server.log"
+    log_file.write_text("line one\nline two\nline three\n")
+
+    lines, end = _tail_file_lines(log_file, max_bytes=64 * 1024, max_lines=100)
+
+    assert lines == ["line one", "line two", "line three"]
+    assert end == log_file.stat().st_size
+
+
+def test_tail_caps_to_max_lines(tmp_path):
+    log_file = tmp_path / "server.log"
+    log_file.write_text("".join(f"line {i}\n" for i in range(10)))
+
+    lines, end = _tail_file_lines(log_file, max_bytes=64 * 1024, max_lines=3)
+
+    assert lines == ["line 7", "line 8", "line 9"]
+    assert end == log_file.stat().st_size
+
+
+def test_tail_bounded_window_drops_partial_first_line(tmp_path):
+    # 100 lines of fixed width; a small byte window starts mid-file, so the
+    # first (partial) line must be dropped and only whole lines kept.
+    log_file = tmp_path / "server.log"
+    log_file.write_text("".join(f"line-{i:04d}\n" for i in range(100)))
+
+    # Each line is "line-NNNN\n" == 10 bytes. A 35-byte window spans the tail
+    # of one line plus the last three full lines.
+    lines, end = _tail_file_lines(log_file, max_bytes=35, max_lines=100)
+
+    assert lines == ["line-0097", "line-0098", "line-0099"]
+    # Partial leading fragment is never emitted.
+    assert all(line.startswith("line-") and len(line) == 9 for line in lines)
+    assert end == log_file.stat().st_size
+
+
+def test_tail_skips_blank_lines(tmp_path):
+    log_file = tmp_path / "server.log"
+    log_file.write_text("first\n\n   \nsecond\n")
+
+    lines, _ = _tail_file_lines(log_file, max_bytes=64 * 1024, max_lines=100)
+
+    assert lines == ["first", "second"]
+
+
+def test_tail_empty_file(tmp_path):
+    log_file = tmp_path / "server.log"
+    log_file.write_text("")
+
+    lines, end = _tail_file_lines(log_file, max_bytes=64 * 1024, max_lines=100)
+
+    assert lines == []
+    assert end == 0
+
+
+def test_tail_preserves_original_minecraft_timestamps(tmp_path):
+    log_file = tmp_path / "server.log"
+    log_file.write_text(
+        "[12:34:56] [Server thread/INFO]: Starting\n"
+        "[12:35:01] [Server thread/INFO]: Done\n"
+    )
+
+    lines, _ = _tail_file_lines(log_file, max_bytes=64 * 1024, max_lines=100)
+
+    # Original embedded [HH:MM:SS] timestamps are preserved verbatim.
+    assert lines == [
+        "[12:34:56] [Server thread/INFO]: Starting",
+        "[12:35:01] [Server thread/INFO]: Done",
+    ]


### PR DESCRIPTION
## Problem

Surfaced in review of #434. With restored servers now running `_read_server_logs` (issue #427), two pre-existing behaviors of the shared reader became relevant on the restore path:

1. **One-time full-file read** — the reader started at `last_position = 0` and did a single `f.read()` of the whole `server.log`. For a freshly *started* server the file is empty (cheap), but a *restored* server's log can already be large, causing a one-time memory spike.
2. **Historical lines re-stamped with `now()`** — every line was prefixed with `datetime.now()`, so after a restart all backfilled historical lines appeared stamped with the restart time instead of their original emission time.

## Fix

Tail the last N lines on restore instead of reading the whole file:

- New bounded helper `_tail_file_lines(path, max_bytes, max_lines)` reads at most a 64KB window from EOF (binary seek, utf-8 with `errors="ignore"`), drops a partial leading line, and returns the last N non-empty lines plus the EOF offset.
- `_read_server_logs(..., *, tail_existing=False)` gains a one-time backfill block. When `tail_existing=True` it backfills the buffer from the tail **preserving the lines' original embedded `[HH:MM:SS]` timestamps**, then continues forward from the captured EOF (no gap/double-count if the server writes between the read and resuming).
- The restore-from-PID call (`pid_file.py`) passes `tail_existing=True`. The fresh-start path (`manager.py`) is unchanged — empty file, reads from position 0, every line stamped as before.

**Trade-off:** backfilled historical lines keep their raw content and do **not** carry the `[YYYY-MM-DD HH:MM:SS]` prefix that live lines get — a minor cosmetic format inconsistency in the buffer.

## Tests

- `tests/unit/servers/application/test_log_tail.py` — pure unit tests for `_tail_file_lines` (small file, line cap, bounded-window partial-line drop, blank lines, empty file, timestamp preservation).
- `tests/infrastructure/servers/test_monitoring.py` — restore backfill test (`tail_existing=True`): historical tail backfilled verbatim, then a live line appended once after EOF and stamped with the reader prefix. Existing fresh-path tests cover the `tail_existing=False` regression.

Resolves #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)