### PR TITLE
Use path-component check for archive traversal detection

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -18,6 +18,19 @@ class SecurityError(Exception):
     pass
 
 
+def _has_traversal_component(name: str) -> bool:
+    """Return True if ``name`` contains a ``..`` path component.
+
+    Uses a path-component check (not a bare substring) so legitimate names
+    containing ".." as part of a filename (e.g. "backup..2024.txt") are not
+    treated as traversal. PureWindowsPath treats both "/" and "\\" as
+    separators, catching POSIX- and Windows-style traversal regardless of the
+    host OS. The ``resolve().relative_to()`` containment check in each archive
+    validator remains the authoritative guard; this is the precise fast-path.
+    """
+    return ".." in PureWindowsPath(name).parts
+
+
 class PathValidator:
     """Utility class for validating and sanitizing file paths."""
 
@@ -278,12 +291,8 @@ class TarExtractor:
         if member.name.startswith("/"):
             raise SecurityError(f"Tar member has absolute path: {member.name}")
 
-        # Check for path traversal sequences. Use a path-component check (not a
-        # bare substring) so legitimate names containing ".." as part of a
-        # filename (e.g. "backup..2024.txt") are not falsely rejected.
-        # PureWindowsPath treats both "/" and "\" as separators, catching
-        # POSIX- and Windows-style traversal regardless of the host OS.
-        if ".." in PureWindowsPath(member.name).parts:
+        # Check for path traversal sequences (path-component check).
+        if _has_traversal_component(member.name):
             raise SecurityError(f"Tar member contains path traversal: {member.name}")
 
         # Check for null bytes (can cause issues)
@@ -419,12 +428,8 @@ class ZipExtractor:
         if name.startswith("/") or name.startswith("\\"):
             raise SecurityError(f"Zip member has absolute path: {name}")
 
-        # Check for path traversal sequences. Use a path-component check (not a
-        # bare substring) so legitimate names containing ".." as part of a
-        # filename (e.g. "backup..2024.txt") are not falsely rejected.
-        # PureWindowsPath treats both "/" and "\" as separators, catching
-        # POSIX- and Windows-style traversal regardless of the host OS.
-        if ".." in PureWindowsPath(name).parts:
+        # Check for path traversal sequences (path-component check).
+        if _has_traversal_component(name):
             raise SecurityError(f"Zip member contains path traversal: {name}")
 
         # Check for null bytes (can cause issues)

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -8,7 +8,7 @@ import re
 import stat
 import tarfile
 import zipfile
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Union
 
 
@@ -278,8 +278,12 @@ class TarExtractor:
         if member.name.startswith("/"):
             raise SecurityError(f"Tar member has absolute path: {member.name}")
 
-        # Check for path traversal sequences
-        if ".." in member.name:
+        # Check for path traversal sequences. Use a path-component check (not a
+        # bare substring) so legitimate names containing ".." as part of a
+        # filename (e.g. "backup..2024.txt") are not falsely rejected.
+        # PureWindowsPath treats both "/" and "\" as separators, catching
+        # POSIX- and Windows-style traversal regardless of the host OS.
+        if ".." in PureWindowsPath(member.name).parts:
             raise SecurityError(f"Tar member contains path traversal: {member.name}")
 
         # Check for null bytes (can cause issues)
@@ -415,8 +419,12 @@ class ZipExtractor:
         if name.startswith("/") or name.startswith("\\"):
             raise SecurityError(f"Zip member has absolute path: {name}")
 
-        # Check for path traversal sequences
-        if ".." in name:
+        # Check for path traversal sequences. Use a path-component check (not a
+        # bare substring) so legitimate names containing ".." as part of a
+        # filename (e.g. "backup..2024.txt") are not falsely rejected.
+        # PureWindowsPath treats both "/" and "\" as separators, catching
+        # POSIX- and Windows-style traversal regardless of the host OS.
+        if ".." in PureWindowsPath(name).parts:
             raise SecurityError(f"Zip member contains path traversal: {name}")
 
         # Check for null bytes (can cause issues)

--- a/tests/unit/core/test_tar_extractor.py
+++ b/tests/unit/core/test_tar_extractor.py
@@ -68,6 +68,26 @@ class TestTarExtractor:
                 with pytest.raises(SecurityError):
                     TarExtractor.validate_tar_member(member, target_dir)
 
+    def test_validate_tar_member_dots_in_filename(self):
+        """Names containing ".." as part of a component (not a traversal
+        segment) must pass — the check is path-component based, not a bare
+        substring (Issue #409)."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target_dir = Path(temp_dir)
+
+            safe_names = [
+                "backup..2024.txt",
+                "v1..2/notes.md",
+                "dir/file..ext",
+            ]
+
+            for name in safe_names:
+                member = tarfile.TarInfo(name)
+                member.size = 5
+
+                # Should not raise an exception
+                TarExtractor.validate_tar_member(member, target_dir)
+
     def test_validate_tar_member_symlinks(self):
         """Test that symbolic links are rejected."""
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/unit/core/test_zip_extractor.py
+++ b/tests/unit/core/test_zip_extractor.py
@@ -59,6 +59,24 @@ class TestZipExtractorMemberValidation:
             with pytest.raises(SecurityError):
                 ZipExtractor.validate_zip_member(info, target_dir)
 
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "backup..2024.txt",
+            "v1..2/notes.md",
+            "dir/file..ext",
+        ],
+    )
+    def test_dots_in_filename_accepted(self, name):
+        """Names containing ".." as part of a component (not a traversal
+        segment) must pass — the check is path-component based, not a bare
+        substring (Issue #409)."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target_dir = Path(temp_dir)
+            info = zipfile.ZipInfo(name)
+            # Should not raise.
+            ZipExtractor.validate_zip_member(info, target_dir)
+
     def test_null_byte_rejected(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             target_dir = Path(temp_dir)


### PR DESCRIPTION
## Summary

Both archive member validators in `app/core/security.py` rejected path traversal with a bare substring test (`".." in name`). Because that is a substring match, legitimate member names that merely *contain* `..` as part of a filename — e.g. `backup..2024.txt` or `v1..2/notes.md` — were falsely rejected.

This replaces the substring test in `TarExtractor.validate_tar_member` and `ZipExtractor.validate_zip_member` with a path-component check: `".." in PureWindowsPath(name).parts`. `PureWindowsPath` treats both `/` and `\` as separators, so POSIX- and Windows-style traversal are still caught regardless of host OS (a plain `Path(name).parts` would miss `..\..\..\windows\system32` on Linux).

The `resolve().relative_to(target_dir.resolve())` containment check remains the real traversal guard, so this only makes the fast-path precise — no weakening of security.

## Tests

- `test_validate_tar_member_dots_in_filename` / `test_dots_in_filename_accepted` — confirm the previously false-positive names now pass validation.
- Existing traversal tests (POSIX + Windows separators) still reject as before.
- Full unit smoke suite green (1537 passed).

Resolves #409